### PR TITLE
feat(admin): read-only form preview from program detail (#16)

### DIFF
--- a/packages/admin/src/components/FormPreviewDialog.vue
+++ b/packages/admin/src/components/FormPreviewDialog.vue
@@ -1,0 +1,69 @@
+<!--
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+<template>
+  <v-dialog fullscreen v-model="dialog" transition="dialog-bottom-transition">
+    <v-card>
+      <v-toolbar color="primary" dark>
+        <v-toolbar-title>{{ title || 'Form Preview' }}</v-toolbar-title>
+        <v-spacer></v-spacer>
+        <v-btn icon @click="closeDialog">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </v-toolbar>
+      <FormioRenderer v-if="dialog" :schema="schema" class="form-preview-host" />
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import FormioRenderer from '@/components/FormioRenderer.vue'
+
+const props = defineProps({
+  modelValue: Boolean,
+  title: {
+    type: String,
+    default: '',
+  },
+  formio: {
+    type: Object,
+    default: () => ({}),
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const dialog = computed({
+  get: () => props.modelValue,
+  set: (val: boolean) => emit('update:modelValue', val),
+})
+
+const schema = computed<object>(() => props.formio ?? {})
+
+const closeDialog = () => {
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+.form-preview-host {
+  height: calc(100vh - 64px);
+  overflow: auto;
+}
+</style>

--- a/packages/admin/src/components/FormioRenderer.vue
+++ b/packages/admin/src/components/FormioRenderer.vue
@@ -1,0 +1,78 @@
+<!--
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+<template>
+  <div ref="mountEl" class="formio-renderer-host" />
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { Formio } from '@formio/js'
+import { loadBuilderAssets } from '@/formio/loadBuilderAssets'
+import { registerBuilderComponents } from '@/formio/builderComponents'
+import type { FormioFormInstance } from '@/formio/types'
+
+const props = defineProps<{
+  schema: object
+}>()
+
+const mountEl = ref<HTMLDivElement | null>(null)
+let form: FormioFormInstance | null = null
+let cancelled = false
+
+function cloneSchema<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value))
+}
+
+onMounted(async () => {
+  if (!mountEl.value) return
+  loadBuilderAssets()
+  // Register the ID PASS custom components (biometricCapture, claim169Scanner)
+  // so a form that uses them renders instead of failing on an unknown type.
+  // These are the builder-side definitions (see builderComponents.ts); the
+  // renderer shows them as their default read-only field. Capture/scan
+  // behaviour is runtime-only and lives in the mobile app, so a plain field
+  // render is the correct read-only preview here. Idempotent.
+  registerBuilderComponents()
+  const instance = (await Formio.createForm(mountEl.value, cloneSchema(props.schema), {
+    readOnly: true,
+  })) as unknown as FormioFormInstance
+  // The component may have unmounted while we were awaiting createForm().
+  // If so, destroy the just-created instance and bail.
+  if (cancelled) {
+    await instance.destroy()
+    return
+  }
+  form = instance
+})
+
+onBeforeUnmount(() => {
+  cancelled = true
+  // Vue does not await async unmount hooks; fire-and-forget.
+  form?.destroy()
+  form = null
+})
+</script>
+
+<style scoped>
+.formio-renderer-host {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+}
+</style>

--- a/packages/admin/src/components/__tests__/FormioRenderer.spec.ts
+++ b/packages/admin/src/components/__tests__/FormioRenderer.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import FormioRenderer from '../FormioRenderer.vue'
+
+const vuetify = createVuetify()
+
+const formInstance = {
+  destroy: vi.fn(),
+}
+
+const createFormMock = vi.fn<
+  (element: HTMLElement, schema: object, options?: object) => Promise<typeof formInstance>
+>(async () => formInstance)
+
+vi.mock('@formio/js', () => ({
+  Formio: {
+    createForm: (...args: unknown[]) =>
+      createFormMock(...(args as [HTMLElement, object, object?])),
+  },
+}))
+
+vi.mock('@/formio/loadBuilderAssets', () => ({
+  loadBuilderAssets: vi.fn(),
+}))
+
+// Custom-component registration touches the real Formio.Components registry,
+// which the @formio/js mock above does not provide. These tests cover the
+// renderer lifecycle, not registration, so stub it out.
+vi.mock('@/formio/builderComponents', () => ({
+  registerBuilderComponents: vi.fn(),
+}))
+
+describe('FormioRenderer', () => {
+  beforeEach(() => {
+    formInstance.destroy.mockClear()
+    createFormMock.mockClear()
+    createFormMock.mockImplementation(async () => formInstance)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the form read-only with the given schema', async () => {
+    const schema = { components: [{ type: 'textfield', key: 'name', label: 'Name' }] }
+    mount(FormioRenderer, {
+      props: { schema },
+      global: { plugins: [vuetify] },
+    })
+    await flushPromises()
+    expect(createFormMock).toHaveBeenCalledTimes(1)
+    const [el, passedSchema, options] = createFormMock.mock.calls[0]
+    expect(el).toBeInstanceOf(HTMLElement)
+    expect(passedSchema).toEqual(schema)
+    expect(options).toMatchObject({ readOnly: true })
+  })
+
+  it('destroys the form instance on unmount', async () => {
+    const wrapper = mount(FormioRenderer, {
+      props: { schema: { components: [] } },
+      global: { plugins: [vuetify] },
+    })
+    await flushPromises()
+    wrapper.unmount()
+    await flushPromises()
+    expect(formInstance.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('destroys a form created during mount even if unmounted before it resolves', async () => {
+    let resolveForm: (v: typeof formInstance) => void = () => {}
+    const pending = new Promise<typeof formInstance>((resolve) => {
+      resolveForm = resolve
+    })
+    createFormMock.mockImplementationOnce(() => pending)
+    const wrapper = mount(FormioRenderer, {
+      props: { schema: { components: [] } },
+      global: { plugins: [vuetify] },
+    })
+    wrapper.unmount()
+    resolveForm(formInstance)
+    await flushPromises()
+    expect(formInstance.destroy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/admin/src/formio/builder-theme.scss
+++ b/packages/admin/src/formio/builder-theme.scss
@@ -27,6 +27,7 @@
  * rule is scoped under:
  *
  *   .formio-builder-host  — the FormioBuilder.vue mount element
+ *   .formio-renderer-host — the FormioRenderer.vue (read-only preview) element
  *   .formio-dialog        — Form.io component-edit dialogs (mounted on body)
  *
  * SCSS variables cannot read CSS custom properties at compile time, so token
@@ -101,7 +102,7 @@ $nav-tabs-link-active-color: $primary;
 // `html`/`body` rules from reboot become dead descendants of the scope —
 // their job is done by the host base styles further down.
 // ---------------------------------------------------------------------------
-:is(.formio-builder-host, .formio-dialog) {
+:is(.formio-builder-host, .formio-renderer-host, .formio-dialog) {
   @import 'bootstrap/scss/root';
   @import 'bootstrap/scss/reboot';
   @import 'bootstrap/scss/type';

--- a/packages/admin/src/formio/types.ts
+++ b/packages/admin/src/formio/types.ts
@@ -36,3 +36,10 @@ export interface FormioBuilderInstance {
   on(event: FormioBuilderEvent, handler: () => void): void
   destroy(): Promise<void> | void
 }
+
+// Narrow interface for the read-only renderer produced by `Formio.createForm`.
+// Same rationale as FormioBuilderInstance: `@formio/js` types this as
+// `Promise<any>`, so we cast at the call site (see FormioRenderer.vue).
+export interface FormioFormInstance {
+  destroy(): Promise<void> | void
+}

--- a/packages/admin/src/views/AppDetailsView.vue
+++ b/packages/admin/src/views/AppDetailsView.vue
@@ -18,6 +18,7 @@ import SyncStatusPanel from '@/components/SyncStatusPanel.vue'
 import SyncScopeCard from '@/components/SyncScopeCard.vue'
 import ProgramsCard from '@/components/ProgramsCard.vue'
 import Claim169Card from '@/components/Claim169Card.vue'
+import FormPreviewDialog from '@/components/FormPreviewDialog.vue'
 import { useFeatureFlag } from '@/composables/useFeatureFlag'
 import type { SyncScopePolicy } from '@idpass/data-collect-core'
 import type { AppProgram, Claim169Config } from '@/api'
@@ -87,6 +88,7 @@ interface FormOverviewItem {
   records: number
   dependsOn?: string
   fields: number
+  formio?: Record<string, unknown>
 }
 
 const authStore = useAuthStore()
@@ -256,9 +258,24 @@ const formOverview = computed<FormOverviewItem[]>(() => {
       dependsOn: form.dependsOn,
       fields: countFormFields(form.formio),
       records: entityDataMap.value.get(form.name) ?? 0,
+      formio: form.formio,
     }
   })
 })
+
+const showPreviewDialog = ref(false)
+const previewForm = ref<{ title: string; formio: Record<string, unknown> }>({
+  title: '',
+  formio: {},
+})
+
+const openFormPreview = (item: FormOverviewItem) => {
+  previewForm.value = {
+    title: item.title,
+    formio: item.formio ?? {},
+  }
+  showPreviewDialog.value = true
+}
 
 const downloadUrl = computed(() => {
   const artifactId = app.value?.artifactId
@@ -697,7 +714,17 @@ watch(
                       cols="12"
                       md="6"
                     >
-                      <v-card class="form-card" border="md" elevation="0">
+                      <v-card
+                        class="form-card form-card--clickable"
+                        border="md"
+                        elevation="0"
+                        role="button"
+                        tabindex="0"
+                        :title="`Preview ${item.title}`"
+                        @click="openFormPreview(item)"
+                        @keydown.enter="openFormPreview(item)"
+                        @keydown.space.prevent="openFormPreview(item)"
+                      >
                         <v-card-text>
                           <div class="form-card__header">
                             <div>
@@ -1064,6 +1091,12 @@ watch(
     @submit="onCredentialsSubmit"
   />
 
+  <FormPreviewDialog
+    v-model="showPreviewDialog"
+    :title="previewForm.title"
+    :formio="previewForm.formio"
+  />
+
   <v-dialog v-model="showArchiveDialog" :max-width="540">
     <v-card>
       <v-card-title class="text-h6">
@@ -1404,6 +1437,21 @@ watch(
 .form-card {
   border-radius: var(--radius-xl);
   height: 100%;
+}
+
+.form-card--clickable {
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.form-card--clickable:hover,
+.form-card--clickable:focus-visible {
+  border-color: rgb(var(--v-theme-primary));
+  box-shadow: var(--shadow-card);
+  transform: translateY(-2px);
 }
 
 .form-card__header {


### PR DESCRIPTION
Closes #16.

Clicking an entity-form card on the program detail page now opens a fullscreen **read-only** Form.io preview of that form.

## Changes
- `FormioRenderer.vue` — read-only renderer via `Formio.createForm(el, schema, { readOnly: true })`; loads Form.io assets, registers the ID PASS custom components so `biometricCapture`/`claim169Scanner` render as read-only fields, destroys on unmount (incl. unmount-during-async-mount).
- `FormPreviewDialog.vue` — fullscreen dialog wrapping the renderer.
- `AppDetailsView.vue` — form cards clickable (mouse + keyboard, `role="button"`); `FormOverviewItem` carries the `formio` schema.
- `builder-theme.scss` — scoped-Bootstrap styling extended to the renderer host.

## Tests
- `FormioRenderer.spec.ts` — asserts read-only render + cleanup.
- Admin suite: 169 tests pass; type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)