### PR TITLE
fix(test): own e2e server lifecycle and retry transient timeouts

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -23,7 +23,8 @@ export default defineConfig({
   testDir: '.',
   testMatch: '**/*.spec.ts',
   timeout: 60000,
-  retries: 0,
+  // Retry once locally / twice in CI to absorb transient e2e timeouts.
+  retries: process.env.CI ? 2 : 1,
   use: {
     headless: true,
     screenshot: 'only-on-failure',

--- a/packages/admin/playwright.config.ts
+++ b/packages/admin/playwright.config.ts
@@ -22,7 +22,8 @@ import { defineConfig } from '@playwright/test'
 export default defineConfig({
   testDir: './e2e',
   timeout: 30000,
-  retries: 0,
+  // Retry once locally / twice in CI to absorb transient e2e timeouts.
+  retries: process.env.CI ? 2 : 1,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:5173',
     headless: true,
@@ -37,6 +38,8 @@ export default defineConfig({
   webServer: {
     command: 'pnpm dev',
     port: 5173,
-    reuseExistingServer: true,
+    // Always let Playwright own the server lifecycle, both locally and in CI,
+    // so runs never depend on a leftover server on this port.
+    reuseExistingServer: false,
   },
 })

--- a/packages/mobile/playwright.config.ts
+++ b/packages/mobile/playwright.config.ts
@@ -28,7 +28,10 @@ const useDevServer = !!process.env.PLAYWRIGHT_DEV_SERVER
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
-  retries: 0,
+  // Retry once locally / twice in CI to absorb transient e2e timeouts (a slow
+  // navigation under machine load can exceed the per-test timeout). Genuinely
+  // flaky tests still surface in the report as "flaky".
+  retries: process.env.CI ? 2 : 1,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:8081',
     headless: true,
@@ -46,7 +49,10 @@ export default defineConfig({
       ? 'VITE_DEVELOP=true pnpm dev:web'
       : 'pnpm run build:web:e2e && pnpm run preview:web',
     port: 8081,
-    reuseExistingServer: !process.env.CI,
+    // Always let Playwright own the server lifecycle (start fresh, tear down),
+    // both locally and in CI, so runs never depend on leftover process/port
+    // state (e.g. an orphaned preview server from an interrupted run).
+    reuseExistingServer: false,
     // Static build + preview-server boot: build takes 30-60s, preview boots
     // instantly. Give plenty of headroom so a slow CI runner has room.
     timeout: 180_000,

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -22,7 +22,8 @@ import { defineConfig } from '@playwright/test'
 export default defineConfig({
   testDir: './e2e',
   timeout: 30000,
-  retries: 0,
+  // Retry once locally / twice in CI to absorb transient e2e timeouts.
+  retries: process.env.CI ? 2 : 1,
   use: {
     baseURL: process.env.BASE_URL || 'http://localhost:5174',
     headless: true,


### PR DESCRIPTION
## What

Two Playwright config changes across all four e2e configs (mobile, admin, web, root `e2e/`):

1. `reuseExistingServer: false` (mobile + admin — the two with a `webServer` block). Previously mobile used `!process.env.CI` and admin hardcoded `true`.
2. `retries: process.env.CI ? 2 : 1` (all four; was `0`).

## Why

`pnpm pr-check` fails intermittently on local machines at the mobile e2e step, while passing in CI. Investigation:

- The failures are **transient per-test timeouts** — a slow `page.goto`/`page.reload` under machine load exceeds the 30s timeout. Proven by running with retries: the same tests report `flaky` (fail once, pass on retry), not `failed`.
- `retries: 0` gave zero tolerance for a single slow navigation, so the whole `pr-check` hard-failed. `retries: CI ? 2 : 1` absorbs the transient timeout; genuinely flaky tests still surface as `flaky` in the report.
- `reuseExistingServer: true`/`!CI` made local runs depend on leftover process/port state — an orphaned preview server from an interrupted run would be silently reused (stale bundle) instead of rebuilt. `false` makes Playwright always own the server lifecycle (start fresh, tear down), matching CI and turning the footgun into a fail-fast "port in use".

No product/test-logic changes.

## Verification

- Mobile e2e: `10 passed, 2 flaky, 0 failed` (green) with the new config.
- Admin e2e: `23 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)