### PR TITLE
fix(backend): redact secrets from public config artifacts

### DIFF
--- a/packages/backend/src/utils/__tests__/publicArtifacts.test.ts
+++ b/packages/backend/src/utils/__tests__/publicArtifacts.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { redactConfigForPublicArtifact } from "../publicArtifacts";
+import { AppConfig } from "../types";
+
+// Minimal valid-ish AppConfig used as a base for each test.
+function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    id: "tenant-a",
+    name: "Tenant A",
+    artifactId: "abc123",
+    entityForms: [{ name: "individual" }],
+    entityData: [{ id: 1, name: "Alice" }],
+    ...overrides,
+  } as unknown as AppConfig;
+}
+
+describe("redactConfigForPublicArtifact", () => {
+  it("drops the externalSync.adapterConfig secret container (OpenSPP V2 / mock clientSecret)", () => {
+    const config = baseConfig({
+      externalSync: {
+        type: "openspp-v2-adapter",
+        auth: "oauth2",
+        url: "https://registry.internal/api",
+        adapterConfig: {
+          clientId: "dc-client",
+          clientSecret: "super-secret-oauth-value",
+          batchSize: 50,
+        },
+        fieldMappings: [{ source: "first_name", target: "name" }],
+      },
+    } as unknown as Partial<AppConfig>);
+
+    const result = redactConfigForPublicArtifact(config);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain("super-secret-oauth-value");
+    expect(result.externalSync?.adapterConfig).toBeUndefined();
+  });
+
+  it("drops the deprecated externalSync.extraFields secret container (OpenFn apiKey/callbackToken, OpenSPP password)", () => {
+    const config = baseConfig({
+      externalSync: {
+        type: "openfn",
+        url: "https://openfn.example/webhook",
+        extraFields: [
+          { name: "apiKey", value: "openfn-api-key-secret" },
+          { name: "callbackToken", value: "callback-token-secret" },
+          { name: "password", value: "odoo-password-secret" },
+        ],
+      },
+    } as unknown as Partial<AppConfig>);
+
+    const result = redactConfigForPublicArtifact(config);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain("openfn-api-key-secret");
+    expect(serialized).not.toContain("callback-token-secret");
+    expect(serialized).not.toContain("odoo-password-secret");
+    expect(result.externalSync?.extraFields).toBeUndefined();
+  });
+
+  it("drops the external registry url but preserves type, auth and fieldMappings (mobile needs fieldMappings)", () => {
+    const config = baseConfig({
+      externalSync: {
+        type: "openspp-v2-adapter",
+        auth: "oauth2",
+        url: "https://registry.internal/api",
+        adapterConfig: { clientSecret: "x" },
+        fieldMappings: [{ source: "first_name", target: "name" }],
+      },
+    } as unknown as Partial<AppConfig>);
+
+    const result = redactConfigForPublicArtifact(config);
+
+    expect(result.externalSync?.type).toBe("openspp-v2-adapter");
+    expect(result.externalSync?.auth).toBe("oauth2");
+    expect(result.externalSync?.fieldMappings).toEqual([{ source: "first_name", target: "name" }]);
+    // registry url is server-side only; not needed by clients
+    expect(result.externalSync?.url).toBeUndefined();
+  });
+
+  it("strips secret-named fields from authConfigs while keeping public OIDC client params", () => {
+    const config = baseConfig({
+      authConfigs: [
+        {
+          type: "keycloak",
+          fields: {
+            authority: "https://keycloak.example/realms/dc",
+            clientId: "dc-web",
+            scope: "openid profile",
+            organization: "org_123",
+            client_secret: "keycloak-confidential-secret",
+            jwtSecret: "a-jwt-signing-secret",
+          },
+        },
+      ],
+    });
+
+    const result = redactConfigForPublicArtifact(config);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain("keycloak-confidential-secret");
+    expect(serialized).not.toContain("a-jwt-signing-secret");
+
+    const fields = result.authConfigs![0].fields;
+    expect(fields.authority).toBe("https://keycloak.example/realms/dc");
+    expect(fields.clientId).toBe("dc-web");
+    expect(fields.scope).toBe("openid profile");
+    expect(fields.organization).toBe("org_123");
+    expect(fields.client_secret).toBeUndefined();
+    expect(fields.jwtSecret).toBeUndefined();
+  });
+
+  it("does not mutate the input config (returns a clone)", () => {
+    const config = baseConfig({
+      externalSync: {
+        type: "openspp-v2-adapter",
+        url: "https://registry.internal/api",
+        adapterConfig: { clientSecret: "still-here-after" },
+      },
+    } as unknown as Partial<AppConfig>);
+
+    redactConfigForPublicArtifact(config);
+
+    // original must be untouched — the server keeps using the real secrets
+    expect(config.externalSync?.adapterConfig?.clientSecret).toBe("still-here-after");
+  });
+
+  it("preserves onboarding payload fields (entityForms, entityData, selfService, claim169)", () => {
+    const config = baseConfig({
+      selfService: { enabled: true, authMethods: ["id"] },
+      claim169: { enabled: true, trustedIssuers: [{ issuerId: "did:web:issuer" }] },
+    } as unknown as Partial<AppConfig>);
+
+    const result = redactConfigForPublicArtifact(config);
+
+    expect(result.entityForms).toEqual([{ name: "individual" }]);
+    expect(result.entityData).toEqual([{ id: 1, name: "Alice" }]);
+    expect((result as unknown as { selfService: unknown }).selfService).toEqual({ enabled: true, authMethods: ["id"] });
+    expect((result as unknown as { claim169: unknown }).claim169).toEqual({
+      enabled: true,
+      trustedIssuers: [{ issuerId: "did:web:issuer" }],
+    });
+  });
+
+  it("handles configs with no externalSync and no authConfigs", () => {
+    const config = baseConfig();
+    const result = redactConfigForPublicArtifact(config);
+    expect(result.externalSync).toBeUndefined();
+    expect(result.authConfigs).toBeUndefined();
+    expect(result.name).toBe("Tenant A");
+  });
+});

