### PR TITLE
fix(security): block horizontal BOLA via group member-GUID injection (#1134)

### DIFF
--- a/packages/backend/src/__tests__/selfServiceEndpoints.test.ts
+++ b/packages/backend/src/__tests__/selfServiceEndpoints.test.ts
@@ -1134,3 +1134,133 @@ describe("Scope hardening", () => {
     expect(response.body.error).toBe("Forbidden: cannot access other entities");
   });
 });
+
+// ─── 6. POST /api/auth/self-service/submit — horizontal BOLA member guard (#1134) ───
+describe("POST /api/auth/self-service/submit — member-GUID injection guard (#1134)", () => {
+  const BOUND_GROUP_GUID = "household-guid-1";
+  const EXISTING_MEMBER_GUID = "member-guid-existing";
+  const VICTIM_GUID = "victim-guid-other-household";
+  const NEW_MEMBER_GUID = "brand-new-member-guid";
+
+  const GROUP_CONFIG: AppConfig = {
+    id: "bola-tenant",
+    name: "BOLA Test Tenant",
+    entityForms: [
+      { id: "f-household", name: "household", title: "Household" },
+      { id: "f-individual", name: "individual", title: "Individual", dependsOn: "household" },
+    ],
+    selfService: {
+      enabled: true,
+      authMethods: ["otp"],
+      allowedForms: ["household", "individual"],
+      languages: ["en"],
+      requireReview: false,
+    },
+  };
+
+  let app: express.Express;
+  let mockSubmitForm: jest.Mock;
+  let mockGetEntity: jest.Mock;
+
+  function boundToken(): string {
+    return jwt.sign(
+      { scope: "self-service", identifier: "beneficiary-1", entityGuid: BOUND_GROUP_GUID, tenantId: "bola-tenant" },
+      JWT_SECRET,
+      { expiresIn: "1h" },
+    );
+  }
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = JWT_SECRET;
+  });
+
+  beforeEach(() => {
+    mockSubmitForm = jest.fn().mockResolvedValue(undefined);
+    // Per-guid entity resolution: the bound group and its existing member and a
+    // victim entity all exist; unknown guids throw (as EntityDataManager does).
+    mockGetEntity = jest.fn().mockImplementation(async (guid: string) => {
+      if (guid === BOUND_GROUP_GUID) {
+        return { modified: { guid, type: "group", data: { name: "My Household" }, memberIds: [EXISTING_MEMBER_GUID] } };
+      }
+      if (guid === EXISTING_MEMBER_GUID) {
+        return { modified: { guid, type: "individual", data: { name: "Alice", gender: "female" } } };
+      }
+      if (guid === VICTIM_GUID) {
+        return { modified: { guid, type: "individual", data: { name: "Victim", gender: "male" } } };
+      }
+      throw new Error(`Entity with ID ${guid} not found`);
+    });
+
+    const mockAppInstanceStore = {
+      initialize: jest.fn(),
+      createAppInstance: jest.fn(),
+      updateAppInstance: jest.fn(),
+      loadEntityData: jest.fn(),
+      getAppInstance: jest.fn().mockResolvedValue({
+        configId: "bola-tenant",
+        config: GROUP_CONFIG,
+        edm: {
+          getEntity: mockGetEntity,
+          getAllEntities: jest.fn().mockResolvedValue([]),
+          searchEntities: jest.fn().mockResolvedValue([]),
+          getAuditTrailByEntityGuid: jest.fn().mockResolvedValue([]),
+          submitForm: mockSubmitForm,
+        } as never,
+      }),
+      clearAppInstance: jest.fn(),
+      clearStore: jest.fn(),
+      closeConnection: jest.fn(),
+    } as unknown as jest.Mocked<AppInstanceStore>;
+
+    const mockOtpStore = {
+      initialize: jest.fn(),
+      createOtp: jest.fn(),
+      verifyOtp: jest.fn(),
+      getActiveCodesByIdentifier: jest.fn(),
+      clearStore: jest.fn(),
+      closeConnection: jest.fn(),
+    };
+
+    app = express();
+    app.use(bodyParser.json());
+    app.use("/api/auth", createSelfServiceRouter(mockOtpStore as never, mockAppInstanceStore));
+    app.use(errorHandler);
+  });
+
+  it("rejects a member entry naming a pre-existing entity outside the caller's household", async () => {
+    const response = await request(app)
+      .post("/api/auth/self-service/submit")
+      .set("Authorization", `Bearer ${boundToken()}`)
+      .send({ formType: "household", formData: { members: [{ guid: VICTIM_GUID, name: "HACKED" }] } });
+
+    expect(response.status).toBe(403);
+    // The malicious submission must never reach the apply path.
+    expect(mockSubmitForm).not.toHaveBeenCalled();
+  });
+
+  it("allows updating a member that already belongs to the caller's household", async () => {
+    const response = await request(app)
+      .post("/api/auth/self-service/submit")
+      .set("Authorization", `Bearer ${boundToken()}`)
+      .send({
+        formType: "household",
+        formData: { members: [{ guid: EXISTING_MEMBER_GUID, name: "Alice", phone: "555-1234" }] },
+      });
+
+    expect(response.status).toBe(200);
+    expect(mockSubmitForm).toHaveBeenCalledTimes(1);
+    // The authorized-scope option is threaded to the apply path (defense-in-depth).
+    const options = mockSubmitForm.mock.calls[0][1];
+    expect(options.authorizedMemberGuids).toEqual(expect.arrayContaining([EXISTING_MEMBER_GUID, BOUND_GROUP_GUID]));
+  });
+
+  it("allows adding a brand-new member whose GUID does not resolve to an existing entity", async () => {
+    const response = await request(app)
+      .post("/api/auth/self-service/submit")
+      .set("Authorization", `Bearer ${boundToken()}`)
+      .send({ formType: "household", formData: { members: [{ guid: NEW_MEMBER_GUID, name: "Newborn" }] } });
+
+    expect(response.status).toBe(200);
+    expect(mockSubmitForm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/routes/selfServiceRoutes.ts
+++ b/packages/backend/src/routes/selfServiceRoutes.ts
@@ -614,6 +614,52 @@ export function createSelfServiceRouter(
         return res.json({ status: "success", submissionGuid: submission.guid });
       }
 
+      // Horizontal BOLA guard (#1134): self-service callers are the
+      // least-trusted actors. Their token binds `entityGuid` to their own
+      // household, but member sub-writes inside a group form could otherwise
+      // name an ARBITRARY existing entity GUID — overwriting a victim's record
+      // and attaching that victim to the caller's group. Restrict member
+      // entries to the caller's bound entity and its CURRENT members; a
+      // brand-new member (guid that resolves to no existing entity) is allowed.
+      // This check runs BEFORE both the review pipeline and direct-apply so a
+      // malicious submission never reaches either path.
+      const members = submission.data?.members;
+      let authorizedMemberGuids: string[] | undefined;
+      if (Array.isArray(members)) {
+        authorizedMemberGuids = [entityGuid];
+        try {
+          const boundPair = await appInstance.edm.getEntity(entityGuid);
+          const boundMemberIds = (boundPair.modified as { memberIds?: string[] }).memberIds;
+          if (Array.isArray(boundMemberIds)) {
+            authorizedMemberGuids.push(...boundMemberIds);
+          }
+        } catch {
+          // Bound entity not found — no pre-existing members to authorize.
+        }
+        const authorizedSet = new Set(authorizedMemberGuids);
+        for (const member of members as Array<Record<string, unknown>>) {
+          const memberGuid = typeof member?.guid === "string" ? member.guid : undefined;
+          if (!memberGuid || authorizedSet.has(memberGuid)) {
+            continue;
+          }
+          // Reject only when the GUID names a PRE-EXISTING entity outside scope.
+          let referencesExistingEntity = false;
+          try {
+            await appInstance.edm.getEntity(memberGuid);
+            referencesExistingEntity = true;
+          } catch {
+            referencesExistingEntity = false;
+          }
+          if (referencesExistingEntity) {
+            log.warn(
+              { entityGuid, tenantId, formType },
+              "Self-service submission rejected: member references an entity outside the caller's household",
+            );
+            return res.status(403).json({ error: "Member is not part of your household" });
+          }
+        }
+      }
+
       // Entity update forms route through the full review pipeline
       const requireReview = appInstance.config.selfService?.requireReview;
       if (requireReview && reviewStore) {
@@ -632,8 +678,14 @@ export function createSelfServiceRouter(
         }
       }
 
-      // Apply entity update directly when review is not required
-      await appInstance.edm.submitForm(submission);
+      // Apply entity update directly when review is not required. Pass the
+      // authorized member scope as defense-in-depth so the apply-path guard
+      // (#1134) rejects any out-of-scope member write even if the door check
+      // above is ever bypassed.
+      await appInstance.edm.submitForm(
+        submission,
+        authorizedMemberGuids ? { authorizedMemberGuids } : undefined,
+      );
 
       log.info({ entityGuid, tenantId, formType }, "Self-service form submitted");
 

--- a/packages/datacollect/src/components/EntityDataManager.ts
+++ b/packages/datacollect/src/components/EntityDataManager.ts
@@ -34,7 +34,7 @@ import {
   TokenCredentials,
 } from "../interfaces/types";
 import type { SyncResult } from "../interfaces/adapter";
-import { EventApplierService } from "../services/EventApplierService";
+import { EventApplierService, SubmitFormOptions } from "../services/EventApplierService";
 import { AppError } from "../utils/AppError";
 import { ExternalSyncManager, SyncOptions } from "./ExternalSyncManager";
 import { InternalSyncManager } from "./InternalSyncManager";
@@ -225,8 +225,8 @@ export class EntityDataManager {
    * });
    * ```
    */
-  async submitForm(formData: FormSubmission): Promise<EntityDoc | null> {
-    return await this.eventApplierService.submitForm(formData);
+  async submitForm(formData: FormSubmission, options?: SubmitFormOptions): Promise<EntityDoc | null> {
+    return await this.eventApplierService.submitForm(formData, options);
   }
 
   /**

--- a/packages/datacollect/src/services/EventApplierService.ts
+++ b/packages/datacollect/src/services/EventApplierService.ts
@@ -50,6 +50,29 @@ type ConflictResolutionResult =
   | { resolution: "remote-wins"; baseEntity?: EntityDoc };
 
 /**
+ * Options controlling how an event is applied.
+ *
+ * These carry the CALLER's authorization context into the apply path. They are
+ * NOT persisted on the event — they only gate the write.
+ */
+export interface SubmitFormOptions {
+  /**
+   * When provided, enables RESTRICTED mode for `create-group`/`update-group`
+   * member sub-writes (OpenProject #1134 — horizontal BOLA guard).
+   *
+   * A member entry whose `guid` resolves to a PRE-EXISTING entity is only
+   * accepted when that guid is present in this set (the caller's own group,
+   * plus its current members). Member entries whose guid does not resolve to
+   * any existing entity are always allowed (creating a brand-new member).
+   *
+   * Omit this option entirely for TRUSTED callers (e.g. field-worker
+   * `/api/sync/push`, whose envelope scope is validated separately) — member
+   * writes are then unrestricted, preserving legacy sync behaviour.
+   */
+  authorizedMemberGuids?: string[];
+}
+
+/**
  * Service responsible for applying events (FormSubmissions) to entities in the event sourcing system.
  *
  * The EventApplierService is the core component that transforms events into entity state changes.
@@ -325,7 +348,7 @@ export class EventApplierService {
    * });
    * ```
    */
-  async submitForm(formDataParam: FormSubmission): Promise<EntityDoc | null> {
+  async submitForm(formDataParam: FormSubmission, options?: SubmitFormOptions): Promise<EntityDoc | null> {
     try {
       const formData = cloneDeep(formDataParam);
       validateFormSubmission(formData);
@@ -345,7 +368,7 @@ export class EventApplierService {
 
       const eventGuid = await this.eventStore.saveEvent(formData);
 
-      const updatedEntity = await this.applyEventToEntity(formData, eventGuid, entityPair);
+      const updatedEntity = await this.applyEventToEntity(formData, eventGuid, entityPair, options);
 
       // Enqueue the entity for asynchronous duplicate detection so the write
       // path is never blocked by the O(n) entity scan.
@@ -404,6 +427,7 @@ export class EventApplierService {
     formData: FormSubmission,
     eventGuid: string,
     entityPair: EntityPair | null,
+    options?: SubmitFormOptions,
   ): Promise<EntityDoc | null> {
     const conflictResult = await this.handleIncomingConflict(entityPair, formData, eventGuid);
 
@@ -421,6 +445,7 @@ export class EventApplierService {
         eventGuid,
         baseEntity as GroupDoc | undefined,
         formData,
+        options,
       );
     } else if (formData.type === "create-individual" || formData.type === "update-individual") {
       // log.debug(`Creating or updating individual: ${JSON.stringify(formData)}`);
@@ -702,6 +727,7 @@ export class EventApplierService {
     eventGuid: string,
     existingGroup: GroupDoc | undefined,
     formData: FormSubmission,
+    options?: SubmitFormOptions,
   ): Promise<GroupDoc> {
     // log.debug(
     //   `Creating or updating group: ${JSON.stringify({
@@ -728,6 +754,18 @@ export class EventApplierService {
 
     if (Array.isArray(formData.data?.members)) {
       // log.debug(`Processing members: ${JSON.stringify(formData.data.members)}`);
+      // Horizontal BOLA guard (#1134): when the caller supplies an authorization
+      // scope (RESTRICTED mode — least-trusted callers such as self-service),
+      // a member entry may only write to a PRE-EXISTING entity if that entity's
+      // guid is in the authorized set. The group's own guid and its current
+      // members are always in scope. Unknown guids (new members) are allowed.
+      const restrictMembers = options?.authorizedMemberGuids !== undefined;
+      const authorizedMemberGuids = new Set<string>(options?.authorizedMemberGuids ?? []);
+      authorizedMemberGuids.add(group.guid);
+      for (const existingMemberId of group.memberIds) {
+        authorizedMemberGuids.add(existingMemberId);
+      }
+
       const newMemberIds = await Promise.all(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         formData.data.members.map(async (member: Record<string, any>) => {
@@ -739,6 +777,12 @@ export class EventApplierService {
 
           if (memberData && memberData.type === "group") {
             const existingPair = await this.entityStore.getEntity(memberGuid);
+            if (restrictMembers && existingPair && !authorizedMemberGuids.has(memberGuid)) {
+              throw new AppError(
+                "UNAUTHORIZED_MEMBER",
+                "Member references an entity outside the caller's authorization scope",
+              );
+            }
             const existingGroup = existingPair?.modified as GroupDoc | undefined;
             const subGroup = await this.createOrUpdateGroup(eventGuid, existingGroup, {
               guid: uuidv4(),
@@ -752,6 +796,12 @@ export class EventApplierService {
             return subGroup.guid;
           } else if (memberData) {
             const existingPair = await this.entityStore.getEntity(memberGuid);
+            if (restrictMembers && existingPair && !authorizedMemberGuids.has(memberGuid)) {
+              throw new AppError(
+                "UNAUTHORIZED_MEMBER",
+                "Member references an entity outside the caller's authorization scope",
+              );
+            }
             const existingIndividual = existingPair?.modified as IndividualDoc | undefined;
             const individualDoc = await this.createOrUpdateIndividual(eventGuid, existingIndividual, {
               guid: uuidv4(),

--- a/packages/datacollect/src/services/__tests__/EventApplierService.bola-member-injection.test.ts
+++ b/packages/datacollect/src/services/__tests__/EventApplierService.bola-member-injection.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression tests for OpenProject #1134 — Horizontal BOLA via member-GUID
+ * injection. A least-trusted caller (self-service beneficiary) must not be
+ * able to name an arbitrary existing entity GUID as a "member" of their group
+ * and thereby overwrite that entity's data or attach it to their group.
+ *
+ * The apply-path guard is opt-in via `submitForm(form, { authorizedMemberGuids })`.
+ * When the option is provided (restricted / untrusted mode), member entries that
+ * resolve to a PRE-EXISTING entity must already be in the authorized set.
+ * Unknown GUIDs (brand-new members) are allowed. When the option is omitted
+ * (trusted field-worker sync), no restriction applies — legacy behaviour.
+ */
+
+import "core-js/stable/structured-clone";
+import "fake-indexeddb/auto";
+
+import { v4 as uuidv4 } from "uuid";
+import { EntityStore, EventStore, FormSubmission, GroupDoc, SyncLevel } from "../../interfaces/types";
+import { EntityStoreImpl } from "../../components/EntityStore";
+import { EventStoreImpl } from "../../components/EventStore";
+import { EventApplierService } from "../EventApplierService";
+import { IndexedDbEntityStorageAdapter } from "../../storage/IndexedDbEntityStorageAdapter";
+import { IndexedDbEventStorageAdapter } from "../../storage/IndexedDbEventStorageAdapter";
+
+function makeForm(overrides: Partial<FormSubmission> = {}): FormSubmission {
+  return {
+    guid: uuidv4(),
+    entityGuid: uuidv4(),
+    type: "create-individual",
+    data: { name: "Test Person" },
+    timestamp: new Date().toISOString(),
+    userId: "test-user",
+    syncLevel: SyncLevel.LOCAL,
+    ...overrides,
+  };
+}
+
+describe("EventApplierService – BOLA member-GUID injection guard (#1134)", () => {
+  let entityStore: EntityStore;
+  let eventStore: EventStore;
+  let service: EventApplierService;
+
+  beforeEach(async () => {
+    entityStore = new EntityStoreImpl(new IndexedDbEntityStorageAdapter());
+    await entityStore.initialize();
+    eventStore = new EventStoreImpl(new IndexedDbEventStorageAdapter());
+    await eventStore.initialize();
+    service = new EventApplierService(eventStore, entityStore);
+  });
+
+  afterEach(async () => {
+    await entityStore.clearStore();
+    await eventStore.clearStore();
+  });
+
+  it("rejects a member entry naming a pre-existing victim GUID under the restricted path", async () => {
+    const victimGuid = uuidv4();
+    const attackerGroupGuid = uuidv4();
+
+    // Victim individual (belongs to someone else) with sensitive data.
+    await service.submitForm(
+      makeForm({
+        entityGuid: victimGuid,
+        type: "create-individual",
+        data: { name: "Victim", gender: "female", date_of_birth: "1990-01-15" },
+      }),
+    );
+
+    // Attacker's own group.
+    await service.submitForm(
+      makeForm({
+        entityGuid: attackerGroupGuid,
+        type: "create-group",
+        data: { name: "Attacker Household", members: [] },
+      }),
+    );
+
+    // Attacker updates their group, injecting the victim's GUID as a member with
+    // attacker-chosen data. Restricted mode: only the group's own members are
+    // authorized (empty set here) — the victim is NOT authorized.
+    await expect(
+      service.submitForm(
+        makeForm({
+          entityGuid: attackerGroupGuid,
+          type: "update-group",
+          data: {
+            name: "Attacker Household",
+            members: [{ guid: victimGuid, name: "HACKED", type: "individual" }],
+          },
+        }),
+        { authorizedMemberGuids: [] },
+      ),
+    ).rejects.toThrow();
+
+    // Victim's record must be untouched.
+    const victimPair = await entityStore.getEntity(victimGuid);
+    expect(victimPair!.modified.data.name).toBe("Victim");
+    expect(victimPair!.modified.data.gender).toBe("female");
+    expect(victimPair!.modified.data.date_of_birth).toBe("1990-01-15");
+
+    // Victim must NOT have been attached to the attacker's group.
+    const groupPair = await entityStore.getEntity(attackerGroupGuid);
+    const group = groupPair!.modified as GroupDoc;
+    expect(group.memberIds).not.toContain(victimGuid);
+  });
+
+  it("allows updating a member that is already in the caller's authorized scope", async () => {
+    const memberGuid = uuidv4();
+    const groupGuid = uuidv4();
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: memberGuid,
+        type: "create-individual",
+        data: { name: "Alice", gender: "female" },
+      }),
+    );
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "create-group",
+        data: { name: "Household", members: [{ guid: memberGuid, name: "Alice", type: "individual" }] },
+      }),
+    );
+
+    // Update the group; the member is authorized (already in the group).
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "update-group",
+        data: {
+          name: "Household",
+          members: [{ guid: memberGuid, name: "Alice", phone: "555-1234", type: "individual" }],
+        },
+      }),
+      { authorizedMemberGuids: [memberGuid] },
+    );
+
+    const memberPair = await entityStore.getEntity(memberGuid);
+    expect(memberPair!.modified.data.phone).toBe("555-1234");
+    // Existing data preserved.
+    expect(memberPair!.modified.data.gender).toBe("female");
+  });
+
+  it("allows creating a brand-new member (unknown GUID) under the restricted path", async () => {
+    const groupGuid = uuidv4();
+    const newMemberGuid = uuidv4();
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "create-group",
+        data: { name: "Household", members: [] },
+      }),
+    );
+
+    // New member GUID does not resolve to any existing entity → allowed.
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "update-group",
+        data: {
+          name: "Household",
+          members: [{ guid: newMemberGuid, name: "Newborn", type: "individual" }],
+        },
+      }),
+      { authorizedMemberGuids: [] },
+    );
+
+    const groupPair = await entityStore.getEntity(groupGuid);
+    const group = groupPair!.modified as GroupDoc;
+    expect(group.memberIds).toContain(newMemberGuid);
+    const memberPair = await entityStore.getEntity(newMemberGuid);
+    expect(memberPair!.modified.data.name).toBe("Newborn");
+  });
+
+  it("does NOT restrict member writes when no authorization scope is given (trusted sync)", async () => {
+    // Field-worker sync path: submitForm without options must keep legacy
+    // behaviour so legitimate group creation with members is never broken.
+    const memberGuid = uuidv4();
+    const groupGuid = uuidv4();
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: memberGuid,
+        type: "create-individual",
+        data: { name: "Bob" },
+      }),
+    );
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "create-group",
+        data: {
+          name: "Household",
+          members: [{ guid: memberGuid, name: "Bob", type: "individual" }],
+        },
+      }),
+    );
+
+    const groupPair = await entityStore.getEntity(groupGuid);
+    const group = groupPair!.modified as GroupDoc;
+    expect(group.memberIds).toContain(memberGuid);
+  });
+});


