### PR TITLE
fix(security): guard sync-push member sub-writes against caller scope

### DIFF
--- a/packages/backend/src/__tests__/syncRoute.memberScope.test.ts
+++ b/packages/backend/src/__tests__/syncRoute.memberScope.test.ts
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * OpenProject #1145 — sync-push member-GUID injection guard (follow-up to
+ * #1134). A bounded field worker whose events pass the envelope scope check
+ * on `/api/sync/push` must NOT be able to smuggle an out-of-scope pre-existing
+ * entity GUID into a group event's `data.members[]` and thereby overwrite that
+ * victim's record or attach it to their group. In-scope members and brand-new
+ * members must still apply. An unbounded/admin caller is unrestricted.
+ */
+
+import "dotenv/config";
+
+import axios from "axios";
+import { get } from "lodash";
+import request from "supertest";
+import { v4 as uuidv4 } from "uuid";
+import { FormSubmission, SyncLevel } from "@idpass/data-collect-core";
+import { run } from "../syncServer";
+import { SyncServerInstance, AppConfig } from "../types";
+import { describeIfPostgres, ensureDatabaseExists, getConnectionString } from "./helpers/testDb";
+
+const baseConfig: AppConfig = {
+  id: "member-scope-config",
+  artifactId: "member-scope-artifact",
+  name: "Member Scope Config",
+  description: "Member Scope Config Description",
+  version: "1.0.0",
+  url: "http://localhost:3000",
+  entityForms: [
+    {
+      id: "mock-entityform",
+      title: "Mock Entityform",
+      formio: { components: [] },
+      name: "Mock Entityform",
+      dependsOn: "",
+    },
+  ],
+};
+
+const postgresUrl = getConnectionString("sync_route_member_scope");
+const DEVICE_ID = "device-member-scope-1";
+
+describeIfPostgres("Sync route — /push member sub-write scope guard (#1145)", () => {
+  let app: SyncServerInstance | null = null;
+  let baseUrl = "";
+  let adminToken = "";
+
+  const requireApp = (): SyncServerInstance => {
+    if (!app) throw new Error("Sync server instance is not initialized");
+    return app;
+  };
+
+  const resolveBaseUrl = (instance: SyncServerInstance): string => {
+    const address = instance.httpServer.address();
+    if (typeof address === "object" && address && address.port) {
+      return `http://127.0.0.1:${address.port}`;
+    }
+    return "http://127.0.0.1";
+  };
+
+  beforeAll(async () => {
+    if (!process.env.JWT_SECRET) {
+      process.env.JWT_SECRET = "test-secret";
+    }
+    await ensureDatabaseExists(postgresUrl);
+  });
+
+  beforeEach(async () => {
+    if (app) {
+      await requireApp().closeConnection();
+    }
+    app = await run({
+      port: 0,
+      adminPassword: "admin1@",
+      adminEmail: "admin@example.com",
+      postgresUrl: postgresUrl as string,
+    });
+    const currentApp = requireApp();
+    baseUrl = resolveBaseUrl(currentApp);
+    if (!adminToken) {
+      const loginRes = await axios.post(baseUrl + "/api/users/login", {
+        email: "admin@example.com",
+        password: "admin1@",
+      });
+      adminToken = get(loginRes.data, "token") ?? "";
+    }
+  });
+
+  afterEach(async () => {
+    if (!app) return;
+    const currentApp = requireApp();
+    await currentApp.telemetryStore?.whenIdle();
+    await currentApp.clearStore();
+    await currentApp.closeConnection();
+    app = null;
+  });
+
+  test("scoped {areaIds:['A1']}: group event injecting an out-of-scope pre-existing member is rejected; victim untouched", async () => {
+    const currentApp = requireApp();
+    const scopedConfig: AppConfig = { ...baseConfig, syncScope: { areaIds: ["A1"] } };
+    await currentApp.appConfigStore.saveConfig(scopedConfig);
+    await currentApp.appInstanceStore.createAppInstance(scopedConfig.id);
+    const manager = (await currentApp.appInstanceStore.getAppInstance(scopedConfig.id))!.edm;
+
+    // Victim lives in area A2 (outside the field worker's A1 scope). Seed via
+    // the in-process manager so it bypasses the HTTP scope check.
+    const victimGuid = uuidv4();
+    await manager.submitForm({
+      guid: uuidv4(),
+      entityGuid: victimGuid,
+      type: "create-individual",
+      data: { name: "Victim", gender: "female", date_of_birth: "1990-01-15", area_id: "A2" },
+      timestamp: "2023-01-01T00:00:00.000Z",
+      userId: "seed",
+      syncLevel: SyncLevel.LOCAL,
+    });
+
+    // Field worker's own group in area A1 (also seeded in-process, empty).
+    const groupGuid = uuidv4();
+    await manager.submitForm({
+      guid: uuidv4(),
+      entityGuid: groupGuid,
+      type: "create-group",
+      data: { name: "Field Worker Household", area_id: "A1", members: [] },
+      timestamp: "2023-01-02T00:00:00.000Z",
+      userId: "seed",
+      syncLevel: SyncLevel.LOCAL,
+    });
+
+    // Push an update-group whose ENVELOPE (the A1 group) passes scope, but
+    // whose members[] names the out-of-scope victim with attacker data.
+    const evilEvent: FormSubmission = {
+      guid: uuidv4(),
+      entityGuid: groupGuid,
+      type: "update-group",
+      data: {
+        name: "Field Worker Household",
+        area_id: "A1",
+        members: [{ guid: victimGuid, name: "HACKED", type: "individual" }],
+      },
+      timestamp: "2023-02-01T00:00:00.000Z",
+      userId: "field-worker",
+      syncLevel: SyncLevel.LOCAL,
+    };
+
+    const response = await request(currentApp.httpServer)
+      .post("/api/sync/push")
+      .send({ events: [evilEvent], configId: scopedConfig.id })
+      .set("Authorization", `Bearer ${adminToken}`)
+      .set("X-Device-Id", DEVICE_ID);
+
+    // The whole (single-event transactional) batch fails — nothing applied.
+    expect(response.status).toBe(422);
+    expect(response.body.applied).toBe(0);
+
+    // Victim's record must be untouched.
+    const victimPair = await manager.getEntity(victimGuid);
+    expect(victimPair.modified.data.name).toBe("Victim");
+    expect(victimPair.modified.data.gender).toBe("female");
+    expect(victimPair.modified.data.date_of_birth).toBe("1990-01-15");
+
+    // Victim must NOT have been attached to the field worker's group.
+    const groupPair = await manager.getEntity(groupGuid);
+    expect((groupPair.modified as { memberIds: string[] }).memberIds).not.toContain(victimGuid);
+  });
+
+  test("scoped {areaIds:['A1']}: group event with an in-scope pre-existing member applies", async () => {
+    const currentApp = requireApp();
+    const scopedConfig: AppConfig = { ...baseConfig, syncScope: { areaIds: ["A1"] } };
+    await currentApp.appConfigStore.saveConfig(scopedConfig);
+    await currentApp.appInstanceStore.createAppInstance(scopedConfig.id);
+    const manager = (await currentApp.appInstanceStore.getAppInstance(scopedConfig.id))!.edm;
+
+    // In-scope member (A1) plus the field worker's A1 group.
+    const memberGuid = uuidv4();
+    await manager.submitForm({
+      guid: uuidv4(),
+      entityGuid: memberGuid,
+      type: "create-individual",
+      data: { name: "Alice", gender: "female", area_id: "A1" },
+      timestamp: "2023-01-01T00:00:00.000Z",
+      userId: "seed",
+      syncLevel: SyncLevel.LOCAL,
+    });
+    const groupGuid = uuidv4();
+    await manager.submitForm({
+      guid: uuidv4(),
+      entityGuid: groupGuid,
+      type: "create-group",
+      data: { name: "Household", area_id: "A1", members: [] },
+      timestamp: "2023-01-02T00:00:00.000Z",
+      userId: "seed",
+      syncLevel: SyncLevel.LOCAL,
+    });
+
+    const updateEvent: FormSubmission = {
+      guid: uuidv4(),
+      entityGuid: groupGuid,
+      type: "update-group",
+      data: {
+        name: "Household",
+        area_id: "A1",
+        members: [{ guid: memberGuid, name: "Alice", phone: "555-1234", type: "individual" }],
+      },
+      timestamp: "2023-02-01T00:00:00.000Z",
+      userId: "field-worker",
+      syncLevel: SyncLevel.LOCAL,
+    };
+
+    const response = await request(currentApp.httpServer)
+      .post("/api/sync/push")
+      .send({ events: [updateEvent], configId: scopedConfig.id })
+      .set("Authorization", `Bearer ${adminToken}`)
+      .set("X-Device-Id", DEVICE_ID);
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe("success");
+    expect(response.body.applied).toBe(1);
+
+    const memberPair = await manager.getEntity(memberGuid);
+    expect(memberPair.modified.data.phone).toBe("555-1234");
+    expect(memberPair.modified.data.gender).toBe("female");
+    const groupPair = await manager.getEntity(groupGuid);
+    expect((groupPair.modified as { memberIds: string[] }).memberIds).toContain(memberGuid);
+  });
+
+  test("scoped {areaIds:['A1']}: create-group with a brand-new member (unknown GUID) applies", async () => {
+    const currentApp = requireApp();
+    const scopedConfig: AppConfig = { ...baseConfig, syncScope: { areaIds: ["A1"] } };
+    await currentApp.appConfigStore.saveConfig(scopedConfig);
+    await currentApp.appInstanceStore.createAppInstance(scopedConfig.id);
+    const manager = (await currentApp.appInstanceStore.getAppInstance(scopedConfig.id))!.edm;
+
+    const groupGuid = uuidv4();
+    const newMemberGuid = uuidv4();
+    const createEvent: FormSubmission = {
+      guid: uuidv4(),
+      entityGuid: groupGuid,
+      type: "create-group",
+      data: {
+        name: "New Household",
+        area_id: "A1",
+        members: [{ guid: newMemberGuid, name: "Newborn", type: "individual" }],
+      },
+      timestamp: "2023-01-01T00:00:00.000Z",
+      userId: "field-worker",
+      syncLevel: SyncLevel.LOCAL,
+    };
+
+    const response = await request(currentApp.httpServer)
+      .post("/api/sync/push")
+      .send({ events: [createEvent], configId: scopedConfig.id })
+      .set("Authorization", `Bearer ${adminToken}`)
+      .set("X-Device-Id", DEVICE_ID);
+
+    expect(response.status).toBe(200);
+    expect(response.body.applied).toBe(1);
+
+    const groupPair = await manager.getEntity(groupGuid);
+    expect((groupPair.modified as { memberIds: string[] }).memberIds).toContain(newMemberGuid);
+    const memberPair = await manager.getEntity(newMemberGuid);
+    expect(memberPair.modified.data.name).toBe("Newborn");
+  });
+
+  test("unbounded tenant: group event naming ANY pre-existing member applies (no member restriction)", async () => {
+    const currentApp = requireApp();
+    // No syncScope → unbounded/admin. Member writes are unrestricted.
+    await currentApp.appConfigStore.saveConfig(baseConfig);
+    await currentApp.appInstanceStore.createAppInstance(baseConfig.id);
+    const manager = (await currentApp.appInstanceStore.getAppInstance(baseConfig.id))!.edm;
+
+    // A pre-existing entity that carries an area unrelated to any scope.
+    const memberGuid = uuidv4();
+    await manager.submitForm({
+      guid: uuidv4(),
+      entityGuid: memberGuid,
+      type: "create-individual",
+      data: { name: "Bob", area_id: "A2" },
+      timestamp: "2023-01-01T00:00:00.000Z",
+      userId: "seed",
+      syncLevel: SyncLevel.LOCAL,
+    });
+
+    const groupGuid = uuidv4();
+    const createEvent: FormSubmission = {
+      guid: uuidv4(),
+      entityGuid: groupGuid,
+      type: "create-group",
+      data: {
+        name: "Household",
+        members: [{ guid: memberGuid, name: "Bob", type: "individual" }],
+      },
+      timestamp: "2023-01-02T00:00:00.000Z",
+      userId: "admin",
+      syncLevel: SyncLevel.LOCAL,
+    };
+
+    const response = await request(currentApp.httpServer)
+      .post("/api/sync/push")
+      .send({ events: [createEvent], configId: baseConfig.id })
+      .set("Authorization", `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.applied).toBe(1);
+
+    const groupPair = await manager.getEntity(groupGuid);
+    expect((groupPair.modified as { memberIds: string[] }).memberIds).toContain(memberGuid);
+  });
+});

--- a/packages/backend/src/routes/syncRoute.ts
+++ b/packages/backend/src/routes/syncRoute.ts
@@ -26,6 +26,7 @@ import {
   validateEventScope,
   type EntityScopeRef,
   type FormSubmission,
+  type SubmitFormOptions,
 } from "@idpass/data-collect-core";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
@@ -501,6 +502,42 @@ export function createSyncRouter(
         acceptedEvents = accepted;
       }
 
+      // Member sub-write scope guard (#1145 — follow-up to #1134). The envelope
+      // check above validates each event's OWN entityGuid against scope, but a
+      // group event's `data.members[]` sub-writes are applied to DIFFERENT
+      // entities. A bounded field worker could pass the envelope check on an
+      // in-scope group yet smuggle an out-of-scope PRE-EXISTING entity GUID
+      // into members[], overwriting that victim and attaching it to their
+      // group. Thread the caller's scope into the apply path as an async
+      // predicate so createOrUpdateGroup rejects any such member. Brand-new
+      // member GUIDs (not resolving to an existing entity) stay allowed.
+      // Unbounded/admin callers get no options → member writes stay
+      // unrestricted, preserving legacy sync behaviour.
+      const memberScopeOptions: SubmitFormOptions | undefined = isBounded
+        ? {
+            isMemberGuidAuthorized: async (memberGuid: string): Promise<boolean> => {
+              let ref: EntityScopeRef | undefined;
+              try {
+                const pair = await appInstance.edm.getEntity(memberGuid);
+                const areaIdRaw = (pair.modified.data as Record<string, unknown> | undefined)?.area_id;
+                const areaId = typeof areaIdRaw === "string" ? areaIdRaw : null;
+                ref = { type: pair.modified.type as EntityScopeRef["type"], areaId };
+              } catch {
+                // Not a pre-existing entity — brand-new member, always allowed.
+                return true;
+              }
+              // Reuse the pure /push validator: treat the member as a
+              // non-create event targeting its own entity so its stored
+              // area + type are checked against the caller's scope.
+              return validateEventScope(
+                { type: "member-write", entityGuid: memberGuid, data: {} },
+                scope,
+                () => ref,
+              ).ok;
+            },
+          }
+        : undefined;
+
       const recordPushTelemetry = (eventCount: number) => {
         const deviceId = readDeviceIdHeader(req);
         if (telemetryStore && deviceId) {
@@ -539,7 +576,7 @@ export function createSyncRouter(
 
       if (txPool) {
         // Transactional path: all accepted events succeed or none are applied
-        const result = await processTransactionalBatch(txPool, tenantId, acceptedEvents);
+        const result = await processTransactionalBatch(txPool, tenantId, acceptedEvents, memberScopeOptions);
         if (!result.success) {
           const failedWithReason = result.failed.map((f) => ({ ...f, reason: "submit_failed" as const }));
           return res.status(422).json({
@@ -562,7 +599,7 @@ export function createSyncRouter(
       // Fallback for environments without a direct postgres URL (e.g., tests
       // that don't pass the URL through). Uses the non-transactional path.
       try {
-        const result = await appInstance.edm.submitFormBatch(acceptedEvents);
+        const result = await appInstance.edm.submitFormBatch(acceptedEvents, memberScopeOptions);
         recordPushTelemetry(result.applied);
         const failedWithReason = result.failed.map((f) => ({ ...f, reason: "submit_failed" as const }));
         const status = rejected.length > 0 ? 207 : 200;

--- a/packages/backend/src/utils/transactionalEdm.ts
+++ b/packages/backend/src/utils/transactionalEdm.ts
@@ -28,6 +28,7 @@ import {
   PostgresEntityStorageAdapter,
   PostgresEventStorageAdapter,
   FormSubmission,
+  SubmitFormOptions,
   createDrizzleFromPool,
 } from "@idpass/data-collect-core";
 import { ConflictStorePg } from "../stores/ConflictStorePg";
@@ -63,12 +64,17 @@ export interface BatchResult {
  * @param pool Shared PostgreSQL connection pool (managed by the caller).
  * @param tenantId Tenant identifier for multi-tenant isolation.
  * @param events Ordered list of form submissions to process atomically.
+ * @param options Optional apply-path options forwarded to every event. Used by
+ *   the bounded `/api/sync/push` caller to enforce the member sub-write scope
+ *   guard (#1145) so an out-of-scope pre-existing member GUID cannot be
+ *   injected into a group event. Omit for unbounded/admin callers.
  * @returns A BatchResult describing the outcome.
  */
 export async function processTransactionalBatch(
   pool: Pool,
   tenantId: string,
   events: FormSubmission[],
+  options?: SubmitFormOptions,
 ): Promise<BatchResult> {
   const db = createDrizzleFromPool(pool);
 
@@ -130,7 +136,7 @@ export async function processTransactionalBatch(
               batchApplied++;
               continue;
             }
-            await edm.submitForm(events[i]);
+            await edm.submitForm(events[i], options);
             batchApplied++;
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);

--- a/packages/datacollect/src/components/EntityDataManager.ts
+++ b/packages/datacollect/src/components/EntityDataManager.ts
@@ -243,6 +243,8 @@ export class EntityDataManager {
    * retried on the next push.
    *
    * @param events The ordered list of form submissions to process.
+   * @param options Optional apply-path options forwarded to every event (e.g.
+   *   the member sub-write scope guard for bounded `/api/sync/push` callers).
    * @returns An object describing the outcome: applied count and any error details.
    *
    * @example
@@ -255,13 +257,14 @@ export class EntityDataManager {
    */
   async submitFormBatch(
     events: FormSubmission[],
+    options?: SubmitFormOptions,
   ): Promise<{ success: boolean; applied: number; failed: FormSubmission[]; errors: string[] }> {
     let applied = 0;
     const failed: FormSubmission[] = [];
     const errors: string[] = [];
     for (const event of events) {
       try {
-        await this.eventApplierService.submitForm(event);
+        await this.eventApplierService.submitForm(event, options);
         applied += 1;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/packages/datacollect/src/services/EventApplierService.ts
+++ b/packages/datacollect/src/services/EventApplierService.ts
@@ -65,11 +65,30 @@ export interface SubmitFormOptions {
    * plus its current members). Member entries whose guid does not resolve to
    * any existing entity are always allowed (creating a brand-new member).
    *
-   * Omit this option entirely for TRUSTED callers (e.g. field-worker
-   * `/api/sync/push`, whose envelope scope is validated separately) — member
-   * writes are then unrestricted, preserving legacy sync behaviour.
+   * Omit this option entirely for TRUSTED, UNBOUNDED callers (e.g. admin
+   * sync) — member writes are then unrestricted, preserving legacy sync
+   * behaviour.
    */
   authorizedMemberGuids?: string[];
+
+  /**
+   * Async predicate variant of the member sub-write guard (OpenProject #1145 —
+   * follow-up to #1134 for the `/api/sync/push` path).
+   *
+   * A field worker's sync scope is NOT a finite list of GUIDs — it is a
+   * PREDICATE over the member entity (its `area_id` and/or type must fall
+   * inside the caller's effective scope). When provided, this callback is
+   * consulted for any member entry whose `guid` resolves to a PRE-EXISTING
+   * entity that is not already covered by {@link authorizedMemberGuids} (nor
+   * the group's own guid / current members). It must resolve `true` iff the
+   * member entity is inside the caller's scope. Member entries whose guid does
+   * not resolve to any existing entity are always allowed (brand-new member)
+   * and the callback is NOT consulted for them.
+   *
+   * Supplying either this callback or {@link authorizedMemberGuids} enables
+   * RESTRICTED mode. Omit both for unbounded callers.
+   */
+  isMemberGuidAuthorized?(guid: string): Promise<boolean>;
 }
 
 /**
@@ -754,17 +773,38 @@ export class EventApplierService {
 
     if (Array.isArray(formData.data?.members)) {
       // log.debug(`Processing members: ${JSON.stringify(formData.data.members)}`);
-      // Horizontal BOLA guard (#1134): when the caller supplies an authorization
-      // scope (RESTRICTED mode — least-trusted callers such as self-service),
-      // a member entry may only write to a PRE-EXISTING entity if that entity's
-      // guid is in the authorized set. The group's own guid and its current
-      // members are always in scope. Unknown guids (new members) are allowed.
-      const restrictMembers = options?.authorizedMemberGuids !== undefined;
+      // Horizontal BOLA guard (#1134 + #1145): when the caller supplies an
+      // authorization scope (RESTRICTED mode — least-trusted callers such as
+      // self-service, or bounded field-worker `/api/sync/push`), a member entry
+      // may only write to a PRE-EXISTING entity if that entity is inside the
+      // caller's scope. The group's own guid and its current members are always
+      // in scope. Unknown guids (new members) are always allowed.
+      //
+      // Scope is expressed two ways, both handled by `isMemberAuthorized`:
+      //   - `authorizedMemberGuids` — a finite GUID set (#1134, self-service).
+      //   - `isMemberGuidAuthorized` — an async predicate over the member
+      //     entity, for scopes that are area/type membership rather than a
+      //     finite list (#1145, sync-push).
+      const restrictMembers =
+        options?.authorizedMemberGuids !== undefined || options?.isMemberGuidAuthorized !== undefined;
       const authorizedMemberGuids = new Set<string>(options?.authorizedMemberGuids ?? []);
       authorizedMemberGuids.add(group.guid);
       for (const existingMemberId of group.memberIds) {
         authorizedMemberGuids.add(existingMemberId);
       }
+      // Resolves true iff a PRE-EXISTING member guid is inside scope. The set
+      // (own guid + current members + explicit allow-list) is checked first;
+      // otherwise the async predicate decides. Callers pass at most one of the
+      // two mechanisms, but both are honoured so the guard stays single-sourced.
+      const isMemberAuthorized = async (memberGuid: string): Promise<boolean> => {
+        if (authorizedMemberGuids.has(memberGuid)) {
+          return true;
+        }
+        if (options?.isMemberGuidAuthorized) {
+          return await options.isMemberGuidAuthorized(memberGuid);
+        }
+        return false;
+      };
 
       const newMemberIds = await Promise.all(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -777,7 +817,7 @@ export class EventApplierService {
 
           if (memberData && memberData.type === "group") {
             const existingPair = await this.entityStore.getEntity(memberGuid);
-            if (restrictMembers && existingPair && !authorizedMemberGuids.has(memberGuid)) {
+            if (restrictMembers && existingPair && !(await isMemberAuthorized(memberGuid))) {
               throw new AppError(
                 "UNAUTHORIZED_MEMBER",
                 "Member references an entity outside the caller's authorization scope",
@@ -796,7 +836,7 @@ export class EventApplierService {
             return subGroup.guid;
           } else if (memberData) {
             const existingPair = await this.entityStore.getEntity(memberGuid);
-            if (restrictMembers && existingPair && !authorizedMemberGuids.has(memberGuid)) {
+            if (restrictMembers && existingPair && !(await isMemberAuthorized(memberGuid))) {
               throw new AppError(
                 "UNAUTHORIZED_MEMBER",
                 "Member references an entity outside the caller's authorization scope",

--- a/packages/datacollect/src/services/__tests__/EventApplierService.sync-push-member-scope.test.ts
+++ b/packages/datacollect/src/services/__tests__/EventApplierService.sync-push-member-scope.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression tests for OpenProject #1145 — Sync-push member-GUID injection.
+ * Follow-up to #1134. The self-service door (#1134) guards member sub-writes
+ * with a finite `authorizedMemberGuids` set. A field worker's sync scope is
+ * NOT a finite GUID list — it is a PREDICATE over the member entity's area /
+ * type. This test exercises the async predicate variant of the apply-path
+ * guard: `submitForm(form, { isMemberGuidAuthorized })`.
+ *
+ * A bounded (area/entity-scoped) field worker must not be able to name an
+ * out-of-scope PRE-EXISTING entity as a member of a group event and thereby
+ * overwrite that entity's data or attach it to their group. In-scope members
+ * and brand-new members must still apply. When no scope option is supplied
+ * (admin / unbounded), member writes are unrestricted (legacy behaviour).
+ */
+
+import "core-js/stable/structured-clone";
+import "fake-indexeddb/auto";
+
+import { v4 as uuidv4 } from "uuid";
+import { EntityStore, EventStore, FormSubmission, GroupDoc, SyncLevel } from "../../interfaces/types";
+import { EntityStoreImpl } from "../../components/EntityStore";
+import { EventStoreImpl } from "../../components/EventStore";
+import { EventApplierService } from "../EventApplierService";
+import { IndexedDbEntityStorageAdapter } from "../../storage/IndexedDbEntityStorageAdapter";
+import { IndexedDbEventStorageAdapter } from "../../storage/IndexedDbEventStorageAdapter";
+
+function makeForm(overrides: Partial<FormSubmission> = {}): FormSubmission {
+  return {
+    guid: uuidv4(),
+    entityGuid: uuidv4(),
+    type: "create-individual",
+    data: { name: "Test Person" },
+    timestamp: new Date().toISOString(),
+    userId: "test-user",
+    syncLevel: SyncLevel.LOCAL,
+    ...overrides,
+  };
+}
+
+describe("EventApplierService – sync-push member scope predicate guard (#1145)", () => {
+  let entityStore: EntityStore;
+  let eventStore: EventStore;
+  let service: EventApplierService;
+
+  beforeEach(async () => {
+    entityStore = new EntityStoreImpl(new IndexedDbEntityStorageAdapter());
+    await entityStore.initialize();
+    eventStore = new EventStoreImpl(new IndexedDbEventStorageAdapter());
+    await eventStore.initialize();
+    service = new EventApplierService(eventStore, entityStore);
+  });
+
+  afterEach(async () => {
+    await entityStore.clearStore();
+    await eventStore.clearStore();
+  });
+
+  it("rejects a member naming a pre-existing out-of-scope victim (predicate returns false)", async () => {
+    const victimGuid = uuidv4();
+    const fieldWorkerGroupGuid = uuidv4();
+
+    // Victim individual in area A2 (outside the field worker's A1 scope).
+    await service.submitForm(
+      makeForm({
+        entityGuid: victimGuid,
+        type: "create-individual",
+        data: { name: "Victim", gender: "female", area_id: "A2" },
+      }),
+    );
+
+    // Field worker's own group in area A1.
+    await service.submitForm(
+      makeForm({
+        entityGuid: fieldWorkerGroupGuid,
+        type: "create-group",
+        data: { name: "Field Worker Household", area_id: "A1", members: [] },
+      }),
+    );
+
+    // The scope predicate authorizes only members whose entity is in A1.
+    // The victim (A2) must be rejected.
+    const isMemberGuidAuthorized = async (guid: string): Promise<boolean> => {
+      const pair = await entityStore.getEntity(guid);
+      return pair?.modified.data.area_id === "A1";
+    };
+
+    await expect(
+      service.submitForm(
+        makeForm({
+          entityGuid: fieldWorkerGroupGuid,
+          type: "update-group",
+          data: {
+            name: "Field Worker Household",
+            area_id: "A1",
+            members: [{ guid: victimGuid, name: "HACKED", type: "individual" }],
+          },
+        }),
+        { isMemberGuidAuthorized },
+      ),
+    ).rejects.toThrow();
+
+    // Victim untouched.
+    const victimPair = await entityStore.getEntity(victimGuid);
+    expect(victimPair!.modified.data.name).toBe("Victim");
+    expect(victimPair!.modified.data.gender).toBe("female");
+    expect(victimPair!.modified.data.area_id).toBe("A2");
+
+    // Victim NOT attached to the field worker's group.
+    const groupPair = await entityStore.getEntity(fieldWorkerGroupGuid);
+    expect((groupPair!.modified as GroupDoc).memberIds).not.toContain(victimGuid);
+  });
+
+  it("allows a member whose entity is in scope (predicate returns true)", async () => {
+    const memberGuid = uuidv4();
+    const groupGuid = uuidv4();
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: memberGuid,
+        type: "create-individual",
+        data: { name: "Alice", gender: "female", area_id: "A1" },
+      }),
+    );
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "create-group",
+        data: { name: "Household", area_id: "A1", members: [] },
+      }),
+    );
+
+    const isMemberGuidAuthorized = async (guid: string): Promise<boolean> => {
+      const pair = await entityStore.getEntity(guid);
+      return pair?.modified.data.area_id === "A1";
+    };
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "update-group",
+        data: {
+          name: "Household",
+          area_id: "A1",
+          members: [{ guid: memberGuid, name: "Alice", phone: "555-1234", type: "individual" }],
+        },
+      }),
+      { isMemberGuidAuthorized },
+    );
+
+    const memberPair = await entityStore.getEntity(memberGuid);
+    expect(memberPair!.modified.data.phone).toBe("555-1234");
+    expect(memberPair!.modified.data.gender).toBe("female");
+    const groupPair = await entityStore.getEntity(groupGuid);
+    expect((groupPair!.modified as GroupDoc).memberIds).toContain(memberGuid);
+  });
+
+  it("allows a brand-new member (guid resolves to no existing entity)", async () => {
+    const groupGuid = uuidv4();
+    const newMemberGuid = uuidv4();
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "create-group",
+        data: { name: "Household", area_id: "A1", members: [] },
+      }),
+    );
+
+    // Predicate would return false for a non-existing entity, but the guard
+    // must never consult the predicate for guids that don't resolve to a
+    // pre-existing entity — brand-new members are always allowed.
+    const isMemberGuidAuthorized = async (guid: string): Promise<boolean> => {
+      const pair = await entityStore.getEntity(guid);
+      return pair?.modified.data.area_id === "A1";
+    };
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "update-group",
+        data: {
+          name: "Household",
+          area_id: "A1",
+          members: [{ guid: newMemberGuid, name: "Newborn", type: "individual" }],
+        },
+      }),
+      { isMemberGuidAuthorized },
+    );
+
+    const groupPair = await entityStore.getEntity(groupGuid);
+    expect((groupPair!.modified as GroupDoc).memberIds).toContain(newMemberGuid);
+    const memberPair = await entityStore.getEntity(newMemberGuid);
+    expect(memberPair!.modified.data.name).toBe("Newborn");
+  });
+
+  it("does NOT restrict member writes when no scope option is given (admin / unbounded sync)", async () => {
+    const memberGuid = uuidv4();
+    const groupGuid = uuidv4();
+
+    await service.submitForm(
+      makeForm({
+        entityGuid: memberGuid,
+        type: "create-individual",
+        data: { name: "Bob", area_id: "A2" },
+      }),
+    );
+
+    // No options → unrestricted. An A2 member is accepted into any group.
+    await service.submitForm(
+      makeForm({
+        entityGuid: groupGuid,
+        type: "create-group",
+        data: { name: "Household", area_id: "A1", members: [{ guid: memberGuid, name: "Bob", type: "individual" }] },
+      }),
+    );
+
+    const groupPair = await entityStore.getEntity(groupGuid);
+    expect((groupPair!.modified as GroupDoc).memberIds).toContain(memberGuid);
+  });
+});


### PR DESCRIPTION
> **Stacked on #60** (`fix/1134-bola-member-guid-injection`). GitHub will retarget this PR to `develop` when #60 merges. See the [compare against the parent branch](https://github.com/idpass/idpass-data-collect/compare/fix/1134-bola-member-guid-injection...fix/1145-sync-push-member-guard) for the isolated delta.

Extends the group member-GUID authorization guard to the `/api/sync/push` path. Sync scope is an area/type predicate rather than a finite GUID list, so the guard accepts an async predicate in addition to the existing allow-set.

## Change
- `EventApplierService.ts` — predicate option + unified member guard (own guid + current members + allow-set, else predicate; fires only for member GUIDs that resolve to a pre-existing entity — brand-new members allowed).
- `EntityDataManager.ts` — `submitFormBatch(events, options?)` forwards per-event options.
- `backend/utils/transactionalEdm.ts` — `processTransactionalBatch(..., options?)` forwards to `submitForm`.
- `backend/routes/syncRoute.ts` — builds the predicate only when the caller is bounded, reusing the existing pure `validateEventScope`. Unbounded/admin callers get no options → unrestricted (legacy behavior preserved).

## Tests
- `EventApplierService.sync-push-member-scope.test.ts` (4) + `syncRoute.memberScope.test.ts` (4), TDD RED-first. datacollect 202 + backend 75 regression pass; type-check + lint clean.

## Residual (follow-up)
The guard is not propagated into recursive subgroup creation inside `createOrUpdateGroup`. Flag if push-based group nesting becomes a supported field-worker flow.
