### PR TITLE
fix(backend): strip seeded entityData from public config artifacts

### DIFF
--- a/packages/backend/src/utils/__tests__/publicArtifactEntityData.test.ts
+++ b/packages/backend/src/utils/__tests__/publicArtifactEntityData.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import fs from "fs/promises";
+import { generatePublicArtifacts, getPublicArtifactPaths } from "../publicArtifacts";
+import { AppConfig } from "../types";
+
+const ARTIFACT_ID = "test-entitydata-strip";
+
+function configWithBeneficiaryData(): AppConfig {
+  return {
+    id: "tenant-a",
+    name: "Demo Registry",
+    artifactId: ARTIFACT_ID,
+    selfService: { enabled: true, authMethods: ["id", "otp"] },
+    entityForms: [{ name: "individual" }],
+    entityData: [
+      {
+        name: "individual",
+        data: [
+          {
+            id: "p-001",
+            name: "Somsak Phanthavong",
+            date_of_birth: "1985-03-15",
+            national_id: "LA-1985-03150001",
+            phone: "+856-20-1234567",
+          },
+        ],
+      },
+    ],
+  } as unknown as AppConfig;
+}
+
+describe("generatePublicArtifacts — entityData stripping", () => {
+  const { jsonPath, qrPath } = getPublicArtifactPaths(ARTIFACT_ID);
+
+  afterEach(async () => {
+    await fs.unlink(jsonPath).catch(() => {});
+    await fs.unlink(qrPath).catch(() => {});
+  });
+
+  it("omits seeded beneficiary entityData (names, national IDs, DOB, phone) from the public artifact", async () => {
+    await generatePublicArtifacts("http://localhost:3000", configWithBeneficiaryData());
+
+    const written = await fs.readFile(jsonPath, "utf8");
+    const parsed = JSON.parse(written);
+
+    expect(parsed.entityData).toEqual([]);
+    expect(written).not.toContain("Somsak Phanthavong");
+    expect(written).not.toContain("LA-1985-03150001");
+    expect(written).not.toContain("1985-03-15");
+    expect(written).not.toContain("+856-20-1234567");
+  });
+
+  it("preserves non-sensitive onboarding fields and sets syncServerUrl", async () => {
+    await generatePublicArtifacts("http://localhost:3000", configWithBeneficiaryData());
+
+    const parsed = JSON.parse(await fs.readFile(jsonPath, "utf8"));
+    expect(parsed.name).toBe("Demo Registry");
+    expect(parsed.entityForms).toEqual([{ name: "individual" }]);
+    expect(parsed.selfService).toEqual({ enabled: true, authMethods: ["id", "otp"] });
+    expect(parsed.syncServerUrl).toBe("http://localhost:3000");
+  });
+
+  it("does not mutate the caller's config (server keeps its seed data)", async () => {
+    const config = configWithBeneficiaryData();
+    await generatePublicArtifacts("http://localhost:3000", config);
+    expect(config.entityData?.[0].data[0].national_id).toBe("LA-1985-03150001");
+  });
+});

--- a/packages/backend/src/utils/publicArtifacts.ts
+++ b/packages/backend/src/utils/publicArtifacts.ts
@@ -91,6 +91,15 @@ export async function generatePublicArtifacts(baseUrl: string, appConfig: AppCon
 
   const publicConfig = cloneDeep(appConfig);
   set(publicConfig, "syncServerUrl", baseUrl);
+  // The public artifact is served unauthenticated for QR onboarding. entityData
+  // holds seeded beneficiary records (names, national IDs, dates of birth) which
+  // would otherwise be publicly downloadable — and, when self-service ID auth is
+  // enabled, those values are the login factors. Clients receive entities via
+  // sync, not from the onboarding config, and the server seeds entityData from
+  // its own stored config, so emptying it here removes the disclosure without
+  // affecting onboarding or server-side seeding. The field is kept (as an empty
+  // array) because the mobile tenant-app schema requires it.
+  set(publicConfig, "entityData", []);
   const publicJson = JSON.stringify(publicConfig, null, 2);
 
   await fs.writeFile(jsonPath, publicJson);


### PR DESCRIPTION
## Summary

Public config artifacts are served **unauthenticated** for QR onboarding, and `generatePublicArtifacts()` serializes the config's `entityData` verbatim. Seed/demo configs put beneficiary records there (names, `national_id`, `date_of_birth`, phone) — so those records become publicly downloadable, and when self-service **ID** auth is enabled (`authMethods: ["id"]`), `national_id` + `date_of_birth` are exactly the login factors. The artifact ends up containing both the identity records and the credentials to impersonate them.

Addresses the "public config artifact leaks ID-auth PII" finding (H23).

## Change

`generatePublicArtifacts()` now empties `entityData` in the published artifact (`set(publicConfig, "entityData", [])`).

This is safe because:
- **Server-side seeding is unaffected** — `AppInstanceStore.loadEntityData()` reads `entityData` from the stored config, not from the artifact.
- **Clients receive entities via sync**, not from the onboarding config; nothing on mobile seeds entities from `config.entityData`.
- The field is kept as an empty array because the mobile tenant-app schema lists `entityData` as required.
- The caller's config object is not mutated (the write targets a deep clone).

## Behavioral note for reviewers

Mobile onboarding downloads will no longer carry seeded `entityData`. If any deployment intentionally used `entityData` to ship non-PII reference lookups to clients offline, that would need a separate, explicitly-public mechanism — public artifacts must not carry beneficiary data.

## Tests

- New `publicArtifactEntityData.test.ts` — drives the real `generatePublicArtifacts` and asserts the written JSON contains no names/national IDs/DOB/phone, preserves the rest of the onboarding config, and does not mutate the input.
- Verified: `type-check`, `eslint`, full backend unit suite (109 passed), Postgres `syncServer.test.ts` integration suite (8 passed, artifact route intact).

## Related

Complements the secret-redaction work (#31) and the host-header hardening (#32). Independent of both — together they ensure public artifacts carry no secrets, no beneficiary PII, and no attacker-influenced URL.
