### PR TITLE
fix(security): enforce tenant-scoped role on review approve/reject

### DIFF
--- a/packages/backend/src/__tests__/rbac.test.ts
+++ b/packages/backend/src/__tests__/rbac.test.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { SystemRole } from "@idpass/data-collect-core";
-import { requireRole, requireAction } from "../middlewares/rbac";
-import { AuthenticatedRequest } from "../middlewares/authentication";
+import { requireRole, requireAction, resolveRoleInTenant, canPerformActionInTenant } from "../middlewares/rbac";
+import { AuthenticatedRequest, DecodedPayload } from "../middlewares/authentication";
 import { Role } from "../types";
 
 const JWT_SECRET = "test-rbac-secret";
@@ -222,6 +222,89 @@ describe("RBAC Middleware", () => {
 
       expect(res.status).toHaveBeenCalledWith(403);
       expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolveRoleInTenant()", () => {
+    const user = (
+      roleAssignments: Array<{ tenantId: string; role: string }>,
+      role: Role = Role.USER,
+    ): DecodedPayload => ({
+      id: "user-1",
+      email: "test@example.com",
+      role,
+      tenantIds: roleAssignments.map((a) => a.tenantId),
+      roleAssignments,
+    });
+
+    it("returns the role the user holds in the requested tenant", () => {
+      const u = user([
+        { tenantId: "tenant-a", role: SystemRole.SUPERVISOR },
+        { tenantId: "tenant-b", role: SystemRole.VIEWER },
+      ]);
+      expect(resolveRoleInTenant(u, "tenant-b")).toBe(SystemRole.VIEWER);
+    });
+
+    it("does NOT leak a role from another tenant (global max is ignored)", () => {
+      const u = user([
+        { tenantId: "tenant-a", role: SystemRole.SUPERVISOR },
+        { tenantId: "tenant-b", role: SystemRole.VIEWER },
+      ]);
+      // The user is a supervisor in tenant-a, but only a viewer in tenant-b.
+      expect(resolveRoleInTenant(u, "tenant-b")).not.toBe(SystemRole.SUPERVISOR);
+    });
+
+    it("returns the highest role when the user has several assignments in one tenant", () => {
+      const u = user([
+        { tenantId: "tenant-a", role: SystemRole.VIEWER },
+        { tenantId: "tenant-a", role: SystemRole.SUPERVISOR },
+      ]);
+      expect(resolveRoleInTenant(u, "tenant-a")).toBe(SystemRole.SUPERVISOR);
+    });
+
+    it("returns null when the user has no assignment in the tenant", () => {
+      const u = user([{ tenantId: "tenant-a", role: SystemRole.SUPERVISOR }]);
+      expect(resolveRoleInTenant(u, "tenant-b")).toBeNull();
+    });
+
+    it("treats a legacy admin as system-admin in every tenant", () => {
+      const u = user([], Role.ADMIN);
+      expect(resolveRoleInTenant(u, "any-tenant")).toBe(SystemRole.SYSTEM_ADMIN);
+    });
+
+    it("returns null for an undefined user", () => {
+      expect(resolveRoleInTenant(undefined, "tenant-a")).toBeNull();
+    });
+  });
+
+  describe("canPerformActionInTenant()", () => {
+    const user = (
+      roleAssignments: Array<{ tenantId: string; role: string }>,
+    ): DecodedPayload => ({
+      id: "user-1",
+      email: "test@example.com",
+      role: Role.USER,
+      tenantIds: roleAssignments.map((a) => a.tenantId),
+      roleAssignments,
+    });
+
+    it("allows approve when the user is supervisor IN that tenant", () => {
+      const u = user([{ tenantId: "tenant-a", role: SystemRole.SUPERVISOR }]);
+      expect(canPerformActionInTenant(u, "tenant-a", "approve")).toBe(true);
+    });
+
+    it("denies approve when the user only has approve rights in ANOTHER tenant", () => {
+      const u = user([
+        { tenantId: "tenant-a", role: SystemRole.SUPERVISOR },
+        { tenantId: "tenant-b", role: SystemRole.VIEWER },
+      ]);
+      // This is the #1135 vulnerability: global max would say yes, per-tenant says no.
+      expect(canPerformActionInTenant(u, "tenant-b", "approve")).toBe(false);
+    });
+
+    it("denies approve when the user is not a member of the tenant at all", () => {
+      const u = user([{ tenantId: "tenant-a", role: SystemRole.SUPERVISOR }]);
+      expect(canPerformActionInTenant(u, "tenant-b", "approve")).toBe(false);
     });
   });
 });

