### PR TITLE
chore(admin): normalize FormEditView license header to canonical style

### DIFF
--- a/packages/admin/src/views/FormEditView.vue
+++ b/packages/admin/src/views/FormEditView.vue
@@ -1,21 +1,22 @@
 <!--
-  Licensed to the Association pour la cooperation numerique (ACN) under one
-  or more contributor license agreements. See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership. The ACN licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License. You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
 -->
+
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'


### PR DESCRIPTION
Follow-up to #100. `FormEditView.vue` (merged via #99) used the two-space `<!-- -->` header variant; normalizes it to the canonical ` * `-prefixed style so all `.vue` headers match. Comment-only; `check-license-headers` now fully clean on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)