### PR TITLE
fix: harden login against user enumeration and rate-limit bypass

### DIFF
--- a/docker/docker-compose.coolify.yaml
+++ b/docker/docker-compose.coolify.yaml
@@ -47,6 +47,9 @@ services:
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
       - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-}
       - EXTERNAL_SYNC_ENABLED=${EXTERNAL_SYNC_ENABLED:-false}
+      # Coolify's proxy terminates ingress and appends the client IP to
+      # X-Forwarded-For, so trust one hop for correct rate-limit keying.
+      - TRUST_PROXY=${TRUST_PROXY:-1}
     expose:
       - "3000"
     depends_on:

--- a/docker/docker-compose.nginx.yaml
+++ b/docker/docker-compose.nginx.yaml
@@ -52,6 +52,9 @@ services:
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
       - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-}
       - EXTERNAL_SYNC_ENABLED=${EXTERNAL_SYNC_ENABLED:-false}
+      # One reverse proxy (nginx) sits in front and appends the client IP to
+      # X-Forwarded-For, so trust exactly one hop for correct rate-limit keying.
+      - TRUST_PROXY=${TRUST_PROXY:-1}
     depends_on:
       postgres:
         condition: service_healthy

--- a/packages/backend/src/__tests__/security-login-timing.test.ts
+++ b/packages/backend/src/__tests__/security-login-timing.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Security: login does not leak account existence via timing.
+ *
+ * The handler must run a password hash comparison even when the email is
+ * unknown, so the response time does not reveal whether an account is
+ * registered (user enumeration).
+ */
+import "dotenv/config";
+import bcrypt from "bcrypt";
+import request from "supertest";
+import { run } from "../syncServer";
+import { SyncServerInstance } from "../types";
+import { getConnectionString, ensureDatabaseExists, describeIfPostgres } from "./helpers/testDb";
+
+jest.mock("../utils/logger", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pino = require("pino");
+  const silentLogger = pino({ level: "silent" });
+  return { createLogger: () => silentLogger.child({ component: "test" }), logger: silentLogger };
+});
+
+const postgresUrl = getConnectionString("login_timing");
+const ADMIN_EMAIL = "admin-login-timing@example.com";
+const ADMIN_PW = "AdminLogin123!";
+
+describeIfPostgres("Login timing (user enumeration)", () => {
+  let app: SyncServerInstance;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = "login-timing-test-secret-32-characters-ok";
+    await ensureDatabaseExists(postgresUrl);
+    app = await run({ port: 0, adminPassword: ADMIN_PW, adminEmail: ADMIN_EMAIL, postgresUrl });
+  });
+
+  afterAll(async () => {
+    await app.clearStore();
+    await app.closeConnection();
+  });
+
+  it("runs a password hash comparison even when the email is unknown", async () => {
+    const spy = jest.spyOn(bcrypt, "compare");
+    spy.mockClear();
+
+    const res = await request(app.httpServer)
+      .post("/api/users/login")
+      .send({ email: "ghost@nowhere.test", password: "WhateverPass1!" });
+
+    expect(res.status).toBe(401);
+    // Without the fix, an unknown email returns before bcrypt.compare is reached;
+    // the constant-time path compares against a placeholder hash instead.
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/backend/src/__tests__/security-ratelimit-proxy.test.ts
+++ b/packages/backend/src/__tests__/security-ratelimit-proxy.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Security: IP-based rate limiting cannot be bypassed via X-Forwarded-For.
+ *
+ * resolveTrustProxy defaults to not trusting the header, and the login limiter
+ * keys on the real connection IP, so rotating X-Forwarded-For does not mint a
+ * fresh rate-limit bucket per request.
+ */
+import "dotenv/config";
+import request from "supertest";
+import { run, resolveTrustProxy } from "../syncServer";
+import { SyncServerInstance } from "../types";
+import { getConnectionString, ensureDatabaseExists, describeIfPostgres } from "./helpers/testDb";
+
+jest.mock("../utils/logger", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pino = require("pino");
+  const silentLogger = pino({ level: "silent" });
+  return { createLogger: () => silentLogger.child({ component: "test" }), logger: silentLogger };
+});
+
+describe("resolveTrustProxy", () => {
+  it("defaults to false when unset or empty", () => {
+    expect(resolveTrustProxy(undefined)).toBe(false);
+    expect(resolveTrustProxy("")).toBe(false);
+  });
+
+  it("parses boolean strings", () => {
+    expect(resolveTrustProxy("true")).toBe(true);
+    expect(resolveTrustProxy("false")).toBe(false);
+  });
+
+  it("parses non-negative hop counts as numbers", () => {
+    expect(resolveTrustProxy("0")).toBe(0);
+    expect(resolveTrustProxy("1")).toBe(1);
+    expect(resolveTrustProxy("3")).toBe(3);
+  });
+
+  it("passes through subnet/preset strings", () => {
+    expect(resolveTrustProxy("loopback")).toBe("loopback");
+    expect(resolveTrustProxy("10.0.0.0/8")).toBe("10.0.0.0/8");
+  });
+});
+
+const postgresUrl = getConnectionString("ratelimit_proxy");
+const ADMIN_EMAIL = "admin-ratelimit@example.com";
+const ADMIN_PW = "AdminRate123!";
+
+describeIfPostgres("Login rate limiting (live)", () => {
+  let app: SyncServerInstance;
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = "ratelimit-proxy-test-secret-32-characters";
+    // Default behaviour: trust no proxy, so X-Forwarded-For is ignored.
+    delete process.env.TRUST_PROXY;
+    await ensureDatabaseExists(postgresUrl);
+    app = await run({ port: 0, adminPassword: ADMIN_PW, adminEmail: ADMIN_EMAIL, postgresUrl });
+  });
+
+  afterAll(async () => {
+    await app.clearStore();
+    await app.closeConnection();
+  });
+
+  it("login limiter is not bypassed by rotating X-Forwarded-For", async () => {
+    let got429 = false;
+    for (let i = 0; i < 30; i++) {
+      const r = await request(app.httpServer)
+        .post("/api/users/login")
+        .set("X-Forwarded-For", `10.9.8.${i}`)
+        .send({ email: "ghost@nowhere.test", password: "WhateverPass1!" });
+      if (r.status === 429) {
+        got429 = true;
+        break;
+      }
+    }
+    expect(got429).toBe(true);
+  });
+});

