### PR TITLE
fix(backend): stop deriving public artifact base URL from untrusted host headers

### DIFF
--- a/packages/backend/src/utils/__tests__/resolvePublicBaseUrl.test.ts
+++ b/packages/backend/src/utils/__tests__/resolvePublicBaseUrl.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { Request } from "express";
+import { resolvePublicBaseUrl } from "../publicArtifacts";
+
+// Builds a minimal Express-like request. `hostname` is what Express resolves
+// after applying the `trust proxy` setting — i.e. with `trust proxy` enabled it
+// already reflects X-Forwarded-Host, which is exactly the poisoning vector.
+function makeReq(opts: {
+  hostname?: string;
+  protocol?: string;
+  localPort?: number;
+  headers?: Record<string, string>;
+}): Request {
+  const headers = opts.headers ?? {};
+  return {
+    hostname: opts.hostname ?? "127.0.0.1",
+    protocol: opts.protocol ?? "http",
+    socket: { localPort: opts.localPort ?? 3000 },
+    get: (name: string) => headers[name.toLowerCase()],
+  } as unknown as Request;
+}
+
+describe("resolvePublicBaseUrl", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.PUBLIC_BASE_URL;
+    delete process.env.RAILWAY_PUBLIC_DOMAIN;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("uses PUBLIC_BASE_URL when set, stripping trailing slashes", () => {
+    process.env.PUBLIC_BASE_URL = "https://dc.example.org/";
+    const url = resolvePublicBaseUrl(makeReq({ hostname: "evil.example" }));
+    expect(url).toBe("https://dc.example.org");
+  });
+
+  it("ignores an attacker X-Forwarded-Host header when PUBLIC_BASE_URL is set", () => {
+    process.env.PUBLIC_BASE_URL = "https://dc.example.org";
+    const url = resolvePublicBaseUrl(
+      makeReq({ hostname: "127.0.0.1", headers: { "x-forwarded-host": "attacker.example" } }),
+    );
+    expect(url).toBe("https://dc.example.org");
+  });
+
+  it("uses RAILWAY_PUBLIC_DOMAIN over HTTPS when set", () => {
+    process.env.RAILWAY_PUBLIC_DOMAIN = "myapp.up.railway.app";
+    const url = resolvePublicBaseUrl(makeReq({ hostname: "evil.example" }));
+    expect(url).toBe("https://myapp.up.railway.app");
+  });
+
+  it("falls back to the request host for loopback dev requests", () => {
+    const url = resolvePublicBaseUrl(makeReq({ hostname: "127.0.0.1", localPort: 4567 }));
+    expect(url).toBe("http://127.0.0.1:4567");
+  });
+
+  it("does NOT trust X-Forwarded-Host for the dev fallback (H29)", () => {
+    // hostname stays loopback; the forwarded header must be ignored entirely.
+    const url = resolvePublicBaseUrl(
+      makeReq({ hostname: "127.0.0.1", localPort: 4567, headers: { "x-forwarded-host": "attacker.example" } }),
+    );
+    expect(url).toBe("http://127.0.0.1:4567");
+    expect(url).not.toContain("attacker.example");
+  });
+
+  it("fails closed for a non-loopback request host with no configured base URL (H31)", () => {
+    // With `trust proxy`, a forged Host/X-Forwarded-Host surfaces as req.hostname.
+    expect(() => resolvePublicBaseUrl(makeReq({ hostname: "attacker.example" }))).toThrow(
+      /trusted public base URL/i,
+    );
+  });
+
+  it("omits the port for default ports on loopback", () => {
+    expect(resolvePublicBaseUrl(makeReq({ hostname: "localhost", protocol: "http", localPort: 80 }))).toBe(
+      "http://localhost",
+    );
+    expect(resolvePublicBaseUrl(makeReq({ hostname: "localhost", protocol: "https", localPort: 443 }))).toBe(
+      "https://localhost",
+    );
+  });
+});

