### PR TITLE
feat: developer testing infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,24 @@ npm test              # Run all tests across modules
 
 ## Testing
 
+### Running All Tests Locally
+
+```bash
+# One command: starts PostgreSQL via Docker, runs all tests, cleans up
+pnpm run test:all
+
+# If you already have PostgreSQL running:
+export POSTGRES_TEST=postgresql://user:pass@localhost:5432/test
+pnpm test
+```
+
+`pnpm run test:all` requires Docker (Compose v2.1.1+). It spins up an ephemeral PostgreSQL on port 5433, sets `POSTGRES_TEST`, runs the full suite, and tears down the container on exit. Backend tests silently skip when `POSTGRES_TEST` is not set, so `pnpm test` alone only runs datacollect, admin, and mobile tests.
+
+### Test Suites
+
 Each module has its own test suite:
 - DataCollect: Uses Jest with fake-indexeddb for IndexedDB testing
-- Backend: Uses Jest with supertest for API testing
+- Backend: Uses Jest with supertest for API testing (requires PostgreSQL)
 - Admin: Uses Vitest for Vue component testing
 
 To run a single test file:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,15 @@ pnpm test
 
 `pnpm run test:all` requires Docker (Compose v2.1.1+). It spins up an ephemeral PostgreSQL on port 5433, sets `POSTGRES_TEST`, runs the full suite, and tears down the container on exit. Backend tests silently skip when `POSTGRES_TEST` is not set, so `pnpm test` alone only runs datacollect, admin, and mobile tests.
 
+### Seed Data
+
+```bash
+# Populate the backend with a demo household registry and sample data
+pnpm run seed
+```
+
+Requires the backend to be running (default `http://localhost:3000`). Creates a "Demo Household Registry" config with 4 households, 9 individuals, and a field worker user. Safe to run multiple times (deletes and recreates). Override defaults with env vars: `BACKEND_URL`, `ADMIN_EMAIL`, `ADMIN_PASSWORD`.
+
 ### Test Suites
 
 Each module has its own test suite:

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,18 @@
+name: idpass-data-collect-test
+
+services:
+  postgres-test:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: test
+    ports:
+      - "5433:5432"
+    tmpfs:
+      - /var/lib/postgresql/data:mode=0700,uid=999
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U test -d test"]
+      interval: 2s
+      timeout: 3s
+      retries: 10

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -13,6 +13,11 @@ services:
     networks:
       - datacollect-network-dev
     command: ["postgres"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-admin}"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
 
   # # pgAdmin for database management (optional)
   # pgadmin:
@@ -55,7 +60,8 @@ services:
       - "9229:9229" # Node.js debugger port
     restart: unless-stopped
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     networks:
       - datacollect-network-dev
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dev:docs": "pnpm --filter @idpass/data-collect-docs dev",
     "check-licenses": "node scripts/check-license-headers.js",
     "check-licenses:fix": "node scripts/check-license-headers.js --fix",
+    "seed": "bash scripts/seed.sh",
     "lint": "pnpm -r --if-present run lint",
     "type-check": "pnpm -r --if-present run type-check",
     "ci:setup": "echo 'enable-pre-post-scripts=true' > .npmrc && echo 'auto-install-peers=true' >> .npmrc && echo 'strict-peer-dependencies=false' >> .npmrc",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "reinstall": "pnpm run clean && pnpm -r install",
     "clean": "pnpm -r --if-present run clean && rm -rf **/*/node_modules",
     "test": "pnpm -r --if-present run test",
+    "test:all": "./scripts/test.sh",
     "test:datacollect": "pnpm --filter @idpass/data-collect-core test",
     "test:backend": "pnpm --filter @idpass/data-collect-backend test",
     "test:admin": "pnpm --filter @idpass/data-collect-admin test:unit",

