### PR TITLE
fix(mobile): bound lock authenticating state so stalled biometric self-heals

### DIFF
--- a/packages/mobile/src/machines/__tests__/lockMachine.test.ts
+++ b/packages/mobile/src/machines/__tests__/lockMachine.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createActor, fromPromise } from 'xstate'
 import { lockMachine } from '../lockMachine'
+import type { LoadLockStateResult, BiometricResult } from '../types'
 
 function createTestMachine(overrides: {
   loadResult?: { isNativePlatform: boolean; isLocked: boolean }
@@ -185,6 +186,50 @@ describe('lockMachine', () => {
     actor.send({ type: 'USER_ACTIVITY' })
     expect(actor.getSnapshot().matches('unlocked')).toBe(true)
     actor.stop()
+  })
+
+  it('leaves authenticating and returns to locked when biometric never settles', async () => {
+    // Reproduces the on-device hang: the native biometric promise never
+    // resolves nor rejects (e.g. cap8 bridge stall on a device with no
+    // enrolled biometric). The machine must not stay pinned in
+    // `authenticating` — it must self-heal back to `locked` with an error so
+    // the lock flow resolves deterministically instead of hanging until the
+    // AppLockService 30s waitForState rejects and crashes Vue.
+    vi.useFakeTimers()
+    try {
+      const machine = lockMachine.provide({
+        actors: {
+          loadPersistedLockState: fromPromise<LoadLockStateResult>(async () => ({
+            isNativePlatform: true,
+            isLocked: true
+          })),
+          // Never settles.
+          biometricAuthenticate: fromPromise<BiometricResult>(() => new Promise(() => {})),
+          persistLockState: fromPromise(async () => {})
+        }
+      })
+      const actor = createActor(machine)
+      actor.start()
+
+      actor.send({ type: 'INIT' })
+      // Flush the load promise so the machine reaches `locked`.
+      await vi.advanceTimersByTimeAsync(0)
+      expect(actor.getSnapshot().matches('locked')).toBe(true)
+
+      actor.send({ type: 'AUTHENTICATE' })
+      expect(actor.getSnapshot().matches('authenticating')).toBe(true)
+
+      // Advance well past any reasonable biometric deadline. The machine must
+      // have left `authenticating` on its own.
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(actor.getSnapshot().matches('authenticating')).toBe(false)
+      expect(actor.getSnapshot().matches('locked')).toBe(true)
+      expect(actor.getSnapshot().context.error).toBeTruthy()
+      actor.stop()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('handles load error by transitioning to unlocked', async () => {

--- a/packages/mobile/src/machines/lockMachine.ts
+++ b/packages/mobile/src/machines/lockMachine.ts
@@ -23,6 +23,17 @@ import { loadPersistedLockState, biometricAuthenticate, persistLockState } from 
 
 const INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000
 
+// Upper bound on how long the machine may stay in `authenticating`. The
+// invoked `biometricAuthenticate` actor normally settles (success / failure /
+// cancel / error), but a native biometric bridge can leave its promise
+// permanently pending — e.g. on a device with no enrolled biometric or no
+// secure lock. Without this bound the machine would sit in `authenticating`
+// forever and the only safety net (AppLockService's 30s waitForState) would
+// reject and surface as a Vue runtime crash. This must stay strictly below
+// that 30s guard so the machine self-heals to a recoverable `locked` state
+// first, giving the user the Unlock button again instead of a hard error.
+const AUTH_TIMEOUT_MS = 20 * 1000
+
 export const lockMachine = setup({
   types: {
     context: {} as LockContext,
@@ -113,6 +124,16 @@ export const lockMachine = setup({
           target: 'locked',
           actions: assign({
             error: ({ event }) => event.error instanceof Error ? event.error.message : 'Authentication error'
+          })
+        }
+      },
+      // Deadline: if the native biometric prompt never settles, fall back to a
+      // recoverable locked state instead of hanging until the caller times out.
+      after: {
+        [AUTH_TIMEOUT_MS]: {
+          target: 'locked',
+          actions: assign({
+            error: 'Authentication timed out. Please try again.'
           })
         }
       }


### PR DESCRIPTION
## Problem
On the app lock screen, tapping **Unlock** could hang and then crash the WebView with a Vue runtime error (`waitForState timed out after 30000ms`) instead of recovering.

## Root cause
The `lockMachine` `authenticating` state only exits when the invoked biometric actor settles (onDone/onError). The actor handles rejection, cancellation, and "unavailable", but not a native `authenticate()`/`checkBiometry()` promise that never settles at all. When that happens the machine is pinned in `authenticating`; `AppLockService`'s 30s `waitForState` guard then rejects and the unhandled rejection crashes the view.

This is a pre-existing gap in the state machine (predates the Capacitor 8 upgrade); it is surfaced by the cap8 runtime bridge on a device with no enrolled biometric. The biometric plugin version is cap8-correct (`@aparajita/capacitor-biometric-auth@10` → `@capacitor/core@^8`), so this is independent of the dependency PR and lands on its own branch.

## Fix
Add a bounded deadline to the `authenticating` state in `lockMachine.ts`: a 20s `after` transition back to `locked` with a user-facing error, strictly below the 30s `waitForState` guard so the machine always resolves first. The lock screen re-renders with the Unlock button (retryable) instead of crashing. Not a timeout bump — the 30s guard remains as an unreachable last resort.

## Tests
`lockMachine.test.ts`: added a case where the biometric actor never settles → asserts the machine self-heals from `authenticating` to `locked` with an error (RED verified first). Full mobile unit suite: 193 passed.

## Verification
Unit-tested; on-device verification on an un-enrolled-biometric device performed alongside the Capacitor 8 build.

## Follow-up (out of scope)
`AppLockService.init()` uses the same unbounded `waitForState` against the `initializing` state — a startup `SecureStorage` stall could crash similarly. Worth hardening if observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)