### PR TITLE
docs: security disclosure hygiene guideline for public-repo PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,9 +125,21 @@ Backend supports multiple tenants via app config files. Config structure:
 - **Adapter wrappers in `syncServer.ts` must be kept in sync with the `ExternalSyncAdapterV2` interface.** If the interface adds a parameter, the wrapper must forward it. Past bug: wrapper dropped `since` parameter for 30 days, causing full re-pull on every sync.
 - **IndexedDB `objectStore.put()` returns `IDBRequest`, not `Promise`.** Wrapping in `await` does not wait for the transaction to commit. Always wrap in `new Promise` that resolves on `transaction.oncomplete`.
 
+## Security Disclosure Hygiene
+
+This is a **public** repository. Do not expose exploitable vulnerability detail or internal tracker IDs (OpenProject `#nnnn`) in public artifacts — PR titles/descriptions, issue text, commit messages, or code/test comments.
+
+- **Undisclosed vulnerabilities:** develop the fix in a private [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories) (GHSA) fork; merge and release; publish the advisory (and a CVE if warranted) only after users can upgrade. The detailed exploit narrative belongs in the post-release advisory, not the PR.
+- **Public PR text** describes *what* changed — the control added, files touched, tests — never the attack path, preconditions, or exploitation steps.
+- **No internal tracker IDs** in public PRs/commits/code. Reference the public advisory ID or omit. Cross-PR references (`#60`, `#61`) are fine (structural).
+- **Code comments / test `describe()` names** name the control or behavior ("tenant-scoped approval guard"), not the vulnerability or ticket ("the #1135 vuln", "BOLA exploit").
+- The goal is timing, not permanent secrecy: once a fix is released, an advisory/CVE and transparency are good — just don't hand attackers a roadmap before the patch ships.
+
 ## Commit Checklist
 
 Before committing:
+
+- [ ] Security fix: no exploit detail or internal tracker IDs in public PR/commit/code text (see Security Disclosure Hygiene)
 
 - [ ] `pnpm pr-check` passes
 - [ ] No `console.log` in `datacollect` or `backend` (use `createLogger`)


### PR DESCRIPTION
Adds a **Security Disclosure Hygiene** section to CLAUDE.md and a commit-checklist item, so security fixes on this public repo keep exploit detail and internal tracker IDs out of public PRs/commits/code, and use the GHSA private-advisory workflow for undisclosed vulnerabilities.

Documentation only. Prompted by scrubbing the descriptions of open security PRs #61/#63/#64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)