### PR TITLE
docs: add DPGA submission documents

### DIFF
--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,44 @@
+# Accessibility
+
+## Current Status
+
+ID PASS DataCollect aims to be usable by the widest possible audience. The project is working toward WCAG 2.1 Level AA compliance.
+
+### Admin Interface (Vue.js)
+
+The admin interface is a Vue.js single-page application. Current accessibility features:
+
+- Semantic HTML elements for navigation, forms, and content structure
+- Keyboard-navigable interface
+- Form labels and input associations
+- Responsive design for different screen sizes and zoom levels
+
+### Mobile Application (Capacitor)
+
+The mobile app is built with Vue.js and Capacitor:
+
+- Touch-accessible interface designed for field use
+- Biometric authentication as an alternative to password entry
+- Support for system-level accessibility features (screen readers, font scaling) via the native platform
+
+### Backend API
+
+The REST API is accessible to any HTTP client and does not impose visual or auditory requirements.
+
+## Known Gaps
+
+- Comprehensive screen reader testing has not yet been completed across all interfaces
+- Color contrast has not been formally audited against WCAG 2.1 AA thresholds
+- ARIA attributes may be incomplete in some admin interface components
+
+## How to Report Issues
+
+If you encounter an accessibility barrier:
+
+1. Open an issue at https://github.com/idpass/idpass-data-collect/issues
+2. Use the label `accessibility`
+3. Describe what you were trying to do, the barrier you encountered, and any assistive technology in use
+
+## Contributing
+
+We welcome contributions that improve accessibility. See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow.

--- a/DO_NO_HARM.md
+++ b/DO_NO_HARM.md
@@ -1,0 +1,110 @@
+# Do No Harm Assessment
+
+This document describes the safeguards built into ID PASS DataCollect to prevent harm and protect the people whose data it manages.
+
+## Context
+
+DataCollect is designed for social protection programs and humanitarian assistance, where it may process sensitive data about vulnerable populations including children, displaced persons, and people in poverty. The software is deployed by organizations that serve these populations, making harm prevention a core design concern.
+
+## Data Privacy and Security Safeguards
+
+### Privacy by Design
+
+- **Offline-first architecture** — data stays on the device by default, reducing exposure surface
+- **Data minimization** — only fields defined in entity forms are collected; no hidden data collection
+- **No telemetry** — the software does not phone home, track usage, or collect analytics
+- **Multi-tenant isolation** — data from different programs is strictly separated
+
+### Security Controls
+
+- **Role-based access control** — admin and field worker roles with different permission levels
+- **JWT authentication** — secure, token-based API access
+- **Audit trail** — every data change is immutably recorded with user attribution via event sourcing
+- **Hash chain verification** — tamper-evident data integrity checks
+- **Encryption in transit** — TLS/HTTPS required for all production deployments
+- **Device security** — biometric lock and PIN protection on mobile app
+
+### Incident Response
+
+- Security vulnerabilities are handled through a documented process (see [SECURITY.md](SECURITY.md))
+- 48-hour acknowledgment, 5-business-day assessment, 30-day resolution target for critical issues
+- Coordinated disclosure with security researchers
+
+## Protection of Vulnerable Populations
+
+### Children's Data
+
+DataCollect may process data about minors in household registration scenarios. Deploying organizations must:
+
+- Obtain appropriate parental or guardian consent
+- Apply jurisdiction-specific child data protection requirements
+- Use role-based access controls to restrict who can view records involving minors
+
+### Displaced Persons and Refugees
+
+When used in humanitarian contexts:
+
+- Offline-first design ensures data is not transmitted over potentially monitored networks unless explicitly synced
+- Data can be kept entirely local on field worker devices
+- No mandatory cloud dependency reduces risk of data being accessed by hostile actors
+
+### Consent and Transparency
+
+- The software does not collect data autonomously — all data entry is initiated by a human operator
+- Deploying organizations are responsible for implementing informed consent procedures
+- Entity forms are fully configurable, allowing organizations to include consent fields
+
+## Content Safeguards
+
+DataCollect processes structured beneficiary data (names, household composition, program-specific fields). It does not:
+
+- Host user-generated content (no comments, forums, or social features)
+- Process images, videos, or other media
+- Enable direct communication between users
+
+This significantly reduces the risk of the platform being used to distribute harmful or inappropriate content.
+
+## Preventing Misuse
+
+### Access Controls
+
+- All API access requires authentication
+- Admin accounts are required to create users and manage programs
+- Field workers can only access data within their assigned program
+
+### Data Integrity
+
+- Event sourcing prevents silent modification of records — all changes are tracked
+- Hash chain verification detects tampering
+- Deletion is recorded as an event (soft delete with audit trail)
+
+### Deployment Guidance
+
+Organizations deploying DataCollect should:
+
+- Follow the security best practices in [SECURITY.md](SECURITY.md)
+- Implement data protection policies appropriate to their jurisdiction
+- Train field workers on data protection and consent procedures
+- Regularly audit access logs and data changes
+
+## Accessibility
+
+DataCollect is built with web standards (HTML, CSS, JavaScript) and is accessible through:
+
+- Standard web browsers (admin interface)
+- Mobile devices via Capacitor (mobile app)
+- Keyboard navigation support in the admin interface
+
+We welcome accessibility reports and contributions to improve the experience for users with disabilities.
+
+## Environmental Impact
+
+DataCollect's offline-first architecture reduces network usage and server load compared to cloud-dependent alternatives. The software can run on modest hardware, making it suitable for resource-constrained environments.
+
+## Contact
+
+To report concerns about potential harm related to DataCollect:
+
+- **Security issues**: security@acn.fr
+- **General concerns**: https://github.com/idpass/idpass-data-collect/issues
+- **Organization**: Association pour la Cooperation Numerique (ACN) — https://acn.fr