--- a/packages/backend/src/__tests__/reviewRoutes.test.ts
+++ b/packages/backend/src/__tests__/reviewRoutes.test.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 
 import axios from "axios";
+import jwt from "jsonwebtoken";
 import { get } from "lodash";
 import request from "supertest";
 import { v4 as uuidv4 } from "uuid";
@@ -443,6 +444,196 @@ describeIfPostgres("Review Routes", () => {
 
       expect(response.status).toBe(200);
       expect(response.body.status).toBe("success");
+    });
+  });
+
+  // Regression guard for OpenProject #1135 — Cross-tenant review approval via
+  // global role aggregation. A user who is an approver in one tenant but only a
+  // low-privileged member (viewer) in another must NOT be able to approve/reject
+  // reviews in the tenant where they lack the approve right. Approval applies a
+  // FormSubmission to the tenant's entities, so this is a cross-tenant data write.
+  describe("Cross-tenant review approval (#1135)", () => {
+    const password = "Attacker1@";
+    const OTHER_TENANT = "other-tenant-approver";
+    const SECOND_TENANT = "review-test-config-b";
+
+    // Provision a real DB user (so verifyRoleFromDatabase resolves their
+    // authoritative role assignments) and mint a matching JWT directly. We sign
+    // the token instead of calling /login because the login endpoint is rate
+    // limited per-process; the token's tenantIds are what validateTenantAccess
+    // reads (it runs before the DB refresh), and roleAssignments are reloaded
+    // from the DB downstream, so the two stay consistent.
+    const provisionUser = async (
+      email: string,
+      tenantIds: string[],
+      roleAssignments: Array<{ tenantId: string; role: string }>,
+    ): Promise<string> => {
+      const res = await request(requireApp().httpServer)
+        .post("/api/users")
+        .send({ email, password, role: "USER", tenantIds, roleAssignments })
+        .set("Authorization", `Bearer ${adminToken}`);
+      expect(res.status).toBe(201);
+      return jwt.sign(
+        { id: email, email, role: "USER", tenantIds, roleAssignments },
+        process.env.JWT_SECRET as string,
+        { expiresIn: "1h" },
+      );
+    };
+
+    const configureInternalReview = async (tenantId: string): Promise<void> => {
+      const res = await request(requireApp().httpServer)
+        .put(`/api/reviews/config/${tenantId}/create-individual`)
+        .send({ policy: "internal-review", requiredRole: "supervisor" })
+        .set("Authorization", `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+    };
+
+    const submitPendingReview = async (tenantId: string, entityGuid: string): Promise<string> => {
+      const res = await request(requireApp().httpServer)
+        .post("/api/reviews/submit")
+        .send({
+          tenantId,
+          formData: {
+            guid: uuidv4(),
+            entityGuid,
+            type: "create-individual",
+            data: { name: "Cross Tenant Person" },
+            timestamp: new Date().toISOString(),
+            userId: "test-user",
+            syncLevel: SyncLevel.LOCAL,
+          },
+        })
+        .set("Authorization", `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body.review.status).toBe("pending");
+      return res.body.review.id;
+    };
+
+    it("returns 403 and does NOT apply when an approver-in-A/viewer-in-B user approves B's review", async () => {
+      const currentApp = requireApp();
+      await configureInternalReview(mockConfig.id);
+      const entityGuid = uuidv4();
+      const reviewId = await submitPendingReview(mockConfig.id, entityGuid);
+
+      // Approver in OTHER_TENANT (drives the global-max role), viewer in the
+      // tenant that actually owns the review.
+      const token = await provisionUser(
+        "attacker-approve@review-test.com",
+        [OTHER_TENANT, mockConfig.id, "default"],
+        [
+          { tenantId: OTHER_TENANT, role: "supervisor" },
+          { tenantId: mockConfig.id, role: "viewer" },
+        ],
+      );
+
+      const res = await request(currentApp.httpServer)
+        .post(`/api/reviews/${reviewId}/approve`)
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+
+      // The review must NOT have been applied to the tenant's entities.
+      const appInstance = await currentApp.appInstanceStore.getAppInstance(mockConfig.id);
+      await expect(appInstance?.edm.getEntity(entityGuid)).rejects.toThrow(/not found/);
+    });
+
+    it("returns 403 and does NOT reject when an approver-in-A/viewer-in-B user rejects B's review", async () => {
+      const currentApp = requireApp();
+      await configureInternalReview(mockConfig.id);
+      const entityGuid = uuidv4();
+      const reviewId = await submitPendingReview(mockConfig.id, entityGuid);
+
+      const token = await provisionUser(
+        "attacker-reject@review-test.com",
+        [OTHER_TENANT, mockConfig.id, "default"],
+        [
+          { tenantId: OTHER_TENANT, role: "supervisor" },
+          { tenantId: mockConfig.id, role: "viewer" },
+        ],
+      );
+
+      const res = await request(currentApp.httpServer)
+        .post(`/api/reviews/${reviewId}/reject`)
+        .send({ reason: "malicious cross-tenant reject" })
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+
+      // The review must still be pending in the database (not rejected).
+      const listResponse = await request(currentApp.httpServer)
+        .get(`/api/reviews?tenantId=${mockConfig.id}&status=pending`)
+        .set("Authorization", `Bearer ${adminToken}`);
+      expect(listResponse.body.reviews.map((r: { id: string }) => r.id)).toContain(reviewId);
+    });
+
+    it("bulk-approve only applies reviews in tenants where the user has the approve right", async () => {
+      const currentApp = requireApp();
+
+      // Second tenant where the user IS an approver (supervisor).
+      await currentApp.appConfigStore.saveConfig({ ...mockConfig, id: SECOND_TENANT });
+      await currentApp.appInstanceStore.createAppInstance(SECOND_TENANT);
+
+      await configureInternalReview(mockConfig.id);
+      await configureInternalReview(SECOND_TENANT);
+
+      const unauthorizedEntityGuid = uuidv4();
+      const authorizedEntityGuid = uuidv4();
+      const unauthorizedReviewId = await submitPendingReview(mockConfig.id, unauthorizedEntityGuid);
+      const authorizedReviewId = await submitPendingReview(SECOND_TENANT, authorizedEntityGuid);
+
+      // Supervisor in SECOND_TENANT (authorized), viewer in mockConfig (not authorized).
+      const token = await provisionUser(
+        "mixed-bulk@review-test.com",
+        [SECOND_TENANT, mockConfig.id, "default"],
+        [
+          { tenantId: SECOND_TENANT, role: "supervisor" },
+          { tenantId: mockConfig.id, role: "viewer" },
+        ],
+      );
+
+      const res = await request(currentApp.httpServer)
+        .post("/api/reviews/bulk-approve")
+        .send({ reviewIds: [unauthorizedReviewId, authorizedReviewId] })
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.approved).toBe(1);
+
+      // Authorized tenant's review WAS applied.
+      const authorizedInstance = await currentApp.appInstanceStore.getAppInstance(SECOND_TENANT);
+      const authorizedEntity = await authorizedInstance?.edm.getEntity(authorizedEntityGuid);
+      expect(authorizedEntity).not.toBeNull();
+
+      // Unauthorized tenant's review was NOT applied.
+      const unauthorizedInstance = await currentApp.appInstanceStore.getAppInstance(mockConfig.id);
+      await expect(unauthorizedInstance?.edm.getEntity(unauthorizedEntityGuid)).rejects.toThrow(
+        /not found/,
+      );
+    });
+
+    it("still allows a legitimate approver (approve right in the review's tenant) to approve", async () => {
+      const currentApp = requireApp();
+      await configureInternalReview(mockConfig.id);
+      const entityGuid = uuidv4();
+      const reviewId = await submitPendingReview(mockConfig.id, entityGuid);
+
+      const token = await provisionUser(
+        "legit-approver@review-test.com",
+        [mockConfig.id, "default"],
+        [{ tenantId: mockConfig.id, role: "supervisor" }],
+      );
+
+      const res = await request(currentApp.httpServer)
+        .post(`/api/reviews/${reviewId}/approve`)
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.review.status).toBe("approved");
+
+      const appInstance = await currentApp.appInstanceStore.getAppInstance(mockConfig.id);
+      const entity = await appInstance?.edm.getEntity(entityGuid);
+      expect(entity).not.toBeNull();
+      expect(entity?.modified.data.name).toBe("Cross Tenant Person");
     });
   });
 });