--- a/packages/backend/src/__tests__/opensppFieldRoutes.test.ts
+++ b/packages/backend/src/__tests__/opensppFieldRoutes.test.ts
@@ -33,7 +33,7 @@ const getConnectionString = () => {
   if (!url) return "";
   const parsed = new URL(url.replace(/ /g, "%20"));
   const baseName = parsed.pathname.replace(/^\//, "");
-  const dbName = baseName ? `${baseName}_sync_server` : "datacollect_sync_server";
+  const dbName = baseName ? `${baseName}_openspp_fields` : "datacollect_openspp_fields";
   parsed.pathname = `/${dbName}`;
   return parsed.toString();
 };

--- a/scripts/seed-config.json
+++ b/scripts/seed-config.json
@@ -1,0 +1,220 @@
+{
+  "id": "demo-household-registry",
+  "name": "Demo Household Registry",
+  "description": "Demo app configuration with households and individuals for development and testing.",
+  "version": "1.0.0",
+  "entityForms": [
+    {
+      "id": "household",
+      "name": "household",
+      "title": "Household",
+      "formio": {
+        "display": "form",
+        "components": [
+          {
+            "key": "name",
+            "type": "textfield",
+            "input": true,
+            "label": "Household Name",
+            "validate": { "required": true }
+          },
+          {
+            "key": "address",
+            "type": "textarea",
+            "input": true,
+            "label": "Address",
+            "rows": 3
+          },
+          {
+            "key": "phone",
+            "type": "phoneNumber",
+            "input": true,
+            "label": "Phone Number"
+          },
+          {
+            "key": "district",
+            "type": "select",
+            "input": true,
+            "label": "District",
+            "data": {
+              "values": [
+                { "label": "Chanthabuly", "value": "chanthabuly" },
+                { "label": "Sikhottabong", "value": "sikhottabong" },
+                { "label": "Xaysetha", "value": "xaysetha" },
+                { "label": "Sisattanak", "value": "sisattanak" },
+                { "label": "Hadxaifong", "value": "hadxaifong" }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "individual",
+      "name": "individual",
+      "title": "Individual",
+      "dependsOn": "household",
+      "formio": {
+        "display": "form",
+        "components": [
+          {
+            "key": "first_name",
+            "type": "textfield",
+            "input": true,
+            "label": "First Name",
+            "validate": { "required": true }
+          },
+          {
+            "key": "last_name",
+            "type": "textfield",
+            "input": true,
+            "label": "Last Name",
+            "validate": { "required": true }
+          },
+          {
+            "key": "date_of_birth",
+            "type": "datetime",
+            "input": true,
+            "label": "Date of Birth",
+            "format": "yyyy-MM-dd",
+            "enableTime": false,
+            "enableDate": true
+          },
+          {
+            "key": "gender",
+            "type": "select",
+            "input": true,
+            "label": "Gender",
+            "data": {
+              "values": [
+                { "label": "Male", "value": "male" },
+                { "label": "Female", "value": "female" },
+                { "label": "Other", "value": "other" }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "entityData": [
+    {
+      "name": "household",
+      "data": [
+        {
+          "id": "hh-001",
+          "name": "Nguyen Family",
+          "address": "123 Main Street, Vientiane",
+          "phone": "+856-20-1234567",
+          "district": "chanthabuly"
+        },
+        {
+          "id": "hh-002",
+          "name": "Santos Household",
+          "address": "456 River Road, Phnom Penh",
+          "phone": "+855-12-9876543",
+          "district": "sikhottabong"
+        },
+        {
+          "id": "hh-003",
+          "name": "Sithong Family",
+          "address": "789 Market Lane, Luang Prabang",
+          "phone": "+856-20-5551234",
+          "district": "xaysetha"
+        },
+        {
+          "id": "hh-004",
+          "name": "Rivera-Lopez Household",
+          "address": "12 Riverside Drive",
+          "district": "sisattanak"
+        }
+      ]
+    },
+    {
+      "name": "individual",
+      "data": [
+        {
+          "id": "ind-001",
+          "name": "Nguyen Van Anh",
+          "first_name": "Van Anh",
+          "last_name": "Nguyen",
+          "date_of_birth": "1985-03-15",
+          "gender": "male",
+          "parentId": "hh-001"
+        },
+        {
+          "id": "ind-002",
+          "name": "Nguyen Thi Mai",
+          "first_name": "Thi Mai",
+          "last_name": "Nguyen",
+          "date_of_birth": "1988-07-22",
+          "gender": "female",
+          "parentId": "hh-001"
+        },
+        {
+          "id": "ind-003",
+          "name": "Nguyen Van Duc",
+          "first_name": "Van Duc",
+          "last_name": "Nguyen",
+          "date_of_birth": "2010-01-10",
+          "gender": "male",
+          "parentId": "hh-001"
+        },
+        {
+          "id": "ind-004",
+          "name": "Maria Santos",
+          "first_name": "Maria",
+          "last_name": "Santos",
+          "date_of_birth": "1990-11-05",
+          "gender": "female",
+          "parentId": "hh-002"
+        },
+        {
+          "id": "ind-005",
+          "name": "Carlos Santos",
+          "first_name": "Carlos",
+          "last_name": "Santos",
+          "date_of_birth": "1992-04-18",
+          "gender": "male",
+          "parentId": "hh-002"
+        },
+        {
+          "id": "ind-006",
+          "name": "Kham Sithong",
+          "first_name": "Kham",
+          "last_name": "Sithong",
+          "date_of_birth": "1978-09-30",
+          "gender": "male",
+          "parentId": "hh-003"
+        },
+        {
+          "id": "ind-007",
+          "name": "Dao Sithong",
+          "first_name": "Dao",
+          "last_name": "Sithong",
+          "date_of_birth": "1982-06-12",
+          "gender": "female",
+          "parentId": "hh-003"
+        },
+        {
+          "id": "ind-008",
+          "name": "Somchai Sithong",
+          "first_name": "Somchai",
+          "last_name": "Sithong",
+          "date_of_birth": "2005-12-25",
+          "gender": "male",
+          "parentId": "hh-003"
+        },
+        {
+          "id": "ind-009",
+          "name": "Maria Santos",
+          "first_name": "Maria",
+          "last_name": "Santos",
+          "date_of_birth": "1990-11-05",
+          "gender": "female",
+          "parentId": "hh-003"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/seed-config.json"
+CONFIG_ID="demo-household-registry"
+
+BACKEND_URL="${BACKEND_URL:-http://localhost:3000}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@datacollect.lan}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-correct horse battery staple 42!}"
+
+FIELDWORKER_EMAIL="fieldworker@datacollect.lan"
+FIELDWORKER_PASSWORD="fieldworker123"
+
+log() { echo "[seed] $*"; }
+fail() { echo "[seed] ERROR: $*" >&2; exit 1; }
+
+# --- Prerequisites ---
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  fail "Config file not found: $CONFIG_FILE"
+fi
+
+if ! command -v curl &>/dev/null; then
+  fail "curl is not installed or not in PATH"
+fi
+
+# --- Step 1: Authenticate ---
+
+log "Authenticating as $ADMIN_EMAIL at $BACKEND_URL ..."
+LOGIN_RESPONSE=$(curl -s -w "\n%{http_code}" "$BACKEND_URL/api/users/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\": \"$ADMIN_EMAIL\", \"password\": \"$ADMIN_PASSWORD\"}" \
+  2>&1) || fail "Could not connect to backend at $BACKEND_URL. Is it running?"
+
+HTTP_CODE=$(echo "$LOGIN_RESPONSE" | tail -1)
+LOGIN_BODY=$(echo "$LOGIN_RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" != "200" ]; then
+  fail "Login failed (HTTP $HTTP_CODE). Check credentials. Response: $LOGIN_BODY"
+fi
+
+TOKEN=$(echo "$LOGIN_BODY" | grep -o '"token":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+if [ -z "$TOKEN" ]; then
+  fail "Failed to extract token from login response: $LOGIN_BODY"
+fi
+
+log "Authenticated."
+
+# --- Step 2: Check for existing config (idempotency) ---
+
+log "Checking if config '$CONFIG_ID' exists ..."
+CHECK_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BACKEND_URL/api/apps/$CONFIG_ID" \
+  -H "Authorization: Bearer $TOKEN")
+
+if [ "$CHECK_STATUS" = "200" ]; then
+  log "WARNING: Config '$CONFIG_ID' already exists. Deleting (this removes all its entity data) ..."
+  DELETE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BACKEND_URL/api/apps/$CONFIG_ID" \
+    -H "Authorization: Bearer $TOKEN")
+  if [ "$DELETE_STATUS" != "200" ]; then
+    fail "Failed to delete existing config (HTTP $DELETE_STATUS)"
+  fi
+  log "Deleted existing config."
+fi
+
+# --- Step 3: Upload config ---
+
+log "Uploading demo config ..."
+UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" "$BACKEND_URL/api/apps" \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "config=@$CONFIG_FILE;type=application/json")
+
+UPLOAD_CODE=$(echo "$UPLOAD_RESPONSE" | tail -1)
+UPLOAD_BODY=$(echo "$UPLOAD_RESPONSE" | sed '$d')
+
+if [ "$UPLOAD_CODE" != "200" ] && [ "$UPLOAD_CODE" != "201" ]; then
+  fail "Config upload failed (HTTP $UPLOAD_CODE). Response: $UPLOAD_BODY"
+fi
+
+log "Config uploaded."
+
+# --- Step 4: Create field worker user ---
+
+log "Creating field worker user ($FIELDWORKER_EMAIL) ..."
+USER_RESPONSE=$(curl -s -w "\n%{http_code}" "$BACKEND_URL/api/users" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\": \"$FIELDWORKER_EMAIL\", \"password\": \"$FIELDWORKER_PASSWORD\", \"role\": \"user\"}")
+
+USER_CODE=$(echo "$USER_RESPONSE" | tail -1)
+
+if [ "$USER_CODE" = "201" ]; then
+  log "Field worker user created."
+elif [ "$USER_CODE" = "409" ] || [ "$USER_CODE" = "400" ]; then
+  log "Field worker user already exists, skipping."
+else
+  log "WARNING: Could not create field worker user (HTTP $USER_CODE). Continuing anyway."
+fi
+
+# --- Step 5: Verify ---
+
+log "Verifying ..."
+VERIFY_RESPONSE=$(curl -s "$BACKEND_URL/api/entities/count?configId=$CONFIG_ID" \
+  -H "Authorization: Bearer $TOKEN")
+
+log "Entity count: $VERIFY_RESPONSE"
+
+log ""
+log "Seed complete! Demo config '$CONFIG_ID' is ready."
+log ""
+log "  Admin UI:     http://localhost:5173"
+log "  Admin login:  $ADMIN_EMAIL / (your admin password)"
+log "  Field worker: $FIELDWORKER_EMAIL / $FIELDWORKER_PASSWORD"
+log ""
+log "  Data: 4 households, 9 individuals (includes 1 duplicate pair for testing)"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.test.yaml"
+
+EXITCODE=0
+MANAGED_DOCKER=false
+
+cleanup() {
+  if [ "$MANAGED_DOCKER" = true ]; then
+    echo "Stopping test database..."
+    docker compose -f "$COMPOSE_FILE" down --volumes 2>/dev/null || true
+  fi
+  exit "$EXITCODE"
+}
+
+# If POSTGRES_TEST is already set (e.g. in CI), skip Docker management
+if [ -z "${POSTGRES_TEST:-}" ]; then
+  if ! command -v docker &>/dev/null; then
+    echo "ERROR: docker is not installed or not in PATH" >&2
+    echo "Install Docker Desktop or set POSTGRES_TEST manually." >&2
+    exit 1
+  fi
+
+  trap cleanup EXIT INT TERM
+  MANAGED_DOCKER=true
+
+  echo "Starting test database on port 5433..."
+  docker compose -f "$COMPOSE_FILE" up -d --wait
+
+  export POSTGRES_TEST="postgresql://test:test@localhost:5433/test"
+else
+  trap cleanup EXIT INT TERM
+fi
+
+export JWT_SECRET="${JWT_SECRET:-test-secret}"
+
+echo "Running tests with POSTGRES_TEST=$POSTGRES_TEST"
+cd "$REPO_ROOT"
+pnpm -r --if-present run test "$@" || EXITCODE=$?


### PR DESCRIPTION
## Summary

- Add `pnpm run test:all` — spins up ephemeral PostgreSQL via Docker, runs full test suite, cleans up automatically
- Add `pnpm run seed` — populates backend with demo household registry (4 households, 9 individuals, field worker user, duplicate pair for testing)
- Fix sync-server startup race condition in docker-compose.dev.yaml (healthcheck + depends_on condition)
- Fix opensppFieldRoutes.test.ts sharing a database name with syncServer.test.ts

## Test plan

- [x] `pnpm run test:all` — all 430 tests pass (261 datacollect + 44 backend + 125 mobile)
- [x] `pnpm run seed` — creates 13 entities, field worker user, idempotent on re-run
- [x] `docker compose -f docker/docker-compose.dev.yaml up -d` — sync-server starts cleanly without manual restart
- [x] `shellcheck` passes on both scripts
- [x] Docker compose configs validate