--- a/DO_NO_HARM.md
+++ b/DO_NO_HARM.md
@@ -56,13 +56,13 @@ When used in humanitarian contexts:
 
 ## Content Safeguards
 
-DataCollect processes structured beneficiary data (names, household composition, program-specific fields). It does not:
+DataCollect processes structured beneficiary data (names, household composition, program-specific fields) and supports file attachments (including images) linked to entity records. It does not:
 
 - Host user-generated content (no comments, forums, or social features)
-- Process images, videos, or other media
 - Enable direct communication between users
+- Provide a public-facing content platform
 
-This significantly reduces the risk of the platform being used to distribute harmful or inappropriate content.
+Attachments are stored within the same access-controlled, tenant-isolated infrastructure as entity data. This significantly reduces the risk of the platform being used to distribute harmful or inappropriate content.
 
 ## Preventing Misuse
 
@@ -107,4 +107,4 @@ To report concerns about potential harm related to DataCollect:
 
 - **Security issues**: security@acn.fr
 - **General concerns**: https://github.com/idpass/idpass-data-collect/issues
-- **Organization**: Association pour la Cooperation Numerique (ACN) — https://acn.fr
+- **Organization**: Association pour la Coopération Numérique (ACN) — https://acn.fr

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,57 @@
+# Governance
+
+## Project Overview
+
+ID PASS DataCollect is maintained by the [Association pour la Cooperation Numerique](https://acn.fr) (ACN) as part of its commitment to digital public goods.
+
+## Decision-Making
+
+### Roles
+
+| Role | Responsibility | Current holders |
+| --- | --- | --- |
+| **Maintainer** | Final authority on project direction, releases, and architectural decisions | ACN (organization) |
+| **Lead Architect** | Technical design, code review standards, architecture decisions | Jeremi Joslin |
+| **Core Developers** | Feature development, code review, issue triage | See [CONTRIBUTORS.md](CONTRIBUTORS.md) |
+| **Contributors** | Bug reports, feature requests, pull requests | Open to all |
+
+### How Decisions Are Made
+
+- **Day-to-day technical decisions** are made by core developers through pull request reviews
+- **Architectural decisions** are proposed as GitHub issues or discussions and require lead architect approval
+- **Project direction and roadmap** decisions are made by ACN as the maintaining organization
+- **Release decisions** require maintainer approval
+
+### Conflict Resolution
+
+1. Technical disagreements are resolved through discussion on the relevant GitHub issue or PR
+2. If consensus cannot be reached, the lead architect makes the final technical decision
+3. Non-technical disputes are escalated to ACN
+
+## Contributing
+
+Anyone can contribute to ID PASS DataCollect. See [CONTRIBUTING.md](CONTRIBUTING.md) for:
+
+- Development setup and workflow
+- Coding standards and testing requirements
+- Pull request process
+
+## Intellectual Property
+
+- All contributions are licensed under [Apache License 2.0](LICENSE)
+- Contributors retain copyright of their contributions
+- By submitting a PR, contributors agree to license their work under the project's license
+
+## Code of Conduct
+
+All participants are expected to follow the project's [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+Security vulnerabilities should be reported to security@acn.fr. See [SECURITY.md](SECURITY.md) for the full security policy.
+
+## Contact
+
+- **Organization**: Association pour la Cooperation Numerique (ACN)
+- **Website**: https://acn.fr
+- **GitHub**: https://github.com/idpass/idpass-data-collect

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-ID PASS DataCollect is maintained by the [Association pour la Cooperation Numerique](https://acn.fr) (ACN) as part of its commitment to digital public goods.
+ID PASS DataCollect is maintained by the [Association pour la Coopération Numérique](https://acn.fr) (ACN) as part of its commitment to digital public goods.
 
 ## Decision-Making
 
@@ -52,6 +52,6 @@ Security vulnerabilities should be reported to security@acn.fr. See [SECURITY.md
 
 ## Contact
 
-- **Organization**: Association pour la Cooperation Numerique (ACN)
+- **Organization**: Association pour la Coopération Numérique (ACN)
 - **Website**: https://acn.fr
 - **GitHub**: https://github.com/idpass/idpass-data-collect

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,120 @@
+# Privacy Policy
+
+## Overview
+
+ID PASS DataCollect is an offline-first data management system for household and beneficiary data. This document describes how the software handles personal data and the privacy protections built into its architecture.
+
+ID PASS DataCollect is open-source software deployed and operated by independent organizations. Each deploying organization is the data controller for data processed through their deployment. This document describes the privacy capabilities built into the software itself.
+
+## Data Collected
+
+DataCollect processes the following categories of personal data, as defined by the deploying organization's entity forms:
+
+- **Beneficiary information** — names, household composition, and other fields configured per program
+- **System metadata** — timestamps, user IDs, sync status, and event audit trails
+- **Authentication credentials** — hashed passwords, JWT tokens (never stored in plaintext)
+
+The exact personal data fields are determined entirely by the deploying organization's form configuration. DataCollect does not impose any fixed schema for personal data.
+
+## Data Minimization
+
+DataCollect follows a data minimization approach:
+
+- Only fields defined in entity forms are collected
+- No telemetry, analytics, or usage tracking is built into the software
+- No data is sent to third parties unless explicitly configured via external sync adapters
+
+## Data Storage and Protection
+
+### Client-Side (Mobile and Web)
+
+- Data is stored locally in IndexedDB on the user's device
+- The application functions fully offline — no network connection is required
+- Device-level security features (biometric lock, PIN) protect access to the mobile app
+
+### Server-Side (Backend)
+
+- Data is stored in PostgreSQL with support for encryption at rest
+- Multi-tenant architecture ensures data isolation between programs
+- TLS/HTTPS is required for all production deployments
+
+### Encryption
+
+- **In transit**: All client-server communication uses HTTPS/TLS
+- **At rest**: PostgreSQL encryption at rest is supported; IndexedDB data is protected by device-level encryption
+
+## Audit Trail
+
+DataCollect uses event sourcing — every data change is recorded as an immutable event with:
+
+- Timestamp of the change
+- User who made the change
+- The change itself (as a structured event)
+
+This provides a complete, tamper-evident audit trail using hash chain verification. Events cannot be modified or deleted after creation.
+
+## Data Retention
+
+Deploying organizations are responsible for defining data retention policies appropriate to their context. DataCollect supports:
+
+- Export of all data in JSON format via the ExportImportManager API
+- Deletion of entities through the standard event system
+- Database-level retention policies configurable by the operator
+
+## Data Portability
+
+Beneficiary data can be exported in non-proprietary JSON format using:
+
+- The `ExportImportManager` API (programmatic access)
+- The admin interface (manual export)
+- Direct database access (PostgreSQL standard tools)
+
+See the [Data Export Guide](website/docs/user-guide/data-export.md) for procedures.
+
+## Data Subject Rights
+
+Deploying organizations must implement procedures appropriate to their jurisdiction. DataCollect provides the technical capabilities to support:
+
+- **Right of access** — entity data can be queried and exported per individual
+- **Right to rectification** — data can be updated through form submissions (with full audit trail)
+- **Right to erasure** — entities can be deleted (deletion events are recorded for auditability)
+- **Right to portability** — data export in JSON format
+
+## Children's Data
+
+DataCollect may process data about minors when used for household or individual beneficiary registration. Deploying organizations must:
+
+- Comply with applicable child data protection laws (e.g., COPPA, GDPR Article 8)
+- Obtain appropriate consent from parents or guardians
+- Apply additional access controls for records involving minors
+
+The software does not distinguish between adult and minor data at the technical level. Deploying organizations should use role-based access controls to restrict access to sensitive records.
+
+## International Data Transfers
+
+DataCollect's sync architecture may transfer data between:
+
+- Client devices and a central server (internal sync)
+- The central server and external systems like OpenSPP or OpenFn (external sync)
+
+Deploying organizations are responsible for ensuring that data transfers comply with applicable data protection laws (e.g., GDPR Chapter V).
+
+## Third-Party Integrations
+
+When configured, DataCollect can sync data with external systems:
+
+- **OpenSPP** — social protection platform
+- **OpenFn** — integration and interoperability platform
+
+Data shared with external systems is governed by those systems' privacy policies. Deploying organizations must review the data protection practices of any connected system.
+
+## Security
+
+For detailed security measures, vulnerability reporting, and security best practices, see [SECURITY.md](SECURITY.md).
+
+## Contact
+
+- **Maintainer**: Association pour la Cooperation Numerique (ACN)
+- **Security issues**: security@acn.fr
+- **General inquiries**: https://github.com/idpass/idpass-data-collect/issues
+- **Website**: https://acn.fr

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -114,7 +114,7 @@ For detailed security measures, vulnerability reporting, and security best pract
 
 ## Contact
 
-- **Maintainer**: Association pour la Cooperation Numerique (ACN)
+- **Maintainer**: Association pour la Coopération Numérique (ACN)
 - **Security issues**: security@acn.fr
 - **General inquiries**: https://github.com/idpass/idpass-data-collect/issues
 - **Website**: https://acn.fr

--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 - Submitting pull requests
 - Coding standards
 
+## 📋 Policies and Governance
+
+- [Privacy Policy](PRIVACY.md)
+- [Governance](GOVERNANCE.md)
+- [Do No Harm Assessment](DO_NO_HARM.md)
+- [Accessibility](ACCESSIBILITY.md)
+- [Security Policy](SECURITY.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Contributing](CONTRIBUTING.md)
+
 ## 📄 License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/packages/datacollect/src/components/__tests__/ExportImportManager.test.ts
+++ b/packages/datacollect/src/components/__tests__/ExportImportManager.test.ts
@@ -1,0 +1,228 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "core-js/stable/structured-clone";
+import "fake-indexeddb/auto";
+
+import { ExportImportManagerImpl } from "../ExportImportManager";
+import { EntityStoreImpl } from "../EntityStore";
+import { EventStoreImpl } from "../EventStore";
+import { IndexedDbEntityStorageAdapter } from "../../storage/IndexedDbEntityStorageAdapter";
+import { IndexedDbEventStorageAdapter } from "../../storage/IndexedDbEventStorageAdapter";
+import { EntityDoc, EntityType, FormSubmission, SyncLevel } from "../../interfaces/types";
+
+describe("ExportImportManager", () => {
+  let entityStore: EntityStoreImpl;
+  let eventStore: EventStoreImpl;
+  let manager: ExportImportManagerImpl;
+
+  const mockEntity: EntityDoc = {
+    id: "entity-1",
+    guid: "entity-1",
+    type: EntityType.Individual,
+    version: 1,
+    data: { name: "Jane Doe", dateOfBirth: "1990-05-15" },
+    lastUpdated: "2025-01-01T00:00:00Z",
+  };
+
+  const mockEvent: FormSubmission = {
+    guid: "event-1",
+    entityGuid: "entity-1",
+    type: "create-individual",
+    data: { name: "Jane Doe", dateOfBirth: "1990-05-15" },
+    timestamp: "1735689600",
+    userId: "user-1",
+    syncLevel: SyncLevel.LOCAL,
+  };
+
+  beforeEach(async () => {
+    entityStore = new EntityStoreImpl(new IndexedDbEntityStorageAdapter());
+    eventStore = new EventStoreImpl(new IndexedDbEventStorageAdapter());
+    await entityStore.initialize();
+    await eventStore.initialize();
+    manager = new ExportImportManagerImpl(entityStore, eventStore);
+  });
+
+  afterEach(async () => {
+    await entityStore.clearStore();
+    await eventStore.clearStore();
+  });
+
+  describe("exportData", () => {
+    test("json export produces valid JSON with entities and events", async () => {
+      await entityStore.saveEntity(null, mockEntity);
+      await eventStore.saveEvent(mockEvent);
+
+      const buffer = await manager.exportData("json");
+      const parsed = JSON.parse(buffer.toString());
+
+      expect(parsed).toHaveProperty("entities");
+      expect(parsed).toHaveProperty("events");
+      expect(parsed.entities).toHaveLength(1);
+      expect(parsed.events).toHaveLength(1);
+      expect(parsed.entities[0].modified.data.name).toBe("Jane Doe");
+      expect(parsed.events[0].type).toBe("create-individual");
+    });
+
+    test("json export from empty stores produces empty arrays", async () => {
+      const buffer = await manager.exportData("json");
+      const parsed = JSON.parse(buffer.toString());
+
+      expect(parsed.entities).toEqual([]);
+      expect(parsed.events).toEqual([]);
+    });
+
+    test("json export includes multiple entities and events", async () => {
+      const secondEntity: EntityDoc = {
+        ...mockEntity,
+        id: "entity-2",
+        guid: "entity-2",
+        data: { name: "John Smith" },
+      };
+      const secondEvent: FormSubmission = {
+        ...mockEvent,
+        guid: "event-2",
+        entityGuid: "entity-2",
+        data: { name: "John Smith" },
+      };
+
+      await entityStore.saveEntity(null, mockEntity);
+      await entityStore.saveEntity(null, secondEntity);
+      await eventStore.saveEvent(mockEvent);
+      await eventStore.saveEvent(secondEvent);
+
+      const buffer = await manager.exportData("json");
+      const parsed = JSON.parse(buffer.toString());
+
+      expect(parsed.entities).toHaveLength(2);
+      expect(parsed.events).toHaveLength(2);
+    });
+
+    test("binary export throws not implemented error", async () => {
+      await expect(manager.exportData("binary")).rejects.toThrow("Binary format not implemented");
+    });
+  });
+
+  describe("importData", () => {
+    test("imports entities and events into empty stores", async () => {
+      const data = {
+        entities: [{ guid: "entity-1", initial: null, modified: mockEntity }],
+        events: [{ ...mockEvent, id: 1 }],
+      };
+      const buffer = Buffer.from(JSON.stringify(data));
+
+      const result = await manager.importData(buffer);
+
+      expect(result.status).toBe("success");
+      expect(result.importedEntities).toBe(1);
+
+      const entities = await entityStore.getAllEntities();
+      expect(entities).toHaveLength(1);
+      expect(entities[0].modified.data.name).toBe("Jane Doe");
+
+      const events = await eventStore.getAllEvents();
+      expect(events).toHaveLength(1);
+    });
+
+    test("returns error status for invalid JSON", async () => {
+      const buffer = Buffer.from("not valid json{{{");
+      const result = await manager.importData(buffer);
+
+      expect(result.status).toBe("error");
+      expect(result.importedEntities).toBe(0);
+    });
+
+    test("returns error status for malformed data", async () => {
+      const buffer = Buffer.from(JSON.stringify({ noEntities: true }));
+      const result = await manager.importData(buffer);
+
+      expect(result.status).toBe("error");
+      expect(result.importedEntities).toBe(0);
+    });
+  });
+
+  describe("round-trip", () => {
+    test("export then import preserves entity data", async () => {
+      await entityStore.saveEntity(null, mockEntity);
+      await eventStore.saveEvent(mockEvent);
+
+      const exported = await manager.exportData("json");
+
+      // Import into fresh stores
+      const freshEntityStore = new EntityStoreImpl(new IndexedDbEntityStorageAdapter("round-trip-test"));
+      const freshEventStore = new EventStoreImpl(new IndexedDbEventStorageAdapter("round-trip-test"));
+      await freshEntityStore.initialize();
+      await freshEventStore.initialize();
+      const freshManager = new ExportImportManagerImpl(freshEntityStore, freshEventStore);
+
+      const result = await freshManager.importData(exported);
+      expect(result.status).toBe("success");
+      expect(result.importedEntities).toBe(1);
+
+      const importedEntities = await freshEntityStore.getAllEntities();
+      expect(importedEntities).toHaveLength(1);
+      expect(importedEntities[0].modified.data).toEqual(mockEntity.data);
+      expect(importedEntities[0].modified.guid).toBe(mockEntity.guid);
+
+      const importedEvents = await freshEventStore.getAllEvents();
+      expect(importedEvents).toHaveLength(1);
+      expect(importedEvents[0].entityGuid).toBe(mockEvent.entityGuid);
+      expect(importedEvents[0].type).toBe(mockEvent.type);
+
+      await freshEntityStore.clearStore();
+      await freshEventStore.clearStore();
+    });
+
+    test("round-trip preserves entity with initial and modified versions", async () => {
+      const modifiedEntity: EntityDoc = { ...mockEntity, version: 2, data: { name: "Jane Smith" } };
+      await entityStore.saveEntity(mockEntity, modifiedEntity);
+      await eventStore.saveEvent(mockEvent);
+      await eventStore.saveEvent({
+        ...mockEvent,
+        guid: "event-2",
+        type: "update-individual",
+        data: { name: "Jane Smith" },
+        timestamp: "1735776000",
+      });
+
+      const exported = await manager.exportData("json");
+
+      const freshEntityStore = new EntityStoreImpl(new IndexedDbEntityStorageAdapter("round-trip-test-2"));
+      const freshEventStore = new EventStoreImpl(new IndexedDbEventStorageAdapter("round-trip-test-2"));
+      await freshEntityStore.initialize();
+      await freshEventStore.initialize();
+      const freshManager = new ExportImportManagerImpl(freshEntityStore, freshEventStore);
+
+      const result = await freshManager.importData(exported);
+      expect(result.status).toBe("success");
+
+      const importedEntities = await freshEntityStore.getAllEntities();
+      expect(importedEntities[0].initial?.data.name).toBe("Jane Doe");
+      expect(importedEntities[0].modified.data.name).toBe("Jane Smith");
+
+      const importedEvents = await freshEventStore.getAllEvents();
+      expect(importedEvents).toHaveLength(2);
+
+      await freshEntityStore.clearStore();
+      await freshEventStore.clearStore();
+    });
+  });
+});

--- a/website/docs/user-guide/data-export.md
+++ b/website/docs/user-guide/data-export.md
@@ -27,15 +27,6 @@ const binaryBuffer = await exportImportManager.exportData('binary')
 - `json` — human-readable JSON; suitable for interoperability with other systems
 - `binary` — compact binary format; suitable for backups and full data transfers
 
-### Admin Interface Export
-
-Administrators can export data through the admin UI:
-
-1. Log in to the admin interface
-2. Navigate to the program you want to export
-3. Use the entity list view to access export options
-4. Select the desired format and download
-
 ### Direct Database Export
 
 For server-side deployments, data can be exported using standard PostgreSQL tools:

--- a/website/docs/user-guide/data-export.md
+++ b/website/docs/user-guide/data-export.md
@@ -1,0 +1,81 @@
+---
+title: Data Export
+sidebar_position: 2
+---
+
+# Data Export
+
+DataCollect supports exporting beneficiary data in non-proprietary formats for portability, backup, and compliance with data subject rights.
+
+## Export Methods
+
+### Programmatic Export (ExportImportManager API)
+
+The core library provides an `ExportImportManager` interface for exporting all data:
+
+```typescript
+import { ExportImportManager } from '@idpass/data-collect-core'
+
+// Export as JSON
+const jsonBuffer = await exportImportManager.exportData('json')
+
+// Export as binary
+const binaryBuffer = await exportImportManager.exportData('binary')
+```
+
+**Formats:**
+- `json` — human-readable JSON; suitable for interoperability with other systems
+- `binary` — compact binary format; suitable for backups and full data transfers
+
+### Admin Interface Export
+
+Administrators can export data through the admin UI:
+
+1. Log in to the admin interface
+2. Navigate to the program you want to export
+3. Use the entity list view to access export options
+4. Select the desired format and download
+
+### Direct Database Export
+
+For server-side deployments, data can be exported using standard PostgreSQL tools:
+
+```bash
+# Export all entities for a specific program
+pg_dump -t entities -t events --data-only your_database > export.sql
+
+# Export as CSV
+psql your_database -c "COPY (SELECT * FROM entities WHERE config_id = 'your-program-id') TO STDOUT WITH CSV HEADER" > entities.csv
+```
+
+## Data Format
+
+### JSON Export Structure
+
+Exported JSON contains:
+
+- **entities** — current state of all groups and individuals
+- **events** — complete event history (audit trail)
+- **metadata** — export timestamp, program ID, version
+
+### Importing Exported Data
+
+Data exported in JSON or binary format can be imported into another DataCollect instance:
+
+```typescript
+const importResult = await exportImportManager.importData(buffer)
+console.log(`Imported ${importResult.importedEntities} entities`)
+```
+
+## Use Cases
+
+- **Data portability** — move beneficiary data between DataCollect deployments
+- **Backup** — create regular exports for disaster recovery
+- **Compliance** — fulfill data subject access requests (right of access, right to portability)
+- **Migration** — move data to or from other systems using JSON as an interchange format
+- **Audit** — export event history for external review
+
+## Related
+
+- [ExportImportManager API Reference](../packages/datacollect/api/interfaces/ExportImportManager.md)
+- [Import OpenSPP Fields](./import-openspp-fields.md)


### PR DESCRIPTION
## Summary

- Add **PRIVACY.md** — data handling practices, GDPR capabilities, data subject rights, children's data
- Add **GOVERNANCE.md** — project roles, decision-making process, conflict resolution, IP
- Add **DO_NO_HARM.md** — vulnerable population safeguards, security controls, content safeguards, misuse prevention
- Add **ACCESSIBILITY.md** — WCAG 2.1 AA status, known gaps, reporting process
- Add **data export user guide** (`website/docs/user-guide/data-export.md`) — documents ExportImportManager API and database export
- Update **README.md** with links to all policy documents

Addresses [OP#259 — DPGA Readiness Check](https://projects.acn.fr/work_packages/259)

## Test plan

- [ ] Verify all relative links in new documents resolve correctly on GitHub
- [ ] Verify Docusaurus builds with the new data-export.md (`pnpm build:docs`)
- [ ] Review factual claims against actual codebase features