--- a/packages/backend/src/utils/publicArtifacts.ts
+++ b/packages/backend/src/utils/publicArtifacts.ts
@@ -34,31 +34,36 @@ export interface PublicArtifactPaths {
   qrPath: string;
 }
 
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
 export function resolvePublicBaseUrl(req: Request): string {
-  // Allow explicit configuration via environment variable (recommended for production)
+  // Trusted, explicit configuration — required for any non-local deployment.
   const configured = process.env.PUBLIC_BASE_URL?.trim();
   if (configured) {
     return configured.replace(/\/+$/, "");
   }
 
-  // Check for Railway's public domain (when behind Railway's proxy)
-  const railwayPublicDomain = process.env.RAILWAY_PUBLIC_DOMAIN;
+  // Railway's public domain (when behind Railway's proxy). Railway always uses
+  // HTTPS for public domains.
+  const railwayPublicDomain = process.env.RAILWAY_PUBLIC_DOMAIN?.trim();
   if (railwayPublicDomain) {
-    // Railway always uses HTTPS for public domains
-    return `https://${railwayPublicDomain}`;
+    return `https://${railwayPublicDomain.replace(/\/+$/, "")}`;
   }
 
-  // Check for X-Forwarded-Host header (when behind a reverse proxy)
-  const forwardedHost = req.get("x-forwarded-host");
-  const forwardedProto = req.get("x-forwarded-proto") || req.protocol;
-  if (forwardedHost) {
-    // Don't include port for standard HTTP/HTTPS (80/443)
-    return `${forwardedProto}://${forwardedHost}`;
-  }
-
-  // Fallback: construct from request (for local development)
-  const protocol = req.protocol;
+  // No trusted base URL is configured. This value is persisted into the public
+  // artifact (syncServerUrl + QR target), so it must NOT be derived from
+  // client-controllable host headers (Host / X-Forwarded-Host): an attacker who
+  // can reach an artifact endpoint could otherwise repoint onboarding at their
+  // own sync server. Accept the request host only when it is loopback (local
+  // development); for anything else, fail closed and require explicit config.
   const hostname = req.hostname;
+  if (!LOOPBACK_HOSTS.has(hostname)) {
+    throw new Error(
+      "Cannot resolve a trusted public base URL. Set PUBLIC_BASE_URL (or RAILWAY_PUBLIC_DOMAIN) for non-local deployments.",
+    );
+  }
+
+  const protocol = req.protocol;
   const port = req.socket.localPort;
   const isDefaultPort = (protocol === "http" && port === 80) || (protocol === "https" && port === 443);
   return `${protocol}://${hostname}${isDefaultPort ? "" : `:${port}`}`;


### PR DESCRIPTION
## Summary

`resolvePublicBaseUrl()` derives the base URL that gets **persisted into the public artifact** (`syncServerUrl` + the QR code target) from client-controllable host headers. The unauthenticated `/artifacts/:id.json|.png` fallback routes call it and regenerate the artifact on demand, so an attacker who knows an `artifactId` could request it with a forged `X-Forwarded-Host` (or, because `app.set("trust proxy", 1)` makes `req.hostname` reflect the forwarded host, a forged `Host`) and persist an artifact that points future onboarding clients at an attacker-controlled sync server — capturing credentials, tokens, and beneficiary data.

Addresses the host/forwarded-header poisoning findings (H29 `X-Forwarded-Host`, H31 `Host`/`req.hostname`).

## Change

`resolvePublicBaseUrl()` now resolves the base URL only from trusted sources:

1. `PUBLIC_BASE_URL` (explicit config) — used verbatim, headers ignored.
2. `RAILWAY_PUBLIC_DOMAIN` — `https://<domain>`.
3. Otherwise, the request host is accepted **only when it is loopback** (local dev). For any non-loopback host with no configured base URL it **fails closed** with a clear error rather than persisting an attacker-influenced URL.

The direct `X-Forwarded-Host` / `X-Forwarded-Proto` read is removed entirely.

## Behavioral note for reviewers

Deployments behind a reverse proxy that previously relied on forwarded headers (without setting `PUBLIC_BASE_URL`) must now set **`PUBLIC_BASE_URL`** (or `RAILWAY_PUBLIC_DOMAIN`). This is the intended hardening — the artifact base URL must come from server config, not the request. Loopback/local development is unchanged.

## Tests

- New `resolvePublicBaseUrl.test.ts` — 7 unit tests incl. explicit H29 (ignores `X-Forwarded-Host`) and H31 (fails closed on non-loopback host) regression cases.
- Verified: `type-check`, `eslint`, full backend unit suite (113 passed), and the Postgres `syncServer.test.ts` integration suite (8 passed) — the artifact route's loopback path still resolves correctly.
