### PR TITLE
feat(admin): edit a single form directly from program detail (#17)

### DIFF
--- a/packages/admin/src/router/index.ts
+++ b/packages/admin/src/router/index.ts
@@ -40,6 +40,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/collection-programs/:id/forms/:formIndex/edit',
+      name: 'form-edit',
+      component: () => import('../views/FormEditView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/collection-programs/:id/entity/:guid',
       name: 'entity-details',
       component: () => import('../views/EntityDetailView.vue'),

--- a/packages/admin/src/views/AppDetailsView.vue
+++ b/packages/admin/src/views/AppDetailsView.vue
@@ -84,6 +84,7 @@ interface AppConfig {
 
 interface FormOverviewItem {
   id: string
+  index: number
   title: string
   records: number
   dependsOn?: string
@@ -254,6 +255,7 @@ const formOverview = computed<FormOverviewItem[]>(() => {
     const formId = form.name || `entity-${index}`
     return {
       id: formId,
+      index,
       title: form.title || formId,
       dependsOn: form.dependsOn,
       fields: countFormFields(form.formio),
@@ -430,6 +432,16 @@ const openEditor = (step: string = 'general') => {
   router.push({
     name: `wizard-${step}`,
     query: { mode: 'edit', id: routeId.value },
+  })
+}
+
+// Open the standalone single-form designer (#17) for one form, bypassing the
+// wizard. `index` is the form's position in entityForms.
+const editForm = (index: number) => {
+  if (!routeId.value) return
+  router.push({
+    name: 'form-edit',
+    params: { id: routeId.value, formIndex: String(index) },
   })
 }
 
@@ -731,9 +743,20 @@ watch(
                               <h3 class="form-card__title">{{ item.title }}</h3>
                               <p class="form-card__id">Entity ID • {{ item.id }}</p>
                             </div>
-                            <v-chip color="primary" size="small" variant="tonal">
-                              {{ item.records }} records
-                            </v-chip>
+                            <div class="form-card__header-actions">
+                              <v-chip color="primary" size="small" variant="tonal">
+                                {{ item.records }} records
+                              </v-chip>
+                              <v-btn
+                                variant="tonal"
+                                color="primary"
+                                size="small"
+                                prepend-icon="mdi-pencil"
+                                @click.stop="editForm(item.index)"
+                              >
+                                Edit
+                              </v-btn>
+                            </div>
                           </div>
                           <p class="form-card__summary">
                             This form currently has {{ item.fields }} configured field{{ item.fields === 1 ? '' : 's' }}
@@ -1460,6 +1483,12 @@ watch(
   justify-content: space-between;
   gap: var(--spacing-md);
   flex-wrap: wrap;
+}
+
+.form-card__header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
 }
 
 .form-card__title {

--- a/packages/admin/src/views/FormEditView.vue
+++ b/packages/admin/src/views/FormEditView.vue
@@ -1,0 +1,223 @@
+<!--
+  Licensed to the Association pour la cooperation numerique (ACN) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ACN licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { getApp, updateApp } from '@/api'
+import { useSnackBarStore } from '@/stores/snackBar'
+import FormioBuilder from '@/components/FormioBuilder.vue'
+
+// Standalone single-form editor (#17). Opens the Form.io designer for ONE
+// form reached directly from the program detail page — no wizard, no draft
+// store. On save it re-loads the full config, splices in just this form's
+// edited schema, and PUTs the whole config back (the backend only accepts a
+// full config.json). The wizard flow is untouched.
+
+interface EntityForm {
+  id?: string
+  name: string
+  title: string
+  dependsOn?: string
+  entityType?: 'group' | 'individual' | 'record'
+  nameField?: string
+  formio?: Record<string, unknown>
+  version?: string
+  [key: string]: unknown
+}
+
+interface AppConfig {
+  id: string
+  name: string
+  entityForms?: EntityForm[]
+  [key: string]: unknown
+}
+
+const route = useRoute()
+const router = useRouter()
+const snackBarStore = useSnackBarStore()
+
+const configId = computed(() => route.params.id as string)
+const formIndex = computed(() => Number.parseInt(route.params.formIndex as string, 10))
+
+const config = ref<AppConfig | null>(null)
+const schema = ref<object>({})
+const isLoading = ref(true)
+const isSaving = ref(false)
+const error = ref<string | null>(null)
+
+const currentForm = computed<EntityForm | null>(() => {
+  if (!config.value?.entityForms) return null
+  return config.value.entityForms[formIndex.value] ?? null
+})
+
+const formTitle = computed(() => currentForm.value?.title || currentForm.value?.name || 'Form')
+
+const goBack = () => {
+  router.push({ name: 'app-details', params: { id: configId.value } })
+}
+
+onMounted(async () => {
+  isLoading.value = true
+  error.value = null
+  try {
+    const loaded = (await getApp(configId.value)) as AppConfig
+    config.value = loaded
+    const forms = loaded.entityForms ?? []
+    if (Number.isNaN(formIndex.value) || formIndex.value < 0 || formIndex.value >= forms.length) {
+      error.value = 'The requested form could not be found.'
+      return
+    }
+    const formio = forms[formIndex.value]?.formio
+    schema.value = formio ? JSON.parse(JSON.stringify(formio)) : {}
+  } catch {
+    error.value = 'Failed to load the collection program configuration.'
+  } finally {
+    isLoading.value = false
+  }
+})
+
+const save = async () => {
+  if (!config.value?.entityForms) return
+  isSaving.value = true
+  try {
+    // Splice the edited schema into just this form, mirroring the wizard's
+    // serialization: re-add `id: form.name` and strip the store-only
+    // `nameField` when empty so the payload matches AppConfigSchema.
+    const entityForms = config.value.entityForms.map((form, index) => {
+      const { nameField, ...rest } = form
+      const formio = index === formIndex.value ? schema.value : form.formio
+      const withId = { ...rest, id: form.name, formio }
+      return nameField ? { ...withId, nameField } : withId
+    })
+
+    const nextConfig = {
+      ...config.value,
+      entityForms,
+    }
+
+    const formData = new FormData()
+    formData.append(
+      'config',
+      new Blob([JSON.stringify(nextConfig)], { type: 'application/json' }),
+      'config.json',
+    )
+
+    await updateApp(configId.value, formData)
+    snackBarStore.showSnackbar('Form saved', 'success')
+    goBack()
+  } catch {
+    snackBarStore.showSnackbar('Failed to save the form', 'error')
+  } finally {
+    isSaving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="form-edit-view">
+    <div class="form-edit-view__topbar">
+      <div class="form-edit-view__title">
+        <v-btn icon="mdi-arrow-left" variant="text" size="small" aria-label="Back" @click="goBack" />
+        <h2 class="text-h6">Edit form: {{ formTitle }}</h2>
+      </div>
+      <div class="form-edit-view__actions">
+        <v-btn variant="text" :disabled="isSaving" @click="goBack">Cancel</v-btn>
+        <v-btn
+          color="primary"
+          variant="tonal"
+          :loading="isSaving"
+          :disabled="isLoading || !!error"
+          @click="save"
+        >
+          Save
+        </v-btn>
+      </div>
+    </div>
+
+    <div v-if="isLoading" class="form-edit-view__state">
+      <v-progress-circular indeterminate color="primary" />
+    </div>
+
+    <v-alert v-else-if="error" type="error" variant="tonal" class="ma-4">
+      {{ error }}
+    </v-alert>
+
+    <div v-else class="form-edit-view__builder">
+      <FormioBuilder v-model="schema" class="form-edit-view__builder-host" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.form-edit-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 100vh;
+}
+
+.form-edit-view__topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.form-edit-view__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.form-edit-view__title h2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.form-edit-view__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-edit-view__state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 3rem;
+}
+
+.form-edit-view__builder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.form-edit-view__builder-host {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/packages/admin/src/views/__tests__/FormEditView.spec.ts
+++ b/packages/admin/src/views/__tests__/FormEditView.spec.ts
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent } from 'vue'
+import FormEditView from '../FormEditView.vue'
+import { getApp, updateApp } from '@/api'
+
+const push = vi.fn()
+
+vi.mock('@/api', () => ({
+  getApp: vi.fn(),
+  updateApp: vi.fn().mockResolvedValue({ status: 'success' }),
+}))
+
+vi.mock('@/stores/snackBar', () => ({
+  useSnackBarStore: vi.fn(() => ({ showSnackbar: vi.fn() })),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(() => ({ params: { id: 'demo-registry', formIndex: '1' } })),
+  useRouter: vi.fn(() => ({ push })),
+}))
+
+// Stub the heavy Form.io builder with a v-model-capable placeholder.
+vi.mock('@/components/FormioBuilder.vue', () => ({
+  default: defineComponent({
+    name: 'FormioBuilder',
+    props: { modelValue: { type: Object, required: true } },
+    emits: ['update:modelValue'],
+    template: '<div class="formio-builder-stub" />',
+  }),
+}))
+
+const baseConfig = () => ({
+  id: 'demo-registry',
+  name: 'Demo Registry',
+  description: 'A demo',
+  version: '2',
+  entityForms: [
+    {
+      id: 'household',
+      name: 'household',
+      title: 'Household',
+      formio: { components: [{ key: 'firstName', type: 'textfield', input: true }] },
+    },
+    {
+      id: 'individual',
+      name: 'individual',
+      title: 'Individual',
+      dependsOn: 'household',
+      nameField: 'firstName',
+      formio: { components: [{ key: 'age', type: 'number', input: true }] },
+    },
+  ],
+  externalSync: { type: 'mock-sync-server' },
+})
+
+async function mountView() {
+  const wrapper = mount(FormEditView)
+  await flushPromises()
+  return wrapper
+}
+
+async function readConfigFromFormData(formData: FormData) {
+  const blob = formData.get('config') as Blob
+  const text = await blob.text()
+  return JSON.parse(text)
+}
+
+describe('FormEditView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.mocked(getApp).mockResolvedValue(baseConfig())
+    vi.mocked(updateApp).mockResolvedValue({ status: 'success' })
+  })
+
+  it('loads the config and shows the selected form title', async () => {
+    const wrapper = await mountView()
+    expect(getApp).toHaveBeenCalledWith('demo-registry')
+    expect(wrapper.text()).toContain('Individual')
+  })
+
+  it('shows an error when the form index is out of range', async () => {
+    const config = baseConfig()
+    config.entityForms = [config.entityForms[0]] // only index 0 exists; route asks for 1
+    vi.mocked(getApp).mockResolvedValue(config)
+    const wrapper = await mountView()
+    expect(wrapper.find('.v-alert').text()).toContain('could not be found')
+  })
+
+  it('splices the edited schema into the right form and PUTs the full config', async () => {
+    const wrapper = await mountView()
+
+    const editedSchema = { components: [{ key: 'age', type: 'number', input: true }, { key: 'gender', type: 'select', input: true }] }
+    wrapper.findComponent({ name: 'FormioBuilder' }).vm.$emit('update:modelValue', editedSchema)
+    await flushPromises()
+
+    await wrapper.get('.form-edit-view__actions .v-btn:last-child').trigger('click')
+    await flushPromises()
+
+    expect(updateApp).toHaveBeenCalledTimes(1)
+    const [id, formData] = vi.mocked(updateApp).mock.calls[0]
+    expect(id).toBe('demo-registry')
+    expect(formData).toBeInstanceOf(FormData)
+
+    const sent = await readConfigFromFormData(formData as FormData)
+    // Edited form (index 1) carries the new schema.
+    expect(sent.entityForms[1].formio).toEqual(editedSchema)
+    // Untouched form (index 0) is preserved verbatim.
+    expect(sent.entityForms[0].formio).toEqual(baseConfig().entityForms[0].formio)
+    // Full config preserved (not just forms).
+    expect(sent.name).toBe('Demo Registry')
+    expect(sent.externalSync).toEqual({ type: 'mock-sync-server' })
+  })
+
+  it('re-adds `id: form.name` and keeps nameField on serialized forms', async () => {
+    const wrapper = await mountView()
+    await wrapper.get('.form-edit-view__actions .v-btn:last-child').trigger('click')
+    await flushPromises()
+
+    const [, formData] = vi.mocked(updateApp).mock.calls[0]
+    const sent = await readConfigFromFormData(formData as FormData)
+    expect(sent.entityForms[0].id).toBe('household')
+    expect(sent.entityForms[1].id).toBe('individual')
+    expect(sent.entityForms[1].nameField).toBe('firstName')
+  })
+
+  it('navigates back to app-details after a successful save', async () => {
+    const wrapper = await mountView()
+    await wrapper.get('.form-edit-view__actions .v-btn:last-child').trigger('click')
+    await flushPromises()
+    expect(push).toHaveBeenCalledWith({ name: 'app-details', params: { id: 'demo-registry' } })
+  })
+})


### PR DESCRIPTION
Closes #17.

> **Stacked on #98 (#16).** Base is `feat/16-form-preview`; merge #98 first, then this retargets to `develop` automatically.

Adds a standalone route to edit one entity form directly from the program detail page, without stepping through the full wizard.

## Changes
- `FormEditView.vue` — standalone editor: loads the config, edits `entityForms[formIndex].formio` via the existing `FormioBuilder.vue`, saves with its own Save/Cancel. Does not touch the wizard draft store.
- Route `/collection-programs/:id/forms/:formIndex/edit` — top-level, outside `WizardLayout` (no draft-init side effects).
- `AppDetailsView.vue` — per-form-card **Edit** button (`@click.stop` so it doesn't trigger the #16 preview).
- Save uses load-modify-PUT through the existing full-config `PUT /api/apps/:id` (no backend change). Serialization mirrors the wizard (re-adds `id: form.name`, preserves `nameField`).

## Note
A single-form save runs the full-config `PUT`, which re-validates the config, restarts the tenant instance, and regenerates public artifacts — same behavior as a wizard save.

## Tests
- `FormEditView.spec.ts` — 5 tests (load, out-of-range guard, correct-index splice + other forms/config preserved, `id`/`nameField` serialization, back-nav on save).
- Admin suite (with #16): 174 tests pass; type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)