--- a/packages/backend/src/__tests__/security-tenant-isolation.test.ts
+++ b/packages/backend/src/__tests__/security-tenant-isolation.test.ts
@@ -231,25 +231,15 @@ describeIfPostgres("SECURITY: Tenant isolation vulnerabilities", () => {
     });
   });
 
-  describe("Review cross-tenant approval", () => {
-    test("review approve endpoint iterates ALL tenants without filtering by user access", () => {
-      // This test verifies the vulnerability at the code structure level.
-      // The reviewRoutes.ts approve endpoint (line 164) iterates over ALL
-      // entries in reviewServiceCache without checking user.tenantIds:
-      //
-      //   for (const [tenantId, reviewService] of reviewServiceCache) {
-      //     const found = reviewService.getReviewById(id);
-      //     if (found) {
-      //       review = await reviewService.approve(id, user.email);
-      //       break;
-      //     }
-      //   }
-      //
-      // There is no check like: if (!user.tenantIds.includes(tenantId)) continue;
-      //
-      // The dynamic import of ReviewService fails in test (needs --experimental-vm-modules),
-      // so we verify the vulnerability by inspecting the route handler source.
-
+  describe("Review cross-tenant approval (#1135)", () => {
+    // These tests verify the remediation at the code-structure level. The
+    // reviewRoutes.ts approve/reject handlers iterate over reviewServiceCache to
+    // locate a review, then must enforce the approve right WITHIN the review's
+    // owning tenant — not the global-max role. The remediation resolves that via
+    // canPerformActionInTenant(user, tenantId, "approve"). Behavioural coverage
+    // (real 403 + non-application) lives in reviewRoutes.test.ts; these guard the
+    // handler wiring against a regression to the global-role gate.
+    test("review approve endpoint enforces the approve right within the review's tenant", () => {
       const reviewRoutesSource = fs.readFileSync(
         path.join(__dirname, "..", "routes", "reviewRoutes.ts"),
         "utf8",
@@ -260,14 +250,14 @@ describeIfPostgres("SECURITY: Tenant isolation vulnerabilities", () => {
         reviewRoutesSource.indexOf("/:id/reject"),
       );
 
-      // EXPECTED (secure): The approve handler checks user.tenantIds or user.role
-      // before operating on a review from a different tenant
-      // ACTUAL (vulnerable): No tenantId check -- the loop iterates ALL cached
-      // review services regardless of user access
-      expect(approveSection).toMatch(/tenantIds|user\.tenantId/);
+      // EXPECTED (secure): the approve handler performs a tenant-scoped
+      // authorization check before applying a review from a given tenant.
+      // ACTUAL (vulnerable): no per-tenant check -- the loop approves any review
+      // found in any cached tenant using the user's global-max role.
+      expect(approveSection).toMatch(/canPerformActionInTenant\([^)]*"approve"\)/);
     });
 
-    test("review reject endpoint iterates ALL tenants without filtering by user access", () => {
+    test("review reject endpoint enforces the approve right within the review's tenant", () => {
       const reviewRoutesSource = fs.readFileSync(
         path.join(__dirname, "..", "routes", "reviewRoutes.ts"),
         "utf8",
@@ -275,14 +265,12 @@ describeIfPostgres("SECURITY: Tenant isolation vulnerabilities", () => {
 
       const rejectSection = reviewRoutesSource.substring(
         reviewRoutesSource.indexOf("/:id/reject"),
-        reviewRoutesSource.indexOf("// List all reviews") ||
-          reviewRoutesSource.indexOf("// Get pending reviews") ||
-          reviewRoutesSource.length,
+        reviewRoutesSource.indexOf("/bulk-approve"),
       );
 
-      // EXPECTED (secure): The reject handler checks tenantIds
-      // ACTUAL (vulnerable): No tenantId check in the loop
-      expect(rejectSection).toMatch(/tenantIds|user\.tenantId/);
+      // EXPECTED (secure): the reject handler performs a tenant-scoped check.
+      // ACTUAL (vulnerable): no per-tenant check in the loop.
+      expect(rejectSection).toMatch(/canPerformActionInTenant\([^)]*"approve"\)/);
     });
   });
 });

--- a/packages/backend/src/middlewares/rbac.ts
+++ b/packages/backend/src/middlewares/rbac.ts
@@ -63,6 +63,75 @@ function getEffectiveRole(req: Request): SystemRole | null {
 }
 
 /**
+ * Resolve the user's highest role WITHIN a specific tenant.
+ *
+ * Unlike {@link getEffectiveRole}, which returns the global maximum role across
+ * ALL tenant assignments, this scopes the role to a single tenant. Use this for
+ * any per-tenant authorization decision (e.g. approving a review that belongs to
+ * a particular tenant) so that a high privilege in tenant A never leaks into
+ * tenant B. See OpenProject #1135.
+ *
+ * Legacy admin users (Role.ADMIN) are treated as system-admin in every tenant.
+ *
+ * @param user The decoded JWT payload (or undefined).
+ * @param tenantId The tenant to resolve the role for.
+ * @returns The highest SystemRole the user holds in that tenant, or null.
+ */
+export function resolveRoleInTenant(
+  user: DecodedPayload | undefined,
+  tenantId: string,
+): SystemRole | null {
+  if (!user) {
+    return null;
+  }
+
+  // Legacy admin users bypass RBAC entirely.
+  if (user.role === Role.ADMIN) {
+    return SystemRole.SYSTEM_ADMIN;
+  }
+
+  const roleAssignments = user.roleAssignments ?? [];
+  let highestRole: SystemRole | null = null;
+  let highestLevel = -1;
+
+  for (const assignment of roleAssignments) {
+    if (assignment.tenantId !== tenantId) {
+      continue;
+    }
+    const level = ROLE_HIERARCHY[assignment.role] ?? -1;
+    if (level > highestLevel) {
+      highestLevel = level;
+      highestRole = assignment.role as SystemRole;
+    }
+  }
+
+  return highestRole;
+}
+
+/**
+ * Check whether the user can perform an action WITHIN a specific tenant.
+ *
+ * Combines {@link resolveRoleInTenant} with the RBAC action map so callers get a
+ * tenant-scoped permission check that does not aggregate roles across tenants.
+ *
+ * @param user The decoded JWT payload (or undefined).
+ * @param tenantId The tenant the action targets.
+ * @param action The action being attempted.
+ * @returns true only if the user's role in that tenant permits the action.
+ */
+export function canPerformActionInTenant(
+  user: DecodedPayload | undefined,
+  tenantId: string,
+  action: RbacAction,
+): boolean {
+  const role = resolveRoleInTenant(user, tenantId);
+  if (!role) {
+    return false;
+  }
+  return rbacService.canPerformAction(role, action);
+}
+
+/**
  * Middleware that enforces a minimum role requirement.
  *
  * Checks if the authenticated user's highest role meets or exceeds

--- a/packages/backend/src/routes/reviewRoutes.ts
+++ b/packages/backend/src/routes/reviewRoutes.ts
@@ -20,10 +20,10 @@
 import { Router } from "express";
 import { FormSubmission, ReviewService, EventApplierService } from "@idpass/data-collect-core";
 import { authenticateJWT, AuthenticatedRequest, validateTenantAccess } from "../middlewares/authentication";
-import { requireAction, verifyRoleFromDatabase } from "../middlewares/rbac";
+import { requireAction, verifyRoleFromDatabase, canPerformActionInTenant } from "../middlewares/rbac";
 import { asyncHandler } from "../middlewares/errorHandlers";
 import { stripServerManagedEventFields } from "../utils/eventSanitize";
-import { AppInstanceStore, Role, UserStore } from "../types";
+import { AppInstanceStore, UserStore } from "../types";
 import { ReviewStore } from "../stores/ReviewStore";
 import { createLogger } from "../utils/logger";
 
@@ -182,16 +182,27 @@ export function createReviewRoutes(appInstanceStore: AppInstanceStore, reviewSto
       const { id } = req.params;
       const user = (req as AuthenticatedRequest).user;
 
-      // Find the review across tenant review services the user has access to
-      const userTenantIds = user.tenantIds ?? [];
+      // Resolve the review's owning tenant FIRST, then enforce the approve right
+      // WITHIN that tenant. The requireAction("approve") gate above uses the
+      // user's global-max role, which is not tenant-scoped: a user who is an
+      // approver in tenant A but a viewer in tenant B would otherwise pass it and
+      // approve B's review, applying a FormSubmission to B's entities (#1135).
       let review = null;
+      let forbidden = false;
       for (const [tenantId, reviewService] of reviewServiceCache) {
-        if (user.role !== Role.ADMIN && !userTenantIds.includes(tenantId)) continue;
         const found = reviewService.getReviewById(id);
-        if (found) {
-          review = await reviewService.approve(id, user.email);
+        if (!found) continue;
+        if (!canPerformActionInTenant(user, tenantId, "approve")) {
+          forbidden = true;
+          log.warn({ userId: user.id, tenantId }, "Denied review approval: no approve right in tenant");
           break;
         }
+        review = await reviewService.approve(id, user.email);
+        break;
+      }
+
+      if (forbidden) {
+        return res.status(403).json({ error: "Forbidden: Insufficient permission for this tenant" });
       }
 
       if (!review) {
@@ -225,15 +236,24 @@ export function createReviewRoutes(appInstanceStore: AppInstanceStore, reviewSto
         return res.status(400).json({ error: "Missing rejection reason" });
       }
 
-      const userTenantIds = user.tenantIds ?? [];
+      // Same tenant-scoped enforcement as /approve — reject also resolves the
+      // review's owning tenant and requires the approve right within it (#1135).
       let review = null;
+      let forbidden = false;
       for (const [tenantId, reviewService] of reviewServiceCache) {
-        if (user.role !== Role.ADMIN && !userTenantIds.includes(tenantId)) continue;
         const found = reviewService.getReviewById(id);
-        if (found) {
-          review = await reviewService.reject(id, user.email, reason);
+        if (!found) continue;
+        if (!canPerformActionInTenant(user, tenantId, "approve")) {
+          forbidden = true;
+          log.warn({ userId: user.id, tenantId }, "Denied review rejection: no approve right in tenant");
           break;
         }
+        review = await reviewService.reject(id, user.email, reason);
+        break;
+      }
+
+      if (forbidden) {
+        return res.status(403).json({ error: "Forbidden: Insufficient permission for this tenant" });
       }
 
       if (!review) {
@@ -271,21 +291,42 @@ export function createReviewRoutes(appInstanceStore: AppInstanceStore, reviewSto
       let totalFailed = 0;
       const allErrors: Array<{ reviewId: string; error: string }> = [];
 
-      // Group review IDs by their tenant's review service, filtered by user access
-      const userTenantIds = user.tenantIds ?? [];
+      // Per-tenant authorization (#1135). A bulk call may span several tenants;
+      // the user is resolved against EACH review's owning tenant independently.
+      // Semantics: approve only the reviews in tenants where the user holds the
+      // approve right; silently skip reviews in tenants where they do not. The
+      // batch is only rejected (403) when the user is unauthorized for EVERY
+      // tenant that owns a matched review — otherwise partial success is returned.
+      let authorizedTenantMatched = false;
+      let unauthorizedTenantMatched = false;
       for (const [tenantId, reviewService] of reviewServiceCache) {
-        if (user.role !== Role.ADMIN && !userTenantIds.includes(tenantId)) continue;
         const tenantReviewIds = reviewIds.filter((rid: string) => {
           const review = reviewService.getReviewById(rid);
           return review !== null;
         });
 
-        if (tenantReviewIds.length > 0) {
-          const result = await reviewService.bulkApprove(tenantReviewIds, user.email);
-          totalApproved += result.approved;
-          totalFailed += result.failed;
-          allErrors.push(...result.errors);
+        if (tenantReviewIds.length === 0) continue;
+
+        if (!canPerformActionInTenant(user, tenantId, "approve")) {
+          unauthorizedTenantMatched = true;
+          log.warn(
+            { userId: user.id, tenantId, count: tenantReviewIds.length },
+            "Skipped bulk-approve for tenant: no approve right",
+          );
+          continue;
         }
+
+        authorizedTenantMatched = true;
+        const result = await reviewService.bulkApprove(tenantReviewIds, user.email);
+        totalApproved += result.approved;
+        totalFailed += result.failed;
+        allErrors.push(...result.errors);
+      }
+
+      if (!authorizedTenantMatched && unauthorizedTenantMatched) {
+        return res
+          .status(403)
+          .json({ error: "Forbidden: Insufficient permission for the requested tenant(s)" });
       }
 
       res.json({ approved: totalApproved, failed: totalFailed, errors: allErrors });


### PR DESCRIPTION
Hardens authorization on review approve/reject/bulk-approve so the action is checked against the role the caller holds **within the review's owning tenant**, rather than their highest role across all tenants.

## Change
- `packages/backend/src/middlewares/rbac.ts` — added tenant-aware helpers `resolveRoleInTenant(user, tenantId)` and `canPerformActionInTenant(user, tenantId, action)`.
- `packages/backend/src/routes/reviewRoutes.ts` — approve/reject/bulk-approve resolve the review's owning tenant and require `canPerformActionInTenant(user, tenantId, "approve")` before applying (else 403).
- bulk-approve: per-tenant resolution — apply only reviews in tenants where the caller is authorized (partial success); 403 the whole batch only when unauthorized for every owning tenant.

## Tests (TDD)
- `rbac.test.ts` +9 unit tests for the new helpers.
- `reviewRoutes.test.ts` +4 integration tests for the tenant-scoped path (cross-tenant denied, same-tenant regression).
- `security-tenant-isolation.test.ts` — replaced two brittle source-grep guards with a real remediation marker.

## Verification (Postgres via docker-compose.test.yaml)
Full backend suite 43 suites / 409 tests passed; backend type-check + lint clean.

## Known follow-up (out of scope)
Two more review endpoints share the same global-role authorization pattern and are tenant-scopable with the new helper. Tracked separately.
