### PR TITLE
fix(test): admin e2e reuses the CI-prestarted dev server

### DIFF
--- a/packages/admin/playwright.config.ts
+++ b/packages/admin/playwright.config.ts
@@ -38,8 +38,10 @@ export default defineConfig({
   webServer: {
     command: 'pnpm dev',
     port: 5173,
-    // Always let Playwright own the server lifecycle, both locally and in CI,
-    // so runs never depend on a leftover server on this port.
-    reuseExistingServer: false,
+    // Reuse a server already listening on this port. The e2e.yml CI workflow
+    // starts `pnpm run dev:admin` in the background before invoking these tests,
+    // so Playwright must reuse it rather than try to bind an occupied 5173.
+    // (Unlike mobile, whose server Playwright owns exclusively.)
+    reuseExistingServer: true,
   },
 })


### PR DESCRIPTION
## What

Revert the admin Playwright config back to `reuseExistingServer: true` (keeps the `retries: CI ? 2 : 1` from #58).

## Why

#58 set `reuseExistingServer: false` across all e2e configs for consistency. That is correct for **mobile** (Playwright owns its preview server exclusively — no external starter), but wrong for **admin**: the `e2e.yml` workflow starts the server itself before running the suite —

```yaml
- name: Start admin dev server in background
  run: pnpm run dev:admin &      # occupies :5173
- name: Run admin e2e tests
  run: pnpm run test:e2e:admin
```

With `false`, Playwright tries to bind the already-occupied `:5173` and hard-fails:

```
Error: http://localhost:5173 is already used, make sure that nothing is running
on the port/url or set reuseExistingServer:true in config.webServer.
```

This turned develop's `E2E Tests` red after #58 merged (and blocked every PR's `e2e`, incl. #29). Reverting admin to `true` restores the intended reuse of the pre-started server. Local runs are unaffected (no server present → Playwright starts its own). Mobile keeps `false`; web/root-e2e have no `webServer` block.

Missed in #58 because locally there is no pre-started server, so admin e2e passed with `false` — the exact local↔CI gap the reuse setting exists to bridge.

## Verification

- Admin e2e locally with `reuseExistingServer: true`: 23 passed.
- Config lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)