### PR DESCRIPTION
Fixes OpenProject **#1134** — Horizontal BOLA: member-GUID injection lets a user write to arbitrary same-tenant entities.

## Vulnerability

`EventApplierService.createOrUpdateGroup` iterated the client-supplied `formData.data.members[]`, read each `member.guid` verbatim, loaded that entity, merged attacker-chosen `memberData` into it, and appended the GUID to `group.memberIds` — with **no authorization check on the member GUID**. Via `POST /api/auth/self-service/submit` (least-trusted beneficiaries), an attacker could name a victim's entity GUID as a "member", overwriting the victim's record and attaching them to the attacker's group. The envelope `entityGuid` is bound to the caller, but the member sub-writes escaped that binding.

## Fix (defense-in-depth, two layers)

1. **`packages/datacollect/src/services/EventApplierService.ts`** — opt-in `SubmitFormOptions { authorizedMemberGuids?: string[] }` threaded `submitForm` → `applyEventToEntity` → `createOrUpdateGroup`. In **restricted mode**, a member entry whose GUID resolves to a pre-existing entity must be in the authorized set (group GUID + current `memberIds` + caller-supplied list), else `AppError("UNAUTHORIZED_MEMBER")`. Brand-new members (no pre-existing entity) are still allowed. `EntityDataManager.submitForm` forwards the option.
2. **`packages/backend/src/routes/selfServiceRoutes.ts`** — at the self-service door, computes the caller's authorized set (bound entity + its current members) and **403**s any member entry naming a pre-existing entity outside it, before both the review-pipeline and direct-apply branches. Direct apply also passes `authorizedMemberGuids`. Logs scoped to the caller's own ids — no victim GUID/data leaked.

**Legitimate field-worker sync is unaffected:** `/api/sync/push` → `submitFormBatch` → `submitForm` passes no options → unrestricted (legacy behavior).

## Tests
- `EventApplierService.bola-member-injection.test.ts` (fake-indexeddb, no PG): rejects victim-GUID injection; allows in-scope update; allows new-member creation; unrestricted trusted path unaffected. (Watched RED first.)
- `selfServiceEndpoints.test.ts` +3: attack → 403 and `submitForm` never called; in-household update → 200 with scope option; new member → 200.

## Verification
core `test` 797 passed / 56 skipped; backend guard tests 3 passed; type-check + lint clean (datacollect + backend). Postgres-only suites skipped in the dev env (new backend tests run without PG).

## Known follow-up (out of scope)
`/api/sync/push` member sub-writes are still not scope-guarded — a *bounded* field-worker could inject an out-of-scope member GUID (`validateEventScope` checks only the envelope `entityGuid`, not `data.members[]`). Lower priority; recommend a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)