--- a/packages/backend/src/utils/publicArtifacts.ts
+++ b/packages/backend/src/utils/publicArtifacts.ts
@@ -70,6 +70,62 @@ function assertValidArtifactId(artifactId: string) {
   }
 }
 
+/**
+ * Matches field names that hold credentials/secrets. Used to strip secret
+ * values out of authConfigs.fields, which is a free-form bag that also carries
+ * legitimately-public OIDC client params (authority, clientId, scope, …) that
+ * client auth adapters need, so we deny by name rather than dropping the bag.
+ */
+const SECRET_FIELD_PATTERN = /(secret|password|passwd|token|api[_-]?key|private[_-]?key|credential)/i;
+
+function redactSecretFields(fields: Record<string, string>): Record<string, string> {
+  const safe: Record<string, string> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (!SECRET_FIELD_PATTERN.test(key)) {
+      safe[key] = value;
+    }
+  }
+  return safe;
+}
+
+/**
+ * Produces a copy of an AppConfig safe to publish in an unauthenticated public
+ * artifact (downloadable JSON / QR onboarding payload).
+ *
+ * Public artifacts are served without authentication, so any secret in the
+ * config would be disclosed to anyone with the artifact/QR URL. This strips:
+ *  - externalSync.adapterConfig and externalSync.extraFields (OAuth client
+ *    secrets, adapter passwords, OpenFn apiKey/callbackToken, OpenSPP
+ *    username/password) and the server-side registry url. Only the fields a
+ *    client legitimately needs are kept (type, auth, fieldMappings).
+ *  - authConfigs[].fields whose name looks like a credential (client_secret,
+ *    JWT secret, …), keeping public OIDC client params.
+ *
+ * The returned config is a deep clone; the caller's config is never mutated, so
+ * the server keeps using the real secrets for external sync.
+ */
+export function redactConfigForPublicArtifact(appConfig: AppConfig): AppConfig {
+  const redacted = cloneDeep(appConfig);
+
+  if (redacted.externalSync) {
+    const { type, auth, fieldMappings } = redacted.externalSync;
+    redacted.externalSync = {
+      type,
+      ...(auth !== undefined ? { auth } : {}),
+      ...(fieldMappings !== undefined ? { fieldMappings } : {}),
+    } as AppConfig["externalSync"];
+  }
+
+  if (redacted.authConfigs) {
+    redacted.authConfigs = redacted.authConfigs.map((c) => ({
+      type: c.type,
+      fields: redactSecretFields(c.fields ?? {}),
+    }));
+  }
+
+  return redacted;
+}
+
 export function getPublicArtifactPaths(artifactId: string): PublicArtifactPaths {
   assertValidArtifactId(artifactId);
   return {
@@ -89,7 +145,7 @@ export async function generatePublicArtifacts(baseUrl: string, appConfig: AppCon
   await fs.mkdir(PUBLIC_FOLDER, { recursive: true });
   const { jsonPath, qrPath } = getPublicArtifactPaths(appConfig.artifactId);
 
-  const publicConfig = cloneDeep(appConfig);
+  const publicConfig = redactConfigForPublicArtifact(appConfig);
   set(publicConfig, "syncServerUrl", baseUrl);
   const publicJson = JSON.stringify(publicConfig, null, 2);
 


### PR DESCRIPTION
## Summary

Public config artifacts (`/artifacts/:id.json` + the static `public/artifacts` dir) are served **unauthenticated** for QR onboarding, but `generatePublicArtifacts()` serialized the **entire** `AppConfig` — including external-sync credentials and auth secrets. Anyone with the artifact/QR URL could recover them.

This redacts secrets from the artifact at the single write chokepoint (`generatePublicArtifacts`), which covers both the create/update path and the on-demand regeneration route. The server keeps using the real secrets (redaction runs on a deep clone).

Addresses the "secrets in public artifacts" cluster from the recent security review:

- OpenSPP V2 OAuth `clientSecret`
- OpenSPP V1 `username`/`password`
- Auth0/Keycloak `authConfigs` secrets
- Mock-registry `clientSecret`
- OpenFn `apiKey` / `callbackToken`

## What it strips

- **`externalSync`** → allowlisted to `{ type, auth, fieldMappings }`; drops `adapterConfig`, `extraFields`, and the server-side registry `url`. Mobile only consumes `externalSync.fieldMappings`, so onboarding is unaffected.
- **`authConfigs[].fields`** → secret-name denylist (`*secret*`, `*password*`, `*token*`, `*apikey*`, `*privatekey*`, `*credential*`). A denylist (rather than dropping all fields) is deliberate: the client-side Auth0/Keycloak adapters need public params (`authority`, `clientId`, `scope`, `organization`) and pass arbitrary extra fields through as query params.

## Tests

- New `publicArtifacts.test.ts` — 7 unit tests, one per leak vector + no-mutation + payload-preservation.
- Verified: `type-check`, `eslint`, full backend unit suite (113 passed), and the Postgres `syncServer.test.ts` integration suite (8 passed, incl. the real `/artifacts/:id.json` route).

## Not in scope (separate follow-ups)

- Real PII shipped in demo `entityData` (nationalId/DOB) — `entityData` is the legitimate onboarding payload and is intentionally preserved; this is a seed-data hygiene issue.
- Host/forwarded-header poisoning of the artifact base URL.
- The artifact route stays intentionally unauthenticated (QR onboarding); removing secrets is the correct fix rather than auth-gating.