--- a/packages/backend/src/routes/userRoutes.ts
+++ b/packages/backend/src/routes/userRoutes.ts
@@ -65,6 +65,11 @@ const loginLimiter = rateLimit({
   message: { error: "Too many login attempts, please try again later" },
 });
 
+// A bcrypt hash compared against when the email is unknown, so login spends the
+// same time hashing whether or not the account exists. Without it, the absence
+// of a hash comparison lets an attacker enumerate valid emails by timing.
+const DUMMY_PASSWORD_HASH = bcrypt.hashSync("invalid-account-placeholder", 10);
+
 export function createUserRoutes(userStore: UserStore): Router {
   const router = Router();
 
@@ -75,11 +80,13 @@ export function createUserRoutes(userStore: UserStore): Router {
     asyncHandler(async (req, res) => {
       const { email, password } = req.body;
       const user = await userStore.getUser(email);
-      if (!user) {
-        return res.status(401).json({ error: "Invalid email or password" });
-      }
-      const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
-      if (!isPasswordValid) {
+      // Always run a hash comparison — against the real hash when the account
+      // exists, otherwise against a placeholder — so the response time does not
+      // reveal whether the email is registered.
+      const candidatePassword = typeof password === "string" ? password : "";
+      const passwordHash = user ? user.passwordHash : DUMMY_PASSWORD_HASH;
+      const isPasswordValid = await bcrypt.compare(candidatePassword, passwordHash);
+      if (!user || !isPasswordValid) {
         return res.status(401).json({ error: "Invalid email or password" });
       }
 

--- a/packages/backend/src/syncServer.ts
+++ b/packages/backend/src/syncServer.ts
@@ -57,6 +57,25 @@ import { MockRegistrySyncAdapter } from "@idpass/adapter-mock";
 
 const log = createLogger("syncServer");
 
+/**
+ * Resolves Express's "trust proxy" setting from the TRUST_PROXY env var.
+ *
+ * Defaults to false so that a directly exposed server does not trust a
+ * client-supplied X-Forwarded-For header — otherwise an attacker can rotate
+ * that header to mint a fresh IP per request and bypass IP-based rate limiting.
+ * When running behind reverse proxies that append the client IP to
+ * X-Forwarded-For, set TRUST_PROXY to the number of those proxies (e.g. "1"
+ * for a single nginx hop). Boolean and subnet/preset strings are also accepted.
+ */
+export function resolveTrustProxy(raw: string | undefined): boolean | number | string {
+  if (!raw) return false;
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  const n = Number(raw);
+  if (Number.isInteger(n) && n >= 0) return n;
+  return raw;
+}
+
 // Register external sync adapters with the V2 adapter registry
 // openspp-v1-adapter: Odoo JSON-RPC (database/username/password)
 adapterRegistry.register("openspp-v1-adapter", (deps) =>
@@ -132,7 +151,7 @@ export async function run(config: SyncServerConfig): Promise<SyncServerInstance>
   const app = express();
 
   setupUncaughtHandlers();
-  app.set("trust proxy", 1);
+  app.set("trust proxy", resolveTrustProxy(process.env.TRUST_PROXY));
   app.use(helmet());
   const corsOrigins = process.env.CORS_ORIGINS;
   const corsOptions: cors.CorsOptions = { origin: false };


### PR DESCRIPTION
## Summary

Two fixes from a security audit of the login endpoint.

### 1. User enumeration via login timing (#4)

`POST /api/users/login` returned immediately for an unknown email and only ran
`bcrypt.compare` when the account existed. The resulting timing gap (~2 ms vs
~40 ms) let an attacker enumerate valid emails. The handler now always compares
against a placeholder hash when the email is unknown, so response time no longer
depends on account existence. The error message was already uniform.

### 2. Rate-limit bypass via X-Forwarded-For (#1)

`trust proxy` was hardcoded to `1`. When the server is exposed directly (e.g.
the plain `docker-compose.yaml`, which publishes port 3000 with no proxy), Express
trusts a client-supplied `X-Forwarded-For`, so an attacker can rotate the header
to get a fresh rate-limit bucket per request and defeat the login limiter.

`trust proxy` is now resolved from the `TRUST_PROXY` env var via `resolveTrustProxy`,
defaulting to `false` (do not trust the header). Deployments behind reverse
proxies set `TRUST_PROXY` to the proxy hop count; the shipped `nginx` and
`coolify` compose files now set `TRUST_PROXY=1` (both front the app with one
proxy that appends the client IP to `X-Forwarded-For`).

**Behavior change:** if you run behind a proxy without setting `TRUST_PROXY`,
rate limiting keys on the proxy IP (all clients share one bucket) and `req.protocol`
reflects the proxy connection. Set `TRUST_PROXY` to your real proxy hop count;
URL generation is unaffected when `PUBLIC_BASE_URL` is set.

## Testing

- `security-login-timing`: login runs `bcrypt.compare` even for unknown emails.
- `security-ratelimit-proxy`: unit tests for `resolveTrustProxy`, plus a live test
  that rotating `X-Forwarded-For` no longer bypasses the login limiter (429 still
  triggers) under the default trust setting.
- Backend type-check passes; `userRoutes` and `security-auth` suites pass.

## Scope notes

- The limiter fix applies to every IP-keyed limiter (login and the OTP limiters),
  since they all rely on `req.ip`.
