### PR TITLE
fix: Tier-1 security remediation — self-service flag, OpenSPP confused-deputy chain, OIDC audience binding

### DIFF
--- a/packages/adapter-openspp/src/__tests__/OpenSppV2SyncAdapter.test.ts
+++ b/packages/adapter-openspp/src/__tests__/OpenSppV2SyncAdapter.test.ts
@@ -737,7 +737,7 @@ describe("OpenSppV2SyncAdapter", () => {
       expect(freshEventApplierService.submitForm).not.toHaveBeenCalled();
     });
 
-    it("pulls individuals with non-matching identifier system", async () => {
+    it("skips individuals whose only identifier system is out-of-namespace (H12)", async () => {
       mockV2ClientImplementation.searchIndividuals.mockReset();
       mockV2ClientImplementation.searchIndividuals.mockResolvedValueOnce({
         data: [{
@@ -763,17 +763,10 @@ describe("OpenSppV2SyncAdapter", () => {
       adapter = new OpenSppV2SyncAdapter(eventStore, eventApplierService, config);
       const result = await adapter.pullData();
 
-      expect(result.pulled).toBe(1);
-      expect(result.skipped).toBe(0);
-      expect(eventApplierService.submitForm).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "create-individual",
-          data: expect.objectContaining({
-            firstName: "Maria",
-            lastName: "Santos",
-          }),
-        }),
-      );
+      // Out-of-namespace records must not be imported as DataCollect entities.
+      expect(result.pulled).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(eventApplierService.submitForm).not.toHaveBeenCalled();
     });
 
     it("pulls individuals with no identifiers at all", async () => {

--- a/packages/adapter-openspp/src/__tests__/OpenSppV2SyncAdapter.test.ts
+++ b/packages/adapter-openspp/src/__tests__/OpenSppV2SyncAdapter.test.ts
@@ -308,6 +308,88 @@ describe("OpenSppV2SyncAdapter", () => {
       expect(mockV2ClientImplementation.createIndividual).toHaveBeenCalled();
     });
 
+    it("pushes back under the preserved identifierType, not the default system (H10 cycle 2)", async () => {
+      const entityPair: EntityPair = {
+        guid: "ind-h10",
+        initial: {
+          id: "e", guid: "ind-h10", type: EntityType.Individual, version: 1, externalId: "PH-123",
+          data: { entityName: "individual", firstName: "Ana", lastName: "Cruz", externalId: "PH-123", identifierType: "national_id" },
+          lastUpdated: "2024-01-01T12:00:00.000Z",
+        },
+        modified: {
+          id: "e", guid: "ind-h10", type: EntityType.Individual, version: 2, externalId: "PH-123",
+          data: { entityName: "individual", firstName: "Ana", lastName: "Cruz", externalId: "PH-123", identifierType: "national_id" },
+          lastUpdated: "2024-01-02T12:00:00.000Z",
+        },
+      };
+      const mockEntityStore = {
+        getAllEntities: jest.fn().mockResolvedValue([entityPair]),
+        getModifiedEntitiesSince: jest.fn().mockResolvedValue([entityPair]),
+        getEntity: jest.fn().mockResolvedValue(entityPair),
+        getEntityByExternalId: jest.fn().mockResolvedValue(entityPair),
+        saveEntity: jest.fn(),
+      };
+      eventApplierService.getEntityStore = jest.fn().mockReturnValue(mockEntityStore);
+      mockV2ClientImplementation.getIndividual.mockResolvedValue({
+        type: "Individual",
+        identifier: [{ system: "urn:openspp:vocab:id-type#national_id", value: "PH-123" }],
+        meta: { versionId: "v9" },
+      });
+
+      adapter = new OpenSppV2SyncAdapter(eventStore, eventApplierService, config);
+      const result = await adapter.pushData();
+
+      expect(result.failed).toBe(0);
+      expect(mockV2ClientImplementation.patchIndividual).toHaveBeenCalledWith(
+        "urn:openspp:vocab:id-type#national_id|PH-123",
+        expect.anything(),
+        "v9",
+      );
+    });
+
+    it("tolerates a non-string identifierType without failing the push (H22)", async () => {
+      const entityPair: EntityPair = {
+        guid: "ind-h22",
+        initial: {
+          id: "e", guid: "ind-h22", type: EntityType.Individual, version: 1, externalId: "ind-h22",
+          data: { entityName: "individual", firstName: "Sam", lastName: "Ng", externalId: "ind-h22" },
+          lastUpdated: "2024-01-01T12:00:00.000Z",
+        },
+        modified: {
+          id: "e", guid: "ind-h22", type: EntityType.Individual, version: 2, externalId: "ind-h22",
+          data: {
+            entityName: "individual", firstName: "Sam", lastName: "Ng", externalId: "ind-h22",
+            identifierType: { malicious: true } as unknown as string,
+          },
+          lastUpdated: "2024-01-02T12:00:00.000Z",
+        },
+      };
+      const mockEntityStore = {
+        getAllEntities: jest.fn().mockResolvedValue([entityPair]),
+        getModifiedEntitiesSince: jest.fn().mockResolvedValue([entityPair]),
+        getEntity: jest.fn().mockResolvedValue(entityPair),
+        getEntityByExternalId: jest.fn().mockResolvedValue(entityPair),
+        saveEntity: jest.fn(),
+      };
+      eventApplierService.getEntityStore = jest.fn().mockReturnValue(mockEntityStore);
+      mockV2ClientImplementation.getIndividual.mockResolvedValue({
+        type: "Individual",
+        identifier: [{ system: "urn:openspp:vocab:id-type#system_id", value: "ind-h22" }],
+        meta: { versionId: "v1" },
+      });
+
+      adapter = new OpenSppV2SyncAdapter(eventStore, eventApplierService, config);
+      const result = await adapter.pushData();
+
+      expect(result.failed).toBe(0);
+      // Falls back to the configured default system, not the bogus identifierType.
+      expect(mockV2ClientImplementation.patchIndividual).toHaveBeenCalledWith(
+        "urn:openspp:vocab:id-type#system_id|ind-h22",
+        expect.anything(),
+        "v1",
+      );
+    });
+
     it("handles empty entity list", async () => {
       const mockEntityStore = {
         getAllEntities: jest.fn().mockResolvedValue([]),
@@ -521,6 +603,39 @@ describe("OpenSppV2SyncAdapter", () => {
             dateOfBirth: "1990-05-15",
             gender: "male",
           }),
+        }),
+      );
+    });
+
+    it("preserves the OpenSPP identifier system as identifierType on pull (H10)", async () => {
+      const mockSearchResult: SearchResult<IndividualResource> = {
+        data: [
+          {
+            type: "Individual",
+            identifier: [{ system: "urn:openspp:vocab:id-type#national_id", value: "PH-123" }],
+            name: { given: "Ana", family: "Cruz", text: "Cruz, Ana" },
+          },
+        ],
+        meta: { total: 1, count: 1, offset: 0 },
+        links: { self: "/api/v2/spp/Individual?_count=100&_offset=0" },
+      };
+      // Reset to drop any mockResolvedValueOnce queue left by earlier tests.
+      mockV2ClientImplementation.searchIndividuals.mockReset();
+      mockV2ClientImplementation.searchIndividuals.mockResolvedValueOnce(mockSearchResult);
+      mockV2ClientImplementation.searchIndividuals.mockResolvedValueOnce({
+        data: [],
+        meta: { total: 1, count: 0, offset: 1 },
+        links: { self: "/api/v2/spp/Individual?_count=100&_offset=1" },
+      });
+
+      adapter = new OpenSppV2SyncAdapter(eventStore, eventApplierService, config);
+      await adapter.pullData();
+
+      // externalId keeps the value; identifierType keeps the system's vocab code
+      // so a later push targets national_id|PH-123 — not the default system_id.
+      expect(eventApplierService.submitForm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ externalId: "PH-123", identifierType: "national_id" }),
         }),
       );
     });

--- a/packages/adapter-openspp/src/__tests__/OpenSppV2SyncAdapter.test.ts
+++ b/packages/adapter-openspp/src/__tests__/OpenSppV2SyncAdapter.test.ts
@@ -253,6 +253,61 @@ describe("OpenSppV2SyncAdapter", () => {
       expect(mockV2ClientImplementation.createIndividual).not.toHaveBeenCalled();
     });
 
+    it("does not discover/patch a record via a client-supplied identifier (H1/H2/H3)", async () => {
+      // Entity carries a server-set externalId that no longer resolves on
+      // OpenSPP, plus an attacker-controlled national_id pointing at a victim.
+      const entityPair: EntityPair = {
+        guid: "attacker-1",
+        initial: {
+          id: "e-att", guid: "attacker-1", type: EntityType.Individual, version: 1,
+          externalId: "stale-ext",
+          data: { entityName: "individual", firstName: "Mal", lastName: "Lory", externalId: "stale-ext" },
+          lastUpdated: "2024-01-01T12:00:00.000Z",
+        },
+        modified: {
+          id: "e-att", guid: "attacker-1", type: EntityType.Individual, version: 2,
+          externalId: "stale-ext",
+          data: {
+            entityName: "individual", firstName: "Mal", lastName: "Lory", externalId: "stale-ext",
+            national_id: "VICTIM-NID", uin: "VICTIM-NID",
+          },
+          lastUpdated: "2024-01-02T12:00:00.000Z",
+        },
+      };
+
+      const mockEntityStore = {
+        getAllEntities: jest.fn().mockResolvedValue([entityPair]),
+        getModifiedEntitiesSince: jest.fn().mockResolvedValue([entityPair]),
+        getEntity: jest.fn().mockResolvedValue(entityPair),
+        getEntityByExternalId: jest.fn().mockResolvedValue(entityPair),
+        saveEntity: jest.fn(),
+      };
+      eventApplierService.getEntityStore = jest.fn().mockReturnValue(mockEntityStore);
+
+      // The victim resolves ONLY if queried by the client-supplied identifier.
+      // The stale externalId resolves to nothing.
+      mockV2ClientImplementation.getIndividual.mockImplementation(async (id: string) => {
+        if (id.includes("VICTIM-NID")) {
+          return {
+            type: "Individual",
+            identifier: [{ system: "urn:openspp:vocab:id-type#national_id", value: "VICTIM-NID" }],
+            meta: { versionId: "victim-version" },
+          } as IndividualResource;
+        }
+        return null;
+      });
+
+      adapter = new OpenSppV2SyncAdapter(eventStore, eventApplierService, config);
+      await adapter.pushData();
+
+      // Discovery must never probe the victim's client-supplied identifier...
+      const queried = mockV2ClientImplementation.getIndividual.mock.calls.map((c) => c[0] as string);
+      expect(queried.some((id) => id.includes("VICTIM-NID"))).toBe(false);
+      // ...so the victim is never PATCHed; the entity is POSTed as new instead.
+      expect(mockV2ClientImplementation.patchIndividual).not.toHaveBeenCalled();
+      expect(mockV2ClientImplementation.createIndividual).toHaveBeenCalled();
+    });
+
     it("handles empty entity list", async () => {
       const mockEntityStore = {
         getAllEntities: jest.fn().mockResolvedValue([]),

--- a/packages/adapter-openspp/src/__tests__/OpenSppV2SyncAdapter.test.ts
+++ b/packages/adapter-openspp/src/__tests__/OpenSppV2SyncAdapter.test.ts
@@ -55,6 +55,8 @@ const mockV2ClientImplementation = {
   })),
   updateGroup: jest.fn().mockImplementation((_: string, resource: GroupResource) => resource),
   patchGroup: jest.fn().mockImplementation(() => ({ type: "Group", identifier: [] })),
+  createChangeRequest: jest.fn().mockResolvedValue({ id: "cr-1", status: "pending" }),
+  getChangeRequest: jest.fn().mockResolvedValue(null),
 };
 
 jest.mock("../v2/OpenSppV2Client", () => {
@@ -64,6 +66,8 @@ jest.mock("../v2/OpenSppV2Client", () => {
     OpenSppV2Client: jest.fn().mockImplementation(() => mockV2ClientImplementation),
     default: jest.fn().mockImplementation(() => mockV2ClientImplementation),
     PreconditionFailedError: actual.PreconditionFailedError,
+    ConflictError: actual.ConflictError,
+    ChangeRequestRevisionNeededError: actual.ChangeRequestRevisionNeededError,
   };
 });
 
@@ -388,6 +392,44 @@ describe("OpenSppV2SyncAdapter", () => {
         expect.anything(),
         "v1",
       );
+    });
+
+    it("pushes enrolments only, without re-patching a baseline-parity entity (H4)", async () => {
+      // initial.version === modified.version (no genuine local entity edit), but
+      // the entity carries client-controllable pendingProgramEnrolments.
+      const entityPair: EntityPair = {
+        guid: "ind-enr",
+        initial: {
+          id: "e", guid: "ind-enr", type: EntityType.Individual, version: 3, externalId: "ind-enr",
+          data: { entityName: "individual", firstName: "Pat", lastName: "Lee", externalId: "ind-enr" },
+          lastUpdated: "2024-01-01T12:00:00.000Z",
+        },
+        modified: {
+          id: "e", guid: "ind-enr", type: EntityType.Individual, version: 3, externalId: "ind-enr",
+          data: {
+            entityName: "individual", firstName: "Pat", lastName: "Lee", externalId: "ind-enr",
+            pendingProgramEnrolments: [{ programId: 42 }],
+          },
+          lastUpdated: "2024-01-01T12:00:00.000Z",
+        },
+      };
+      const mockEntityStore = {
+        getAllEntities: jest.fn().mockResolvedValue([entityPair]),
+        getModifiedEntitiesSince: jest.fn().mockResolvedValue([entityPair]),
+        getEntity: jest.fn().mockResolvedValue(entityPair),
+        getEntityByExternalId: jest.fn().mockResolvedValue(entityPair),
+        saveEntity: jest.fn(),
+      };
+      eventApplierService.getEntityStore = jest.fn().mockReturnValue(mockEntityStore);
+
+      adapter = new OpenSppV2SyncAdapter(eventStore, eventApplierService, config);
+      await adapter.pushData();
+
+      // The entity itself must NOT be written (no stale overwrite)...
+      expect(mockV2ClientImplementation.patchIndividual).not.toHaveBeenCalled();
+      expect(mockV2ClientImplementation.createIndividual).not.toHaveBeenCalled();
+      // ...but the enrolment CR still flows.
+      expect(mockV2ClientImplementation.createChangeRequest).toHaveBeenCalled();
     });
 
     it("handles empty entity list", async () => {

--- a/packages/adapter-openspp/src/v2/OpenSppV2SyncAdapter.ts
+++ b/packages/adapter-openspp/src/v2/OpenSppV2SyncAdapter.ts
@@ -824,57 +824,28 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
    * doesn't kill the discovery sweep.
    */
   private async tryDiscoverIndividual(
-    data: Record<string, unknown>,
+    _data: Record<string, unknown>,
     storedExternalId?: string,
   ): Promise<{ resource: IndividualResource; identifier: string } | null> {
-    const seen = new Set<string>();
-    const candidates: Array<{ system: string; value: string }> = [];
-
-    const ensureNamespace = (code: string) =>
-      code.startsWith(this.identifierNamespace) ? code : `${this.identifierNamespace}${code}`;
-
-    const tryAdd = (code: string, value: unknown) => {
-      if (typeof value !== "string" || value.length === 0) return;
-      const system = ensureNamespace(code);
-      const key = `${system}|${value}`;
-      if (seen.has(key)) return;
-      seen.add(key);
-      candidates.push({ system, value });
-    };
-
-    // Walk common identity fields on the entity. Order matters: cheaper /
-    // more authoritative identifiers first so the first hit short-circuits.
-    // OpenSPP id-type vocab codes are case-sensitive on the validator side
-    // but registries differ on casing convention (UIN vs uin, NATIONAL_ID vs
-    // national_id) — probe both casings so we don't miss the partner.
-    const bothCasings = (code: string, value: unknown) => {
-      tryAdd(code.toUpperCase(), value);
-      tryAdd(code.toLowerCase(), value);
-    };
-    bothCasings("UIN", data.uin);
-    bothCasings("NATIONAL_ID", data.national_id);
-    bothCasings("REG_ID", data.reg_id);
-    bothCasings("REGISTRATION_ID", data.registration_id);
-    bothCasings("PASSPORT_ID", data.passport_id);
-    // The stored externalId is a single opaque string but the operator may
-    // have registered it under any id-type on OpenSPP (depends on how the
-    // upstream registry was bootstrapped). Probe every known system with it
-    // — the first GET hit wins.
-    if (storedExternalId) {
-      for (const code of ["UIN", "NATIONAL_ID", "REG_ID", "REGISTRATION_ID", "PASSPORT_ID", "HOUSEHOLD_ID"]) {
-        bothCasings(code, storedExternalId);
-      }
-      tryAdd(this.identifierType, storedExternalId);
+    // Discovery is restricted to the server-resolved externalId probed under
+    // the tenant's configured identifier type. Probing client-supplied identity
+    // fields (uin/national_id/...), alternate casings, or other id-type
+    // namespaces would let a client name a victim's OpenSPP record and have it
+    // rebound + overwritten with the server's privileged credentials
+    // (findings H1/H2/H3). externalId itself is server-managed: clients can no
+    // longer set it (stripped at the /api/sync/push boundary).
+    if (typeof storedExternalId !== "string" || storedExternalId.length === 0) {
+      return null;
     }
-
-    for (const c of candidates) {
-      const id = this.getClient().formatIdentifier(c.system, c.value);
-      try {
-        const found = await this.getClient().getIndividual(id);
-        if (found) return { resource: found, identifier: id };
-      } catch {
-        // ignore — try next candidate
-      }
+    const system = this.identifierType.startsWith(this.identifierNamespace)
+      ? this.identifierType
+      : `${this.identifierNamespace}${this.identifierType}`;
+    const id = this.getClient().formatIdentifier(system, storedExternalId);
+    try {
+      const found = await this.getClient().getIndividual(id);
+      if (found) return { resource: found, identifier: id };
+    } catch {
+      // ignore — discovery is best-effort
     }
     return null;
   }
@@ -1000,49 +971,24 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
    * GET each candidate, return the first hit.
    */
   private async tryDiscoverGroup(
-    data: Record<string, unknown>,
+    _data: Record<string, unknown>,
     storedExternalId?: string,
   ): Promise<{ resource: GroupResource; identifier: string } | null> {
-    const seen = new Set<string>();
-    const candidates: Array<{ system: string; value: string }> = [];
-
-    const ensureNamespace = (code: string) =>
-      code.startsWith(this.identifierNamespace) ? code : `${this.identifierNamespace}${code}`;
-
-    const tryAdd = (code: string, value: unknown) => {
-      if (typeof value !== "string" || value.length === 0) return;
-      const system = ensureNamespace(code);
-      const key = `${system}|${value}`;
-      if (seen.has(key)) return;
-      seen.add(key);
-      candidates.push({ system, value });
-    };
-
-    // Probe both casings — OpenSPP vocab is case-sensitive on validate.
-    const bothCasings = (code: string, value: unknown) => {
-      tryAdd(code.toUpperCase(), value);
-      tryAdd(code.toLowerCase(), value);
-    };
-    bothCasings("HOUSEHOLD_ID", data.household_id);
-    bothCasings("REG_ID", data.reg_id);
-    bothCasings("REGISTRATION_ID", data.registration_id);
-    // Same opaque-externalId logic as the individual sweep — probe each
-    // known group system with the stored externalId.
-    if (storedExternalId) {
-      for (const code of ["HOUSEHOLD_ID", "REG_ID", "REGISTRATION_ID"]) {
-        bothCasings(code, storedExternalId);
-      }
-      tryAdd(this.groupIdentifierType, storedExternalId);
+    // Restricted to the server-resolved externalId under the configured group
+    // identifier type — see tryDiscoverIndividual. Client identity fields,
+    // alternate casings and cross-namespace probing removed (H1/H2/H3).
+    if (typeof storedExternalId !== "string" || storedExternalId.length === 0) {
+      return null;
     }
-
-    for (const c of candidates) {
-      const id = this.getClient().formatIdentifier(c.system, c.value);
-      try {
-        const found = await this.getClient().getGroup(id);
-        if (found) return { resource: found, identifier: id };
-      } catch {
-        // ignore — try next
-      }
+    const system = this.groupIdentifierType.startsWith(this.identifierNamespace)
+      ? this.groupIdentifierType
+      : `${this.identifierNamespace}${this.groupIdentifierType}`;
+    const id = this.getClient().formatIdentifier(system, storedExternalId);
+    try {
+      const found = await this.getClient().getGroup(id);
+      if (found) return { resource: found, identifier: id };
+    } catch {
+      // ignore — discovery is best-effort
     }
     return null;
   }

--- a/packages/adapter-openspp/src/v2/OpenSppV2SyncAdapter.ts
+++ b/packages/adapter-openspp/src/v2/OpenSppV2SyncAdapter.ts
@@ -614,7 +614,10 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
   // ==================== Push Logic ====================
 
   private async pushEntities(
-    entities: Array<{ modified: { guid: string; type: EntityType; externalId?: string; data: Record<string, unknown> } }>,
+    entities: Array<{
+      initial?: { version: number } | null;
+      modified: { guid: string; type: EntityType; version: number; externalId?: string; data: Record<string, unknown> };
+    }>,
     entityType: "individual" | "group",
   ): Promise<{ pushed: number; failed: number; skipped: number; errors: Array<{ guid: string; error: string; code: string }> }> {
     const failedEntities: Array<{ guid: string; error: string; code: string }> = [];
@@ -626,6 +629,17 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
         const entity = entityPair.modified;
         const externalId = this.resolveExternalId(entity);
 
+        // An entity at baseline parity (no genuine local entity edit) that was
+        // force-included only because it carries pending enrolments must push
+        // ONLY the enrolment CRs — never re-PATCH the entity, which would
+        // overwrite OpenSPP fields with stale/pull-sourced data using a fresh
+        // If-Match. pendingProgramEnrolments is user-controllable (H4).
+        const pending = entity.data?.pendingProgramEnrolments;
+        const hasPending = Array.isArray(pending) && pending.length > 0;
+        const baselineParity =
+          !!entity.externalId && !!entityPair.initial && entityPair.initial.version === entity.version;
+        const enrolmentsOnly = baselineParity && hasPending;
+
         let attempt = 0;
         let lastError: Error | null = null;
         let success = false;
@@ -633,9 +647,9 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
         while (attempt <= this.maxRetries && !success) {
           try {
             if (entityType === "individual") {
-              await this.pushIndividual(entity.guid, entity.data, externalId);
+              await this.pushIndividual(entity.guid, entity.data, externalId, enrolmentsOnly);
             } else {
-              await this.pushGroup(entity.guid, entity.data, externalId);
+              await this.pushGroup(entity.guid, entity.data, externalId, enrolmentsOnly);
             }
             success = true;
           } catch (error) {
@@ -701,11 +715,14 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
     guid: string,
     data: Record<string, unknown>,
     externalId?: string,
+    enrolmentsOnly = false,
   ): Promise<void> {
-    if (this.submitVia === "change-request") {
-      await this.pushIndividualViaCR(guid, data, externalId);
-    } else {
-      await this.pushIndividualDirect(guid, data, externalId);
+    if (!enrolmentsOnly) {
+      if (this.submitVia === "change-request") {
+        await this.pushIndividualViaCR(guid, data, externalId);
+      } else {
+        await this.pushIndividualDirect(guid, data, externalId);
+      }
     }
     // Direct create writes the new externalId via `saveExternalIdToEntity`;
     // re-resolve from the store so the program-enrolment CR registrant
@@ -854,11 +871,14 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
     guid: string,
     data: Record<string, unknown>,
     externalId?: string,
+    enrolmentsOnly = false,
   ): Promise<void> {
-    if (this.submitVia === "change-request") {
-      await this.pushGroupViaCR(guid, data, externalId);
-    } else {
-      await this.pushGroupDirect(guid, data, externalId);
+    if (!enrolmentsOnly) {
+      if (this.submitVia === "change-request") {
+        await this.pushGroupViaCR(guid, data, externalId);
+      } else {
+        await this.pushGroupDirect(guid, data, externalId);
+      }
     }
     const refreshedId = await this.refreshExternalIdAfterPush(guid, externalId);
     await this.pushPendingProgramEnrolments(guid, "group", data, refreshedId);

--- a/packages/adapter-openspp/src/v2/OpenSppV2SyncAdapter.ts
+++ b/packages/adapter-openspp/src/v2/OpenSppV2SyncAdapter.ts
@@ -1643,13 +1643,16 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
 
   /**
    * Fallback identifier extraction for records created directly in OpenSPP
-   * that don't carry a DataCollect-issued identifier.
-   * Uses system|value composite so round-trips are stable.
+   * that don't carry a DataCollect-issued identifier. Restricted to the
+   * configured OpenSPP namespace: a record whose only identifiers live in other
+   * id-type namespaces is NOT adopted — importing it would pull unrelated
+   * beneficiary PII and make it a confused-deputy PATCH target on the next
+   * push (H12). Uses system|value composite so round-trips are stable.
    */
   private extractAnyIdentifier(resource: IndividualResource | GroupResource): string | undefined {
-    const first = resource.identifier?.[0];
-    if (!first) return undefined;
-    return `${first.system}|${first.value}`;
+    const matched = resource.identifier?.find((id) => this.isOpenSppIdentifier(id.system));
+    if (!matched) return undefined;
+    return `${matched.system}|${matched.value}`;
   }
 
   // ==================== Transform to Form Submissions ====================

--- a/packages/adapter-openspp/src/v2/OpenSppV2SyncAdapter.ts
+++ b/packages/adapter-openspp/src/v2/OpenSppV2SyncAdapter.ts
@@ -1424,7 +1424,11 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
    * Checks for an `identifierType` field in the form data, falling back to `national_id`.
    */
   private resolveIdentifierSystem(data: Record<string, unknown>, entityType: "individual" | "group" = "individual"): string {
-    const formCode = data.identifierType as string | undefined;
+    // identifierType is server-managed and must be a string. A non-string value
+    // (e.g. an object smuggled in entity data) would throw on `.startsWith`,
+    // failing every sync. Ignore anything that is not a usable string. (H22)
+    const formCode =
+      typeof data.identifierType === "string" && data.identifierType.length > 0 ? data.identifierType : undefined;
     const defaultCode = entityType === "group" ? this.groupIdentifierType : this.identifierType;
     const code = formCode || defaultCode;
     if (code.startsWith(this.identifierNamespace)) {
@@ -1663,7 +1667,8 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
     userId: string;
     syncLevel: SyncLevel;
   } {
-    const identifier = resolvedIdentifier ?? this.extractIdentifier(individual);
+    const matched = this.extractMatchingId(individual);
+    const identifier = resolvedIdentifier ?? matched?.value;
     const guid = existingGuid || identifier || uuidv4();
 
     const data: Record<string, unknown> = {
@@ -1710,6 +1715,15 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
 
     data.externalId = identifier;
 
+    // Preserve the OpenSPP identifier system so a later push targets the same
+    // id-type instead of defaulting to system_id and overwriting a different
+    // record (H10).
+    if (matched?.system) {
+      data.identifierType = matched.system.startsWith(this.identifierNamespace)
+        ? matched.system.slice(this.identifierNamespace.length)
+        : matched.system;
+    }
+
     return {
       guid: uuidv4(),
       entityGuid: guid,
@@ -1734,7 +1748,8 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
     userId: string;
     syncLevel: SyncLevel;
   } {
-    const identifier = resolvedIdentifier ?? this.extractGroupIdentifier(group);
+    const matched = this.extractMatchingId(group);
+    const identifier = resolvedIdentifier ?? matched?.value;
     const guid = existingGuid || identifier || uuidv4();
 
     const data: Record<string, unknown> = {
@@ -1751,6 +1766,14 @@ class OpenSppV2SyncAdapter implements ExternalSyncAdapter {
     }
 
     data.externalId = identifier;
+
+    // Preserve the OpenSPP identifier system so a later push targets the same
+    // id-type instead of defaulting and overwriting a different record (H10).
+    if (matched?.system) {
+      data.identifierType = matched.system.startsWith(this.identifierNamespace)
+        ? matched.system.slice(this.identifierNamespace.length)
+        : matched.system;
+    }
 
     return {
       guid: uuidv4(),

--- a/packages/backend/src/__tests__/eventSanitize.test.ts
+++ b/packages/backend/src/__tests__/eventSanitize.test.ts
@@ -1,0 +1,52 @@
+import { stripServerManagedEventFields } from "../utils/eventSanitize";
+import { FormSubmission } from "@idpass/data-collect-core";
+
+/**
+ * Clients must not assert server-managed identifier fields on pushed events.
+ * `externalId` / `identifierType` select which external (OpenSPP) record gets
+ * PATCHed and must originate only from a trusted external pull — never from a
+ * client push. These are pure unit tests (no DB). Findings: H11, H30, H10/H22.
+ */
+
+function event(data: Record<string, unknown>): FormSubmission {
+  return {
+    guid: "evt-1",
+    entityGuid: "ent-1",
+    type: "update-individual",
+    data,
+    timestamp: "2026-06-25T00:00:00.000Z",
+    userId: "user-1",
+    syncLevel: 1,
+  } as FormSubmission;
+}
+
+describe("stripServerManagedEventFields", () => {
+  it("removes a client-supplied externalId from event data", () => {
+    const out = stripServerManagedEventFields(event({ name: "Alice", externalId: "victim-opensspp-id" }));
+    expect(out.data.externalId).toBeUndefined();
+    expect(out.data.name).toBe("Alice");
+  });
+
+  it("removes a client-supplied identifierType from event data", () => {
+    const out = stripServerManagedEventFields(event({ name: "Bob", identifierType: "national_id" }));
+    expect(out.data.identifierType).toBeUndefined();
+    expect(out.data.name).toBe("Bob");
+  });
+
+  it("preserves legitimate beneficiary fields (national_id, household_id, dob)", () => {
+    const out = stripServerManagedEventFields(
+      event({ national_id: "PH-123", household_id: "HH-9", dateOfBirth: "1990-01-01", name: "Carol" }),
+    );
+    expect(out.data).toEqual({ national_id: "PH-123", household_id: "HH-9", dateOfBirth: "1990-01-01", name: "Carol" });
+  });
+
+  it("returns the event unchanged when no forbidden fields are present", () => {
+    const e = event({ name: "Dave" });
+    expect(stripServerManagedEventFields(e)).toBe(e);
+  });
+
+  it("tolerates events with empty data", () => {
+    const out = stripServerManagedEventFields(event({}));
+    expect(out.data).toEqual({});
+  });
+});

--- a/packages/backend/src/__tests__/phase1-backend-hardening.test.ts
+++ b/packages/backend/src/__tests__/phase1-backend-hardening.test.ts
@@ -132,7 +132,7 @@ describeIfPostgres("Phase 1b: Uniform error messages for brute-force protection"
     await otpStore.closeConnection();
   });
 
-  it("/id/verify should return uniform 'Verification failed' when tenant not found", async () => {
+  it("/id/verify should return uniform self-service-disabled error when tenant not found", async () => {
     mockAppInstanceStore.getAppInstance.mockResolvedValue(null);
 
     const response = await request(app).post("/api/auth/id/verify").send({
@@ -141,8 +141,9 @@ describeIfPostgres("Phase 1b: Uniform error messages for brute-force protection"
       tenantId: "nonexistent-tenant",
     });
 
-    expect(response.status).toBe(401);
-    expect(response.body.error).toBe("Verification failed");
+    // Self-service gate runs first; uniform 403 regardless of tenant existence.
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Self-service is not enabled for this tenant");
   });
 
   it("/id/verify should return uniform 'Verification failed' when identity not found", async () => {
@@ -152,7 +153,7 @@ describeIfPostgres("Phase 1b: Uniform error messages for brute-force protection"
 
     mockAppInstanceStore.getAppInstance.mockResolvedValue({
       configId: "tenant-1",
-      config: { id: "tenant-1", name: "Test" } as AppConfig,
+      config: { id: "tenant-1", name: "Test", selfService: { enabled: true } } as AppConfig,
       edm: mockEdm as never,
     });
 
@@ -200,7 +201,7 @@ describeIfPostgres("Phase 1b: Uniform error messages for brute-force protection"
     expect(identityResponse.body.error).not.toContain("Identity not found");
   });
 
-  it("/oidc/exchange should return uniform 'Authentication failed' when tenant not found", async () => {
+  it("/oidc/exchange should return uniform self-service-disabled error when tenant not found", async () => {
     mockAppInstanceStore.getAppInstance.mockResolvedValue(null);
 
     const response = await request(app).post("/api/auth/oidc/exchange").send({
@@ -209,8 +210,9 @@ describeIfPostgres("Phase 1b: Uniform error messages for brute-force protection"
       tenantId: "nonexistent-tenant",
     });
 
-    expect(response.status).toBe(401);
-    expect(response.body.error).toBe("Authentication failed");
+    // Self-service gate runs first; uniform 403 regardless of tenant existence.
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Self-service is not enabled for this tenant");
   });
 
   it("/oidc/exchange should NOT leak 'Tenant not found' message", async () => {
@@ -540,7 +542,7 @@ describeIfPostgres("Phase 1c: Dynamic availableForms from tenant config", () => 
     expect(response.body.availableForms[0].label).toBe("Update Profile");
   });
 
-  it("should fall back to generic form when no selfService config at all", async () => {
+  it("should reject access when no selfService config at all (feature off by default)", async () => {
     mockAppInstanceStore.getAppInstance.mockResolvedValue({
       configId: "tenant-no-ss",
       config: {
@@ -562,10 +564,9 @@ describeIfPostgres("Phase 1c: Dynamic availableForms from tenant config", () => 
 
     const response = await request(app).get("/api/auth/self-service/entity").set("Authorization", `Bearer ${token}`);
 
-    expect(response.status).toBe(200);
-    expect(response.body.availableForms).toHaveLength(1);
-    expect(response.body.availableForms[0].type).toBe("update-individual");
-    expect(response.body.availableForms[0].label).toBe("Update Profile");
+    // No selfService config means the feature is disabled (C2 gate).
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Self-service is not enabled for this tenant");
   });
 
   it("should match forms by id when name does not match", async () => {

--- a/packages/backend/src/__tests__/security-phase1-fixes.test.ts
+++ b/packages/backend/src/__tests__/security-phase1-fixes.test.ts
@@ -78,11 +78,17 @@ describeIfPostgres("L15: Per-identifier OTP rate limiting", () => {
       createAppInstance: jest.fn(),
       updateAppInstance: jest.fn(),
       loadEntityData: jest.fn(),
-      getAppInstance: jest.fn().mockResolvedValue(null),
+      // Self-service is gated behind selfService.enabled (default off); this
+      // suite exercises the enabled feature, so the instance opts in.
+      getAppInstance: jest.fn().mockResolvedValue({
+        configId: "rate-tenant",
+        config: { selfService: { enabled: true } },
+        edm: { searchEntities: jest.fn().mockResolvedValue([]) },
+      }),
       clearAppInstance: jest.fn(),
       clearStore: jest.fn(),
       closeConnection: jest.fn(),
-    } as jest.Mocked<AppInstanceStore>;
+    } as unknown as jest.Mocked<AppInstanceStore>;
 
     app = express();
     app.use(bodyParser.json());

--- a/packages/backend/src/__tests__/selfServiceEndpoints.test.ts
+++ b/packages/backend/src/__tests__/selfServiceEndpoints.test.ts
@@ -295,7 +295,7 @@ describeIfPostgres("POST /api/auth/oidc/exchange", () => {
     expect(response.body.error).toBe("Invalid request");
   });
 
-  it("should return uniform 'Authentication failed' when tenant is not found", async () => {
+  it("should return uniform self-service-disabled error when tenant is not found", async () => {
     mockAppInstanceStore.getAppInstance.mockResolvedValue(null);
 
     const response = await request(app).post("/api/auth/oidc/exchange").send({
@@ -304,9 +304,10 @@ describeIfPostgres("POST /api/auth/oidc/exchange", () => {
       tenantId: "nonexistent-tenant",
     });
 
-    expect(response.status).toBe(401);
-    expect(response.body.error).toBe("Authentication failed");
-    // Should NOT leak tenant-specific information
+    // The self-service gate runs first and returns a uniform 403 regardless of
+    // whether the tenant exists, so it does not leak tenant-specific info.
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Self-service is not enabled for this tenant");
     expect(response.body.error).not.toContain("Tenant not found");
   });
 
@@ -561,8 +562,8 @@ describe("GET /api/auth/self-service/entity (without PostgreSQL)", () => {
 
     const response = await request(app).get("/api/auth/self-service/entity").set("Authorization", `Bearer ${token}`);
 
-    expect(response.status).toBe(404);
-    expect(response.body.error).toBe("Tenant not found");
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Self-service is not enabled for this tenant");
   });
 
   it("should return 404 when entity is not found", async () => {
@@ -707,8 +708,8 @@ describe("POST /api/auth/self-service/submit (without PostgreSQL)", () => {
       .set("Authorization", `Bearer ${token}`)
       .send({ formType: "update-individual", formData: { name: "Updated" } });
 
-    expect(response.status).toBe(404);
-    expect(response.body.error).toBe("Tenant not found");
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Self-service is not enabled for this tenant");
   });
 });
 
@@ -990,8 +991,8 @@ describe("GET /api/auth/self-service/submissions (without PostgreSQL)", () => {
       .get("/api/auth/self-service/submissions")
       .set("Authorization", `Bearer ${token}`);
 
-    expect(response.status).toBe(404);
-    expect(response.body.error).toBe("Tenant not found");
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Self-service is not enabled for this tenant");
   });
 });
 

--- a/packages/backend/src/__tests__/selfServiceFeatureFlag.test.ts
+++ b/packages/backend/src/__tests__/selfServiceFeatureFlag.test.ts
@@ -1,0 +1,128 @@
+import "dotenv/config";
+
+import request from "supertest";
+import express from "express";
+import bodyParser from "body-parser";
+import jwt from "jsonwebtoken";
+import { createSelfServiceRouter } from "../routes/selfServiceRoutes";
+import { AppInstanceStore } from "../types";
+
+/**
+ * Self-service is gated behind a per-tenant feature flag (selfService.enabled)
+ * that defaults to OFF. The feature is under rework and must stay hidden for
+ * every config that has not explicitly opted in. These tests verify the gate
+ * is enforced server-side — independent of PostgreSQL — so they stub both the
+ * OtpStore and AppInstanceStore injected dependencies. Security finding: C2.
+ */
+
+const JWT_SECRET = "test-secret-feature-flag";
+
+function makeAppInstanceStore(getAppInstance: jest.Mock): AppInstanceStore {
+  return {
+    initialize: jest.fn(),
+    createAppInstance: jest.fn(),
+    updateAppInstance: jest.fn(),
+    loadEntityData: jest.fn(),
+    getAppInstance,
+    clearAppInstance: jest.fn(),
+    clearStore: jest.fn(),
+    closeConnection: jest.fn(),
+  } as unknown as AppInstanceStore;
+}
+
+function makeOtpStore() {
+  return {
+    getActiveCodesByIdentifier: jest.fn().mockResolvedValue([]),
+    createOtp: jest.fn().mockResolvedValue({ id: "otp-1", code: "123456" }),
+    verifyOtp: jest.fn().mockResolvedValue({ entityGuid: "entity-1" }),
+  } as never;
+}
+
+function buildApp(getAppInstance: jest.Mock) {
+  const app = express();
+  app.use(bodyParser.json());
+  app.use("/api/auth", createSelfServiceRouter(makeOtpStore(), makeAppInstanceStore(getAppInstance)));
+  return app;
+}
+
+function selfServiceToken(tenantId: string, entityGuid: string) {
+  return jwt.sign({ scope: "self-service", identifier: entityGuid, entityGuid, tenantId }, JWT_SECRET, {
+    expiresIn: "1h",
+  });
+}
+
+describe("Self-service feature flag (default OFF)", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = JWT_SECRET;
+  });
+
+  describe("token issuance is blocked when self-service is not enabled", () => {
+    it("returns 403 from /otp/request when selfService.enabled is false", async () => {
+      const app = buildApp(jest.fn().mockResolvedValue({ configId: "t1", config: { selfService: { enabled: false } } }));
+
+      const res = await request(app).post("/api/auth/otp/request").send({ identifier: "+15551234567", tenantId: "t1" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatch(/not enabled/i);
+    });
+
+    it("returns 403 from /id/verify when selfService config is absent", async () => {
+      const app = buildApp(jest.fn().mockResolvedValue({ configId: "t1", config: {} }));
+
+      const res = await request(app)
+        .post("/api/auth/id/verify")
+        .send({ nationalId: "NID-1", dateOfBirth: "1990-01-01", tenantId: "t1" });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 from /otp/verify when the tenant instance is missing", async () => {
+      const app = buildApp(jest.fn().mockResolvedValue(null));
+
+      const res = await request(app)
+        .post("/api/auth/otp/verify")
+        .send({ identifier: "+15551234567", otp: "123456", tenantId: "t1" });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 from /oidc/exchange when selfService.enabled is false", async () => {
+      const app = buildApp(jest.fn().mockResolvedValue({ configId: "t1", config: { selfService: { enabled: false } } }));
+
+      const res = await request(app)
+        .post("/api/auth/oidc/exchange")
+        .send({ idToken: "a.b.c", accessToken: "x", tenantId: "t1" });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("authenticated self-service routes are blocked when not enabled", () => {
+    it("returns 403 from GET /self-service/entity even with a valid self-service token", async () => {
+      const app = buildApp(jest.fn().mockResolvedValue({ configId: "t1", config: { selfService: { enabled: false } } }));
+
+      const res = await request(app)
+        .get("/api/auth/self-service/entity")
+        .set("Authorization", `Bearer ${selfServiceToken("t1", "entity-1")}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("issuance proceeds when self-service is explicitly enabled", () => {
+    it("does not 403 /otp/request when selfService.enabled is true", async () => {
+      const app = buildApp(
+        jest.fn().mockResolvedValue({
+          configId: "t1",
+          config: { selfService: { enabled: true } },
+          edm: { searchEntities: jest.fn().mockResolvedValue([]) },
+        }),
+      );
+
+      const res = await request(app).post("/api/auth/otp/request").send({ identifier: "+15551234567", tenantId: "t1" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+});

--- a/packages/backend/src/__tests__/selfServiceRoutes.test.ts
+++ b/packages/backend/src/__tests__/selfServiceRoutes.test.ts
@@ -39,11 +39,17 @@ describeIfPostgres("Self-Service Routes", () => {
       createAppInstance: jest.fn(),
       updateAppInstance: jest.fn(),
       loadEntityData: jest.fn(),
-      getAppInstance: jest.fn().mockResolvedValue(null),
+      // Self-service is gated behind selfService.enabled (default OFF). These
+      // suites exercise the enabled feature, so the default instance opts in.
+      getAppInstance: jest.fn().mockResolvedValue({
+        configId: "tenant-1",
+        config: { selfService: { enabled: true } },
+        edm: { searchEntities: jest.fn().mockResolvedValue([]) },
+      }),
       clearAppInstance: jest.fn(),
       clearStore: jest.fn(),
       closeConnection: jest.fn(),
-    } as jest.Mocked<AppInstanceStore>;
+    } as unknown as jest.Mocked<AppInstanceStore>;
 
     app = express();
     app.use(bodyParser.json());
@@ -259,8 +265,9 @@ describeIfPostgres("Self-Service Routes", () => {
 
       mockAppInstanceStore.getAppInstance.mockResolvedValue({
         configId: "tenant-1",
+        config: { selfService: { enabled: true } },
         edm: mockEdm as never,
-      });
+      } as never);
 
       const response = await request(app)
         .post("/api/auth/id/verify")
@@ -287,8 +294,9 @@ describeIfPostgres("Self-Service Routes", () => {
 
       mockAppInstanceStore.getAppInstance.mockResolvedValue({
         configId: "tenant-1",
+        config: { selfService: { enabled: true } },
         edm: mockEdm as never,
-      });
+      } as never);
 
       const response = await request(app)
         .post("/api/auth/id/verify")
@@ -309,7 +317,7 @@ describeIfPostgres("Self-Service Routes", () => {
       expect(response.status).toBe(400);
     });
 
-    it("should return 401 with uniform error when tenant is not found", async () => {
+    it("should return 403 when the tenant is not found (self-service gate)", async () => {
       mockAppInstanceStore.getAppInstance.mockResolvedValue(null);
 
       const response = await request(app)
@@ -320,8 +328,8 @@ describeIfPostgres("Self-Service Routes", () => {
           tenantId: "nonexistent-tenant",
         });
 
-      expect(response.status).toBe(401);
-      expect(response.body.error).toBe("Verification failed");
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe("Self-service is not enabled for this tenant");
     });
   });
 

--- a/packages/backend/src/__tests__/syncPushTransaction.test.ts
+++ b/packages/backend/src/__tests__/syncPushTransaction.test.ts
@@ -165,6 +165,46 @@ describeIfPostgres("Transactional Sync Push", () => {
     expect(names).toEqual(["Alice", "Bob", "Charlie"]);
   });
 
+  it("strips client-supplied externalId/identifierType from pushed events (H11/H30)", async () => {
+    const currentApp = requireApp();
+    const entityGuid = uuidv4();
+
+    const events: FormSubmission[] = [
+      {
+        guid: uuidv4(),
+        entityGuid,
+        type: "create-individual",
+        data: {
+          name: "Mallory",
+          // Attacker attempts to bind this entity to a victim's external record.
+          externalId: "victim-openspp-id",
+          identifierType: "national_id",
+        },
+        timestamp: "2024-01-01T00:00:01.000Z",
+        userId: "user-1",
+        syncLevel: SyncLevel.LOCAL,
+      },
+    ];
+
+    const response = await request(currentApp.httpServer)
+      .post("/api/sync/push")
+      .send({ events, configId: mockConfig.id })
+      .set("Authorization", `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ status: "success", applied: 1 });
+
+    const manager = (await currentApp.appInstanceStore.getAppInstance(mockConfig.id))?.edm;
+    const entity = await manager?.getEntity(entityGuid);
+
+    // The forbidden fields must not reach the entity by any path.
+    expect(entity?.modified.externalId).toBeUndefined();
+    expect(entity?.modified.data.externalId).toBeUndefined();
+    expect(entity?.modified.data.identifierType).toBeUndefined();
+    // Legitimate data is preserved.
+    expect(entity?.modified.data.name).toBe("Mallory");
+  });
+
   it("should rollback all events when one fails", async () => {
     const currentApp = requireApp();
     const entityGuid1 = uuidv4();

--- a/packages/backend/src/routes/selfServiceRoutes.ts
+++ b/packages/backend/src/routes/selfServiceRoutes.ts
@@ -27,7 +27,7 @@ import { asyncHandler } from "../middlewares/errorHandlers";
 import { extractBearerToken } from "../middlewares/authentication";
 import { OtpStore } from "../stores/OtpStore";
 import { ReviewStore } from "../stores/ReviewStore";
-import { AppInstanceStore } from "../types";
+import { AppInstance, AppInstanceStore } from "../types";
 import { getReviewService } from "./reviewRoutes";
 import { createLogger } from "../utils/logger";
 
@@ -133,6 +133,24 @@ export function createSelfServiceRouter(
   const router = Router();
 
   /**
+   * Self-service is gated behind a per-tenant feature flag that defaults to OFF.
+   * Token issuance and every self-service data route are unavailable unless the
+   * tenant config explicitly sets `selfService.enabled === true`. The feature is
+   * under rework and must stay hidden/disabled for any config that has not opted
+   * in — this is the server-side enforcement that `selfService.enabled` lacked.
+   * Returns the resolved AppInstance on success, or null after writing a 403.
+   * Security finding: C2 (self-service auth ignored tenant settings).
+   */
+  async function requireSelfServiceEnabled(tenantId: string, res: Response): Promise<AppInstance | null> {
+    const appInstance = await appInstanceStore.getAppInstance(tenantId);
+    if (!appInstance || appInstance.config?.selfService?.enabled !== true) {
+      res.status(403).json({ error: "Self-service is not enabled for this tenant" });
+      return null;
+    }
+    return appInstance;
+  }
+
+  /**
    * POST /otp/request
    * Request a one-time password to be sent to the given identifier.
    * In production, this would integrate with an SMS/email gateway.
@@ -152,6 +170,9 @@ export function createSelfServiceRouter(
 
       const { identifier, tenantId } = parseResult.data;
 
+      const appInstance = await requireSelfServiceEnabled(tenantId, res);
+      if (!appInstance) return;
+
       // Per-identifier rate limit: reject if >= 5 codes requested for
       // this identifier+tenant in the last 15 minutes.
       const recentCodes = await otpStore.getActiveCodesByIdentifier(identifier, tenantId);
@@ -166,16 +187,13 @@ export function createSelfServiceRouter(
       // This allows the self-service token to include entityGuid for data access.
       // SearchCriteria items are AND'd, so search phone and email separately.
       let entityGuid: string | undefined;
-      const appInstance = await appInstanceStore.getAppInstance(tenantId);
-      if (appInstance) {
-        const edm = appInstance.edm;
-        let searchResults = await edm.searchEntities([{ phone: identifier }]);
-        if (searchResults.length === 0) {
-          searchResults = await edm.searchEntities([{ email: identifier }]);
-        }
-        if (searchResults.length > 0) {
-          entityGuid = searchResults[0].modified.guid;
-        }
+      const edm = appInstance.edm;
+      let searchResults = await edm.searchEntities([{ phone: identifier }]);
+      if (searchResults.length === 0) {
+        searchResults = await edm.searchEntities([{ email: identifier }]);
+      }
+      if (searchResults.length > 0) {
+        entityGuid = searchResults[0].modified.guid;
       }
 
       const otpCode = await otpStore.createOtp(identifier, tenantId, entityGuid);
@@ -213,6 +231,8 @@ export function createSelfServiceRouter(
       }
 
       const { identifier, otp, tenantId } = parseResult.data;
+
+      if (!(await requireSelfServiceEnabled(tenantId, res))) return;
 
       // Verify the OTP using constant-time hash comparison in the store.
       // The store atomically locks the row, verifies the hash, increments
@@ -263,11 +283,8 @@ export function createSelfServiceRouter(
 
       const { nationalId, dateOfBirth, tenantId } = parseResult.data;
 
-      // Look up the entity with matching national ID and date of birth
-      const appInstance = await appInstanceStore.getAppInstance(tenantId);
-      if (!appInstance) {
-        return res.status(401).json({ error: "Verification failed" });
-      }
+      const appInstance = await requireSelfServiceEnabled(tenantId, res);
+      if (!appInstance) return;
 
       const edm = appInstance.edm;
 
@@ -354,11 +371,9 @@ export function createSelfServiceRouter(
 
       const { idToken, tenantId, nonce } = parseResult.data;
 
-      // Load tenant config
-      const appInstance = await appInstanceStore.getAppInstance(tenantId);
-      if (!appInstance) {
-        return res.status(401).json({ error: "Authentication failed" });
-      }
+      // Load tenant config (also enforces the self-service feature flag)
+      const appInstance = await requireSelfServiceEnabled(tenantId, res);
+      if (!appInstance) return;
 
       // Validate that OIDC is configured for this tenant
       const oidcConfig = appInstance.config.selfService?.oidcConfig;
@@ -469,10 +484,8 @@ export function createSelfServiceRouter(
         return res.status(400).json({ error: "No entity associated with this token" });
       }
 
-      const appInstance = await appInstanceStore.getAppInstance(tenantId);
-      if (!appInstance) {
-        return res.status(404).json({ error: "Tenant not found" });
-      }
+      const appInstance = await requireSelfServiceEnabled(tenantId, res);
+      if (!appInstance) return;
 
       let entityPair;
       try {
@@ -540,10 +553,8 @@ export function createSelfServiceRouter(
         return res.status(400).json({ error: "No entity associated with this token" });
       }
 
-      const appInstance = await appInstanceStore.getAppInstance(tenantId);
-      if (!appInstance) {
-        return res.status(404).json({ error: "Tenant not found" });
-      }
+      const appInstance = await requireSelfServiceEnabled(tenantId, res);
+      if (!appInstance) return;
 
       // Validate formType against tenant's allowed forms
       const selfServiceConfig = appInstance.config.selfService;
@@ -639,10 +650,8 @@ export function createSelfServiceRouter(
         return res.status(400).json({ error: "No entity associated with this token" });
       }
 
-      const appInstance = await appInstanceStore.getAppInstance(tenantId);
-      if (!appInstance) {
-        return res.status(404).json({ error: "Tenant not found" });
-      }
+      const appInstance = await requireSelfServiceEnabled(tenantId, res);
+      if (!appInstance) return;
 
       // Build submission history from both applied events and pending reviews
       const submissions: Array<{

--- a/packages/backend/src/routes/syncRoute.ts
+++ b/packages/backend/src/routes/syncRoute.ts
@@ -35,6 +35,7 @@ import { createScopeContextMiddleware, type ScopeAwareRequest } from "../middlew
 import { AppInstanceStore, Role } from "../types";
 import { createLogger } from "../utils/logger";
 import { processTransactionalBatch } from "../utils/transactionalEdm";
+import { stripServerManagedEventFields } from "../utils/eventSanitize";
 import { SyncEventStore } from "../stores/SyncEventStore";
 import { SyncJobRegistry } from "../stores/SyncJobRegistry";
 import { SyncTelemetryStore } from "../stores/SyncTelemetryStore";
@@ -411,7 +412,13 @@ export function createSyncRouter(
       const sorted = events
         .slice()
         .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-      const allEvents: FormSubmission[] = sorted.map((event) => ({ ...event, syncLevel: 1 }));
+      // Strip client-asserted server-managed identifier fields (externalId,
+      // identifierType) before applying. These select the external record a
+      // later push PATCHes and must come only from a trusted external pull —
+      // never from a client. Findings: H11, H30, H10/H22.
+      const allEvents: FormSubmission[] = sorted.map((event) =>
+        stripServerManagedEventFields({ ...event, syncLevel: 1 }),
+      );
 
       // ---------------------------------------------------------------
       // Per-event scope validation (Phase 3 — WP #947)

--- a/packages/backend/src/utils/eventSanitize.ts
+++ b/packages/backend/src/utils/eventSanitize.ts
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { FormSubmission } from "@idpass/data-collect-core";
+
+/**
+ * Identifier fields that select which external (OpenSPP) record a sync push
+ * targets. They are server-managed: a value must originate from a trusted
+ * external pull, never from a client-pushed event. Stripping them at the
+ * `/api/sync/push` trust boundary prevents a confused-deputy write where a
+ * client names a victim's external identifier and the adapter PATCHes it with
+ * the server's privileged credentials.
+ *
+ * Security findings: H11 (externalId retarget), H30 (V1 update externalId),
+ * H10/H22 (externalId/identifierType half).
+ */
+const CLIENT_FORBIDDEN_EVENT_DATA_FIELDS: readonly string[] = ["externalId", "identifierType"];
+
+/**
+ * Returns a copy of the event with server-managed identifier fields removed
+ * from its `data`. The event is returned unchanged (same reference) when no
+ * forbidden field is present, so callers pay nothing on the common path.
+ */
+export function stripServerManagedEventFields(event: FormSubmission): FormSubmission {
+  const data = event.data as Record<string, unknown> | undefined;
+  if (!data || typeof data !== "object") {
+    return event;
+  }
+  const present = CLIENT_FORBIDDEN_EVENT_DATA_FIELDS.some((field) =>
+    Object.prototype.hasOwnProperty.call(data, field),
+  );
+  if (!present) {
+    return event;
+  }
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (CLIENT_FORBIDDEN_EVENT_DATA_FIELDS.includes(key)) {
+      continue;
+    }
+    cleaned[key] = value;
+  }
+  return { ...event, data: cleaned };
+}

--- a/packages/datacollect/package.json
+++ b/packages/datacollect/package.json
@@ -50,6 +50,7 @@
     "crypto-js": "^4.2.0",
     "dotenv": "^16.6.1",
     "drizzle-orm": "^0.45.1",
+    "jose": "^6.1.3",
     "lodash": "^4.17.23",
     "oidc-client-ts": "^3.4.1",
     "pg": "^8.18.0",

--- a/packages/datacollect/src/components/authentication/Auth0AuthAdapter.ts
+++ b/packages/datacollect/src/components/authentication/Auth0AuthAdapter.ts
@@ -19,10 +19,7 @@
 
 import { AuthAdapter, AuthConfig, OIDCConfig, SingleAuthStorage } from "../../interfaces/types";
 import OIDCClient from "./OIDCClient";
-import axios from "axios";
-import { createLogger } from "../../utils/logger";
-
-const log = createLogger("Auth0AuthAdapter");
+import { verifyOidcAccessToken } from "./verifyOidcAccessToken";
 
 export class Auth0AuthAdapter implements AuthAdapter {
   private oidc: OIDCClient;
@@ -82,16 +79,16 @@ export class Auth0AuthAdapter implements AuthAdapter {
   }
 
   private async validateTokenServer(token: string): Promise<boolean> {
-   
-    try {
-     
-      // Use userinfo validation since crypto module is not available in browsers
-      log.debug("Using userinfo validation for Auth0 token");
-      return this.checkTokenActive(token);
-    } catch (error) {
-      log.error({ err: error }, "Auth0 token validation error");
-      return false;
-    }
+    // Verify the JWT signature + issuer via JWKS and bind it to this tenant's
+    // configured client/audience. A userinfo 200 alone is NOT sufficient — it
+    // accepts any live token from the same Auth0 tenant regardless of which
+    // client it was issued for (finding H33). `audience` overrides `organization`
+    // as the expected API audience when configured.
+    return verifyOidcAccessToken(token, {
+      authority: this.config.fields.authority,
+      clientId: this.config.fields.client_id,
+      audience: this.config.fields.audience,
+    });
   }
 
   private async validateTokenClient(token: string): Promise<boolean> {
@@ -103,38 +100,6 @@ export class Auth0AuthAdapter implements AuthAdapter {
     const user = await this.oidc.handleCallback();
     if (user && this.authStorage) {
       await this.authStorage.setToken(user.access_token);
-    }
-  }
-
-  private async checkTokenActive(token: string): Promise<boolean> {
-    try {
-      
-      // Call Auth0's userinfo endpoint to verify token is still active
-      const userinfoUrl = `${this.config.fields.authority}/userinfo`;
-      const response = await axios.get(userinfoUrl, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
-        timeout: 5000 // 5 second timeout
-      });
-      
-      // If we get a successful response with user data, the token is active
-      const isActive = !!(response.status === 200 && response.data && response.data.sub);
-      if(this.config.fields.organization){
-        if(isActive && response.data.org_id === this.config.fields.organization){ 
-          return true;
-        }
-      }
-      else if(isActive){
-        return true;
-      }
-     
-      return false;
-    } catch (error) {
-      log.error({ err: error }, "Error checking token activity");
-      // If userinfo call fails, token might be revoked or invalid
-      return false;
     }
   }
 

--- a/packages/datacollect/src/components/authentication/KeycloakAuthAdapter.ts
+++ b/packages/datacollect/src/components/authentication/KeycloakAuthAdapter.ts
@@ -19,10 +19,7 @@
 
 import { AuthAdapter, AuthConfig, AuthResult, OIDCConfig, SingleAuthStorage } from "../../interfaces/types";
 import OIDCClient from "./OIDCClient";
-import axios from "axios";
-import { createLogger } from "../../utils/logger";
-
-const log = createLogger("KeycloakAuthAdapter");
+import { verifyOidcAccessToken } from "./verifyOidcAccessToken";
 
 export class KeycloakAuthAdapter implements AuthAdapter {
   private oidc: OIDCClient;
@@ -80,14 +77,14 @@ export class KeycloakAuthAdapter implements AuthAdapter {
   }
 
   private async validateTokenServer(token: string): Promise<boolean> {
-    try {
-      // Use userinfo validation since JWKS requires Node.js crypto
-      log.debug("Using userinfo validation for Keycloak token");
-      return this.checkTokenActive(token);
-    } catch (error) {
-      log.error({ err: error }, "Keycloak token validation error");
-      return false;
-    }
+    // Verify the JWT signature + issuer via JWKS and bind it to this tenant's
+    // configured client/audience. A userinfo 200 alone accepts any live token
+    // from the same Keycloak realm regardless of client (finding H33).
+    return verifyOidcAccessToken(token, {
+      authority: this.config.fields.authority,
+      clientId: this.config.fields.client_id,
+      audience: this.config.fields.audience,
+    });
   }
 
   private async validateTokenClient(token: string): Promise<boolean> {
@@ -106,29 +103,6 @@ export class KeycloakAuthAdapter implements AuthAdapter {
 
   async getStoredAuth(): Promise<AuthResult | null> {
     return this.oidc.getStoredAuth();
-  }
-
-  private async checkTokenActive(token: string): Promise<boolean> {
-    try {
-      // Call Keycloak's userinfo endpoint to verify token is still active
-      const userinfoUrl = `${this.config.fields.authority}/protocol/openid-connect/userinfo`;
-      const response = await axios.get(userinfoUrl, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
-        timeout: 5000 // 5 second timeout
-      });
-
-      // If we get a successful response with user data, the token is active
-      const isActive = !!(response.status === 200 && response.data && response.data.sub);
-      
-      return isActive;
-    } catch (error) {
-      log.error({ err: error }, "Error checking Keycloak token activity");
-      // If userinfo call fails, token might be revoked or invalid
-      return false;
-    }
   }
 
   protected transformConfig(config: AuthConfig): AuthConfig {

--- a/packages/datacollect/src/components/authentication/__tests__/Auth0AuthAdapter.test.ts
+++ b/packages/datacollect/src/components/authentication/__tests__/Auth0AuthAdapter.test.ts
@@ -6,10 +6,12 @@ import { Auth0AuthAdapter } from "../Auth0AuthAdapter";
 import OIDCClient from "../OIDCClient";
 import axios from "axios";
 import { AuthConfig, SingleAuthStorage, OIDCConfig } from "../../../interfaces/types";
+import { verifyOidcAccessToken } from "../verifyOidcAccessToken";
 
 // Mock dependencies
 jest.mock("../OIDCClient");
 jest.mock("axios");
+jest.mock("../verifyOidcAccessToken", () => ({ verifyOidcAccessToken: jest.fn() }));
 jest.mock("../../../utils/logger", () => ({
   createLogger: () => ({
     info: jest.fn(),
@@ -24,6 +26,7 @@ jest.mock("../../../utils/logger", () => ({
 
 const MockedOIDCClient = OIDCClient as jest.MockedClass<typeof OIDCClient>;
 const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockVerify = verifyOidcAccessToken as jest.Mock;
 
 describe("Auth0AuthAdapter", () => {
   let adapter: Auth0AuthAdapter;
@@ -312,101 +315,31 @@ describe("Auth0AuthAdapter", () => {
       expect(mockedAxios.get).not.toHaveBeenCalled();
     });
 
-    it("should return false for invalid token on server", async () => {
-      // Ensure backend environment - window is undefined
+    it("delegates server-side validation to verifyOidcAccessToken with the tenant client binding", async () => {
       (global as unknown as Record<string, unknown>).window = undefined;
 
       const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "invalid-token";
+      mockVerify.mockResolvedValue(true);
 
-      mockedAxios.get.mockRejectedValue(new Error("Unauthorized"));
+      const result = await backendAdapter.validateToken("server-token");
 
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(false);
+      expect(result).toBe(true);
+      expect(mockVerify).toHaveBeenCalledWith("server-token", {
+        authority: authConfig.fields.authority,
+        clientId: authConfig.fields.client_id,
+        audience: authConfig.fields.audience,
+      });
+      // userinfo is no longer used for validation
+      expect(mockedAxios.get).not.toHaveBeenCalled();
     });
 
-    it("should return false when userinfo response has no sub", async () => {
-      // Ensure backend environment - window is undefined
+    it("returns false when verifyOidcAccessToken rejects the token (H33)", async () => {
       (global as unknown as Record<string, unknown>).window = undefined;
 
       const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      const mockResponse = {
-        status: 200,
-        data: { 
-          name: "Test User",
-          org_id: "test-org-123"
-        }, // Missing 'sub' field
-      };
+      mockVerify.mockResolvedValue(false);
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
-
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return false when userinfo response status is not 200", async () => {
-      // Ensure backend environment - window is undefined
-      (global as unknown as Record<string, unknown>).window = undefined;
-
-      const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      const mockResponse = {
-        status: 401,
-        data: { error: "Unauthorized" },
-      };
-
-      mockedAxios.get.mockResolvedValue(mockResponse);
-
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return false when organization does not match", async () => {
-      // Ensure backend environment - window is undefined
-      (global as unknown as Record<string, unknown>).window = undefined;
-
-      const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      const mockResponse = {
-        status: 200,
-        data: { 
-          sub: "user123", 
-          name: "Test User",
-          org_id: "different-org-456" // Different organization
-        },
-      };
-
-      mockedAxios.get.mockResolvedValue(mockResponse);
-
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return false when organization is missing from response", async () => {
-      // Ensure backend environment - window is undefined
-      (global as unknown as Record<string, unknown>).window = undefined;
-
-      const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      const mockResponse = {
-        status: 200,
-        data: { 
-          sub: "user123", 
-          name: "Test User"
-          // Missing org_id
-        },
-      };
-
-      mockedAxios.get.mockResolvedValue(mockResponse);
-
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(false);
+      expect(await backendAdapter.validateToken("foreign-token")).toBe(false);
     });
 
     it("should return false for mismatched token on client", async () => {
@@ -429,31 +362,15 @@ describe("Auth0AuthAdapter", () => {
     it("should call validateTokenServer when appType is backend", async () => {
       // Ensure backend environment - window is undefined
       (global as unknown as Record<string, unknown>).window = undefined;
-      
+
       const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      
-      // Mock successful server response
-      const mockResponse = {
-        status: 200,
-        data: { 
-          sub: "user123", 
-          name: "Test User",
-          org_id: "test-org-123"
-        },
-      };
-      mockedAxios.get.mockResolvedValue(mockResponse);
-      
-      // Spy on the private method by checking what gets called
-      const result = await backendAdapter.validateToken(token);
-      
+      mockVerify.mockResolvedValue(true);
+
+      const result = await backendAdapter.validateToken("test-token");
+
       expect(result).toBe(true);
-      // Verify server-side validation was used (axios called)
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        `${authConfig.fields.authority}/userinfo`,
-        expect.any(Object)
-      );
-      // Verify client-side validation was NOT used
+      // Server-side path uses the JWKS verifier, not the OIDC client.
+      expect(mockVerify).toHaveBeenCalled();
       expect(mockOIDCClient.getStoredAuth).not.toHaveBeenCalled();
     });
 
@@ -594,51 +511,26 @@ describe("Auth0AuthAdapter", () => {
   });
 
   describe("error handling", () => {
-    it("should handle axios timeout in token validation", async () => {
+    it("returns false when the verifier rejects (e.g. provider unreachable)", async () => {
      (global as unknown as Record<string, unknown>).window = undefined;
 
       const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
+      mockVerify.mockResolvedValue(false);
 
-      const token = "test-token";
-      const timeoutError = new Error("timeout of 5000ms exceeded");
-
-      mockedAxios.get.mockRejectedValue(timeoutError);
-
-      const result = await backendAdapter.validateToken(token);
+      const result = await backendAdapter.validateToken("test-token");
 
       expect(result).toBe(false);
     });
 
-    it("should handle network errors in token validation", async () => {
-      const token = "test-token";
-      const networkError = new Error("Network Error");
-
-      mockedAxios.get.mockRejectedValue(networkError);
-
-      const result = await adapter.validateToken(token);
-
-      expect(result).toBe(false);
-    });
-
-    it("should log token validation success", async () => {
+    it("returns the verifier result for a valid server-side token", async () => {
      (global as unknown as Record<string, unknown>).window = undefined;
 
       const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      const mockResponse = {
-        status: 200,
-        data: { 
-          sub: "user123", 
-          name: "Test User",
-          org_id: "test-org-123"
-        },
-      };
+      mockVerify.mockResolvedValue(true);
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
-      const result = await backendAdapter.validateToken(token);
+      const result = await backendAdapter.validateToken("test-token");
 
       expect(result).toBe(true);
-
     });
   });
 
@@ -648,24 +540,13 @@ describe("Auth0AuthAdapter", () => {
       (global as unknown as Record<string, unknown>).window = undefined;
 
       const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      
-      // Mock successful server response
-      const mockResponse = {
-        status: 200,
-        data: { 
-          sub: "user123", 
-          name: "Test User",
-          org_id: "test-org-123"
-        },
-      };
-      mockedAxios.get.mockResolvedValue(mockResponse);
-      
-      const result = await backendAdapter.validateToken(token);
-      
+      mockVerify.mockResolvedValue(true);
+
+      const result = await backendAdapter.validateToken("test-token");
+
       expect(result).toBe(true);
       // Verify server-side validation was used (proves appType is 'backend')
-      expect(mockedAxios.get).toHaveBeenCalled();
+      expect(mockVerify).toHaveBeenCalled();
       expect(mockOIDCClient.getStoredAuth).not.toHaveBeenCalled();
     });
 
@@ -698,24 +579,13 @@ describe("Auth0AuthAdapter", () => {
       (global as unknown as Record<string, unknown>).window = {};
 
       const backendAdapter = new Auth0AuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      
-      // Mock successful server response
-      const mockResponse = {
-        status: 200,
-        data: { 
-          sub: "user123", 
-          name: "Test User",
-          org_id: "test-org-123"
-        },
-      };
-      mockedAxios.get.mockResolvedValue(mockResponse);
-      
-      const result = await backendAdapter.validateToken(token);
-      
+      mockVerify.mockResolvedValue(true);
+
+      const result = await backendAdapter.validateToken("test-token");
+
       expect(result).toBe(true);
       // Verify server-side validation was used (proves appType is 'backend')
-      expect(mockedAxios.get).toHaveBeenCalled();
+      expect(mockVerify).toHaveBeenCalled();
       expect(mockOIDCClient.getStoredAuth).not.toHaveBeenCalled();
 
       // Clean up

--- a/packages/datacollect/src/components/authentication/__tests__/KeycloakAuthAdapter.test.ts
+++ b/packages/datacollect/src/components/authentication/__tests__/KeycloakAuthAdapter.test.ts
@@ -5,10 +5,12 @@ import { KeycloakAuthAdapter } from "../KeycloakAuthAdapter";
 import OIDCClient from "../OIDCClient";
 import axios from "axios";
 import { AuthConfig, SingleAuthStorage, OIDCConfig } from "../../../interfaces/types";
+import { verifyOidcAccessToken } from "../verifyOidcAccessToken";
 
 // Mock dependencies
 jest.mock("../OIDCClient");
 jest.mock("axios");
+jest.mock("../verifyOidcAccessToken", () => ({ verifyOidcAccessToken: jest.fn() }));
 jest.mock("../../../utils/logger", () => ({
   createLogger: () => ({
     info: jest.fn(),
@@ -23,6 +25,7 @@ jest.mock("../../../utils/logger", () => ({
 
 const MockedOIDCClient = OIDCClient as jest.MockedClass<typeof OIDCClient>;
 const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockVerify = verifyOidcAccessToken as jest.Mock;
 
 describe("KeycloakAuthAdapter", () => {
   let adapter: KeycloakAuthAdapter;
@@ -263,66 +266,31 @@ describe("KeycloakAuthAdapter", () => {
       }
     });
 
-    it("should validate token on server side using userinfo", async () => {
-      // Ensure backend environment - window is undefined
+    it("delegates server-side validation to verifyOidcAccessToken with the tenant client binding", async () => {
       (global as unknown as Record<string, unknown>).window = undefined;
 
       const backendAdapter = new KeycloakAuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      const mockResponse = {
-        status: 200,
-        data: { sub: "user123", name: "Test User" },
-      };
+      mockVerify.mockResolvedValue(true);
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
-
-      const result = await backendAdapter.validateToken(token);
+      const result = await backendAdapter.validateToken("server-token");
 
       expect(result).toBe(true);
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        `${authConfig.fields.authority}/protocol/openid-connect/userinfo`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          timeout: 5000,
-        }
-      );
+      expect(mockVerify).toHaveBeenCalledWith("server-token", {
+        authority: authConfig.fields.authority,
+        clientId: authConfig.fields.client_id,
+        audience: authConfig.fields.audience,
+      });
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(mockOIDCClient.getStoredAuth).not.toHaveBeenCalled();
     });
 
-    it("should explicitly use backend validation when no window object exists", async () => {
-      // Ensure backend environment - window is undefined
+    it("returns false when verifyOidcAccessToken rejects the token (H33)", async () => {
       (global as unknown as Record<string, unknown>).window = undefined;
 
       const backendAdapter = new KeycloakAuthAdapter(mockAuthStorage, authConfig);
-      const token = "backend-test-token";
-      const mockResponse = {
-        status: 200,
-        data: { 
-          sub: "backend-user", 
-          name: "Backend User"
-        },
-      };
+      mockVerify.mockResolvedValue(false);
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
-
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(true);
-      // Verify axios was called (server-side validation)
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        `${authConfig.fields.authority}/protocol/openid-connect/userinfo`,
-        expect.objectContaining({
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          timeout: 5000,
-        })
-      );
-      // Verify OIDC client was NOT called (not client-side validation)
-      expect(mockOIDCClient.getStoredAuth).not.toHaveBeenCalled();
+      expect(await backendAdapter.validateToken("foreign-token")).toBe(false);
     });
 
     it("should validate token on client side", async () => {
@@ -341,114 +309,30 @@ describe("KeycloakAuthAdapter", () => {
 
       expect(result).toBe(true);
       expect(mockOIDCClient.getStoredAuth).toHaveBeenCalled();
-      // Verify axios was NOT called (not server-side validation)
-      expect(mockedAxios.get).not.toHaveBeenCalled();
-    });
-
-    it("should return false for invalid token on server", async () => {
-      // Ensure backend environment - window is undefined
-      (global as unknown as Record<string, unknown>).window = undefined;
-
-      const backendAdapter = new KeycloakAuthAdapter(mockAuthStorage, authConfig);
-      const token = "invalid-token";
-
-      mockedAxios.get.mockRejectedValue(new Error("Unauthorized"));
-
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return false when userinfo response has no sub", async () => {
-      // Ensure backend environment - window is undefined
-      (global as unknown as Record<string, unknown>).window = undefined;
-
-      const backendAdapter = new KeycloakAuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      const mockResponse = {
-        status: 200,
-        data: { name: "Test User" }, // Missing 'sub' field
-      };
-
-      mockedAxios.get.mockResolvedValue(mockResponse);
-
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(false);
-    });
-
-    it("should return false when userinfo response status is not 200", async () => {
-      // Ensure backend environment - window is undefined
-      (global as unknown as Record<string, unknown>).window = undefined;
-
-      const backendAdapter = new KeycloakAuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      const mockResponse = {
-        status: 401,
-        data: { error: "Unauthorized" },
-      };
-
-      mockedAxios.get.mockResolvedValue(mockResponse);
-
-      const result = await backendAdapter.validateToken(token);
-
-      expect(result).toBe(false);
+      expect(mockVerify).not.toHaveBeenCalled();
     });
 
     it("should return false for mismatched token on client", async () => {
-      // Mock frontend environment - ensure window exists with localStorage
       (global as unknown as Record<string, unknown>).window = { localStorage: {} };
 
       const frontendAdapter = new KeycloakAuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
 
       mockOIDCClient.getStoredAuth.mockResolvedValue({
         access_token: "different-token",
         expires_in: 3600,
       });
 
-      const result = await frontendAdapter.validateToken(token);
+      const result = await frontendAdapter.validateToken("test-token");
 
       expect(result).toBe(false);
     });
 
-    it("should call validateTokenServer when appType is backend", async () => {
-      // Ensure backend environment - window is undefined
-      (global as unknown as Record<string, unknown>).window = undefined;
-      
-      const backendAdapter = new KeycloakAuthAdapter(mockAuthStorage, authConfig);
-      const token = "test-token";
-      
-      // Mock successful server response
-      const mockResponse = {
-        status: 200,
-        data: { 
-          sub: "user123", 
-          name: "Test User"
-        },
-      };
-      mockedAxios.get.mockResolvedValue(mockResponse);
-      
-      const result = await backendAdapter.validateToken(token);
-      
-      expect(result).toBe(true);
-      // Verify server-side validation was used (axios called)
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        `${authConfig.fields.authority}/protocol/openid-connect/userinfo`,
-        expect.any(Object)
-      );
-      // Verify client-side validation was NOT used
-      expect(mockOIDCClient.getStoredAuth).not.toHaveBeenCalled();
-    });
-
     it("should call validateTokenClient when appType is frontend", async () => {
-      // Mock frontend environment - ensure window exists with localStorage
       (global as unknown as Record<string, unknown>).window = { localStorage: {} };
 
       const frontendAdapter = new KeycloakAuthAdapter(mockAuthStorage, authConfig);
       const token = "test-token";
 
-      // Mock client-side auth
       mockOIDCClient.getStoredAuth.mockResolvedValue({
         access_token: token,
         expires_in: 3600,
@@ -457,10 +341,8 @@ describe("KeycloakAuthAdapter", () => {
       const result = await frontendAdapter.validateToken(token);
 
       expect(result).toBe(true);
-      // Verify client-side validation was used
       expect(mockOIDCClient.getStoredAuth).toHaveBeenCalled();
-      // Verify server-side validation was NOT used
-      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(mockVerify).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/datacollect/src/components/authentication/__tests__/verifyOidcAccessToken.test.ts
+++ b/packages/datacollect/src/components/authentication/__tests__/verifyOidcAccessToken.test.ts
@@ -1,0 +1,92 @@
+import { verifyOidcAccessToken } from "../verifyOidcAccessToken";
+
+/**
+ * H33: OIDC access tokens on sync routes were accepted on a userinfo 200 alone,
+ * with no signature / issuer / audience / client binding. These tests cover the
+ * replacement verifier: JWKS signature + issuer via jose, plus client/audience
+ * binding, fail-closed when unconfigured. jose and fetch are mocked.
+ */
+
+const mockJwtVerify: jest.Mock = jest.fn();
+const mockCreateRemoteJWKSet: jest.Mock = jest.fn(() => "JWKS-KEYSET");
+
+jest.mock("jose", () => ({
+  createRemoteJWKSet: (...args: unknown[]) => mockCreateRemoteJWKSet(...args),
+  jwtVerify: (...args: unknown[]) => mockJwtVerify(...args),
+}));
+
+jest.mock("../../../utils/logger", () => ({
+  createLogger: () => ({ debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+}));
+
+let fetchMock: jest.Mock;
+
+const AUTHORITY = "https://issuer.example";
+
+function mockDiscovery(jwksUri = `${AUTHORITY}/jwks`, issuer = AUTHORITY) {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ issuer, jwks_uri: jwksUri }),
+  });
+}
+
+describe("verifyOidcAccessToken (H33)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it("accepts a token bound to the configured client via azp", async () => {
+    mockDiscovery();
+    mockJwtVerify.mockResolvedValueOnce({ payload: { sub: "u1", azp: "my-client" } });
+
+    const ok = await verifyOidcAccessToken("tok", { authority: AUTHORITY, clientId: "my-client" });
+    expect(ok).toBe(true);
+    expect(mockJwtVerify).toHaveBeenCalledWith("tok", "JWKS-KEYSET", { issuer: AUTHORITY });
+  });
+
+  it("accepts a token whose aud contains the configured audience", async () => {
+    mockDiscovery();
+    mockJwtVerify.mockResolvedValueOnce({ payload: { sub: "u1", aud: ["my-api", "other"] } });
+
+    const ok = await verifyOidcAccessToken("tok", { authority: AUTHORITY, audience: "my-api" });
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a token issued for a different client (foreign azp/aud)", async () => {
+    mockDiscovery();
+    mockJwtVerify.mockResolvedValueOnce({ payload: { sub: "u1", azp: "other-client", aud: "other-api" } });
+
+    const ok = await verifyOidcAccessToken("tok", { authority: AUTHORITY, clientId: "my-client" });
+    expect(ok).toBe(false);
+  });
+
+  it("fails closed when neither clientId nor audience is configured", async () => {
+    const ok = await verifyOidcAccessToken("tok", { authority: AUTHORITY });
+    expect(ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockJwtVerify).not.toHaveBeenCalled();
+  });
+
+  it("rejects when signature/issuer verification fails", async () => {
+    mockDiscovery();
+    mockJwtVerify.mockRejectedValueOnce(new Error("signature verification failed"));
+
+    const ok = await verifyOidcAccessToken("tok", { authority: AUTHORITY, clientId: "my-client" });
+    expect(ok).toBe(false);
+  });
+
+  it("rejects when the JWKS URI origin does not match the issuer (anti-spoof)", async () => {
+    mockDiscovery("https://evil.example/jwks");
+
+    const ok = await verifyOidcAccessToken("tok", { authority: AUTHORITY, clientId: "my-client" });
+    expect(ok).toBe(false);
+    expect(mockJwtVerify).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when authority is missing", async () => {
+    const ok = await verifyOidcAccessToken("tok", { clientId: "my-client" });
+    expect(ok).toBe(false);
+  });
+});

--- a/packages/datacollect/src/components/authentication/verifyOidcAccessToken.ts
+++ b/packages/datacollect/src/components/authentication/verifyOidcAccessToken.ts
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("verifyOidcAccessToken");
+
+export interface OidcVerifyParams {
+  /** OIDC issuer / authority base URL (e.g. https://tenant.auth0.com). */
+  authority?: string;
+  /** This tenant's OIDC client_id — the token must be bound to it. */
+  clientId?: string;
+  /** Expected API audience, if the deployment configured one. */
+  audience?: string;
+}
+
+/**
+ * Verify an OIDC access token for a server-side sync request.
+ *
+ * Replaces the previous userinfo-200-only check (finding H33), which accepted
+ * any live token from the same Auth0 tenant / Keycloak realm regardless of who
+ * it was issued for. This:
+ *   1. fetches the provider's JWKS via OIDC discovery (origin-checked),
+ *   2. verifies the JWT signature + issuer with jose,
+ *   3. binds the token to this tenant's client/audience (aud / azp / client_id).
+ *
+ * Fails closed: returns false on any verification error, and refuses to accept
+ * a token when no clientId/audience is configured to bind against. `jose` is
+ * isomorphic (WebCrypto) so this runs in both the backend and browser builds.
+ */
+export async function verifyOidcAccessToken(token: string, params: OidcVerifyParams): Promise<boolean> {
+  const authority = params.authority?.replace(/\/+$/, "");
+  if (!authority) {
+    log.warn("OIDC token rejected: no authority configured");
+    return false;
+  }
+
+  const acceptable = new Set([params.clientId, params.audience].filter((v): v is string => !!v));
+  if (acceptable.size === 0) {
+    log.warn("OIDC token rejected: no clientId/audience configured to bind against (fail-closed)");
+    return false;
+  }
+
+  try {
+    const discoveryRes = await fetch(`${authority}/.well-known/openid-configuration`);
+    if (!discoveryRes.ok) {
+      log.warn({ status: discoveryRes.status }, "OIDC token rejected: discovery fetch failed");
+      return false;
+    }
+    const discovery = (await discoveryRes.json()) as { issuer?: string; jwks_uri?: string };
+    if (!discovery.issuer || !discovery.jwks_uri) {
+      log.warn("OIDC token rejected: discovery missing issuer/jwks_uri");
+      return false;
+    }
+
+    // Guard against a discovery document pointing JWKS at an attacker origin.
+    const jwksUrl = new URL(discovery.jwks_uri);
+    if (jwksUrl.origin !== new URL(authority).origin) {
+      log.warn({ jwksOrigin: jwksUrl.origin }, "OIDC token rejected: jwks_uri origin mismatch");
+      return false;
+    }
+
+    // Imported dynamically: jose is ESM-only, and a static import would be
+    // eagerly loaded by every module that transitively imports this adapter
+    // (breaking CommonJS test runners that never exercise this path).
+    const { createRemoteJWKSet, jwtVerify } = await import("jose");
+    const JWKS = createRemoteJWKSet(jwksUrl);
+    const { payload } = await jwtVerify(token, JWKS, { issuer: discovery.issuer });
+
+    // Bind the token to this tenant's client/audience. Auth0 access tokens carry
+    // the client in `azp` and the API in `aud`; Keycloak likewise. Accept if any
+    // of aud / azp / client_id matches a configured value.
+    const aud = payload.aud;
+    const refs = [
+      ...(Array.isArray(aud) ? aud : aud ? [aud] : []),
+      typeof payload.azp === "string" ? payload.azp : undefined,
+      typeof (payload as { client_id?: unknown }).client_id === "string"
+        ? (payload as { client_id: string }).client_id
+        : undefined,
+    ].filter((v): v is string => typeof v === "string");
+
+    if (!refs.some((ref) => acceptable.has(ref))) {
+      log.warn("OIDC token rejected: not bound to the configured client/audience");
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    log.error({ err }, "OIDC token rejected: verification failed");
+    return false;
+  }
+}

--- a/packages/datacollect/tsconfig.json
+++ b/packages/datacollect/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "module": "ES2022",
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,13 +73,13 @@ importers:
         version: 15.15.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.33)
+        version: 29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -122,13 +122,13 @@ importers:
         version: 15.15.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.33)
+        version: 29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -174,13 +174,13 @@ importers:
         version: 15.15.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.33)
+        version: 29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -461,7 +461,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)
@@ -486,6 +486,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.18.0)(postgres@3.4.8)
+      jose:
+        specifier: ^6.1.3
+        version: 6.1.3
       lodash:
         specifier: ^4.17.23
         version: 4.17.23
@@ -573,7 +576,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)
@@ -15768,41 +15771,6 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 24.10.13
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -17544,10 +17512,10 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.55.0
       '@typescript-eslint/type-utils': 8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)
       '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)
@@ -19013,21 +18981,6 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.6.3
-
-  create-jest@29.7.0(@types/node@20.19.33):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   create-jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)):
     dependencies:
@@ -21402,25 +21355,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.33):
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.33)
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
@@ -21794,18 +21728,6 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@29.7.0(@types/node@20.19.33):
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.33)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)):
     dependencies:
@@ -25713,12 +25635,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25734,32 +25656,12 @@ snapshots:
       esbuild: 0.25.12
       jest-util: 29.7.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@20.19.33)
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.4
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      jest-util: 29.7.0
-
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@24.10.13)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@24.10.13)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@20.19.33)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@swc/wasm@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25885,7 +25787,7 @@ snapshots:
 
   typescript-eslint@8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.8.3)

--- a/scripts/seed-config.json
+++ b/scripts/seed-config.json
@@ -4,7 +4,7 @@
   "description": "Demo app configuration with households and individuals for development and testing.",
   "version": "1.0.0",
   "selfService": {
-    "enabled": true,
+    "enabled": false,
     "authMethods": ["otp", "id"],
     "allowedForms": ["individual", "household", "life_event", "assistance_request", "grievance"],
     "languages": ["en", "fr"],


### PR DESCRIPTION
Tier-1 security remediation from the 2026-06-18 Codex scan triage. Closes the highest-severity cluster: self-service auth bypass, the OpenSPP confused-deputy / discovery-overwrite chain, and OIDC audience confusion. Branched off `develop` (where the discovery code lives).

## Findings closed (11)

**WS1 — self-service (C2)**
- `selfService.enabled` is now enforced server-side; all `/api/auth/*` self-service routes return 403 unless the tenant explicitly opts in. Flag defaults **off** (seed config flipped). Self-service is being reworked from scratch; this contains it. `authMethods`/`allowedForms`-at-issuance hardening deferred to that rework.

**WS2 — OpenSPP confused-deputy / discovery-overwrite (H1, H2, H3, H4, H10, H11, H12, H22, H30)**
- H11/H30: strip client-asserted `externalId`/`identifierType` at the `/api/sync/push` trust boundary (external-pull events bypass `/push`, so unaffected).
- H1/H2/H3: discovery restricted to the server-resolved `externalId` under the configured identifier type — removed client-field, both-casing and cross-namespace probing.
- H10/H22: preserve the OpenSPP identifier system on pull (as `identifierType`) so push targets the same id-type; ignore non-string `identifierType`.
- H12: skip out-of-namespace identifiers on pull (no longer adopted as PATCH targets).
- H4: baseline-parity entities carrying `pendingProgramEnrolments` push the enrolment CRs only — no stale entity overwrite.

**WS3 — OIDC audience binding (H33)**
- New shared `verifyOidcAccessToken`: OIDC discovery (origin-checked) → JWKS signature + issuer via `jose` → bind token to the tenant's client/audience (`aud`/`azp`/`client_id`), fail-closed. Auth0 + Keycloak server-side validators delegate to it; userinfo-only path removed.

## Verification
- datacollect 792 tests, adapter-openspp 139, backend 388 — all green; type-checks 0 errors; full builds; eslint clean; admin e2e 23 green.
- Two-cycle sync test (H10) and a confused-deputy regression test (a client identifier cannot discover/PATCH a victim) included.
- `pnpm pr-check`: green except pre-existing **flaky mobile Playwright e2e** (non-deterministic 30s `page.goto`/`page.reload` timeouts; failing set differs per run; unrelated to this diff, which touches no mobile UI).

## Notes / decisions
- WS2 discovery: chose deterministic (externalId-only) over client-field linking; UC3 adapter tests still pass. national_id auto-linking deferred to the UC3 rework.
- Out of Tier-1 scope (separate branches): RBAC tenant-scoping (C3/H13/H14/H15/H17), SSRF (H18/H28), mobile config trust (H21/H27/H32), infra (H8/H16/H20/H26). Re-run the full triage before the next develop→main merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
