### PR TITLE
docs: add Security policy + vulnerability-reporting page to docs site

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,12 +8,16 @@ The ID PASS DataCollect project takes security seriously. This document outlines
 
 We actively maintain and provide security updates for the following versions:
 
-| Version | Supported | Status                                      |
-| ------- | --------- | ------------------------------------------- |
-| 1.1.x   | ✅ Yes    | Active development                          |
-| < 1.0   | ❌ No     | Pre-release, not recommended for production |
+| Version | Supported | Status                          |
+| ------- | --------- | ------------------------------- |
+| 2.x     | ✅ Yes    | Active development              |
+| < 2.0   | ❌ No     | Upgrade to the latest 2.x       |
 
 **Note**: We recommend always using the latest stable release for security updates.
+
+> 📖 The full, current policy — reporting steps, scope, and coordinated disclosure — lives on
+> the documentation site: **https://data-collect.idpass.org/security/** (source in
+> `website/docs/security/`).
 
 ## Security Considerations
 
@@ -31,18 +35,21 @@ We encourage responsible disclosure of security vulnerabilities. **Please do not
 
 ### How to Report
 
-1. **Email**: Send details to `security@acn.fr`
-2. **Subject Line**: `[SECURITY] ID PASS DataCollect - [Brief Description]`
+1. **Preferred — GitHub private vulnerability reporting**: open a private report at
+   https://github.com/idpass/idpass-data-collect/security/advisories/new (or the repository's
+   **Security** tab → *Report a vulnerability*).
+2. **Fallback — Email**: if you cannot use GitHub, send details to `security@acn.fr` with the
+   subject line `[SECURITY] ID PASS DataCollect - [Brief Description]`.
 3. **Include**:
    - Description of the vulnerability
-   - Steps to reproduce the issue
+   - Steps to reproduce the issue (use synthetic data — never real credentials or beneficiary records)
    - Potential impact assessment
    - Suggested fix (if available)
    - Your contact information
 
 ### What to Expect
 
-- **Acknowledgment**: We will acknowledge receipt within 48 hours
+- **Acknowledgment**: We will acknowledge receipt within 2 business days
 - **Initial Assessment**: We will provide an initial assessment within 5 business days
 - **Regular Updates**: We will keep you informed of our progress
 - **Resolution Timeline**: We aim to resolve critical vulnerabilities within 30 days
@@ -121,7 +128,7 @@ _To be updated as we receive and resolve security reports._
 
 ---
 
-**Last Updated**: June 2025
-**Next Review**: July 2025
+**Last Updated**: July 2026
+**Next Review**: January 2027
 
 This security policy is subject to change. Please check this document regularly for updates.

--- a/website/docs/how-to/security-testing.md
+++ b/website/docs/how-to/security-testing.md
@@ -5,7 +5,7 @@ against DataCollect: the live API attack probes, the durable regression tests
 they became, and the static scanners. It also lists the third-party
 cybersecurity "skills" the assessment drew on and how to install them.
 
-:::warning Authorized targets only
+:::warning[Authorized targets only]
 Only run the offensive probes and scanners against an instance you own or are
 explicitly authorized to test — a local stack or your own staging. Never point
 them at another party's deployment.

--- a/website/docs/security/index.md
+++ b/website/docs/security/index.md
@@ -1,0 +1,80 @@
+---
+id: security-overview
+title: Security
+sidebar_label: Overview
+sidebar_position: 1
+description: Security policy, supported versions, and coordinated disclosure for ID PASS DataCollect.
+---
+
+# Security
+
+ID PASS DataCollect handles sensitive household and individual beneficiary data. We treat
+the confidentiality, integrity, and availability of that data as a first-order concern and
+welcome coordinated disclosure from the security community.
+
+If you believe you have found a vulnerability, please **do not open a public GitHub issue**.
+Follow [Report a vulnerability](./report-a-vulnerability.md).
+
+## Supported versions
+
+Security fixes are released for the current major line. We recommend always running the
+latest stable release.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | ✅ Yes             |
+| < 2.0   | ❌ No (upgrade)    |
+
+## What we protect
+
+DataCollect is offline-first and multi-tenant, so the security model spans the client
+library, the sync server, and external-system adapters:
+
+- **Tenant isolation** — each program's entities and events are scoped to its tenant; no
+  cross-tenant read or write.
+- **Authentication & authorization** — JWT-based access with role checks; per-entity
+  authorization on group members.
+- **Event integrity** — an append-only, hash-chained event store provides a tamper-evident
+  audit trail.
+- **Sync integrity** — server-managed fields are sanitized at every ingestion boundary, and
+  external identifiers are resolved server-side.
+- **Data minimization at the edge** — public configuration artifacts are stripped of secrets
+  and seeded data; internal fields are removed from sync payloads.
+
+## Coordinated disclosure
+
+We follow a coordinated-disclosure process so that users can upgrade before details are
+public:
+
+1. **Report received** — we acknowledge and triage the private report.
+2. **Verify & assess** — we reproduce the issue and assess severity and impact.
+3. **Fix privately** — the fix is developed in a private
+   [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories)
+   draft, not in public commits.
+4. **Release** — we ship a patched version.
+5. **Disclose** — we publish the advisory (and request a CVE where warranted) **after** users
+   can upgrade, crediting the reporter unless they prefer to remain anonymous.
+
+Our aim is timing, not permanent secrecy: once a fix is available, transparency helps
+everyone.
+
+## Response targets
+
+| Stage              | Target                                  |
+| ------------------ | --------------------------------------- |
+| Acknowledgement    | within 2 business days                  |
+| Initial assessment | within 5 business days                  |
+| Fix for confirmed critical issues | prioritized; typically within 30 days |
+
+## Recognition
+
+We credit researchers who responsibly disclose valid vulnerabilities in the published
+advisory (with your permission). We do not currently run a paid bug-bounty program.
+
+## Operating DataCollect securely
+
+Deployment hardening is the operator's responsibility. See the
+[deployment guides](/deployment/) for the current baseline, which includes: serving over
+TLS, setting a strong `JWT_SECRET` (≥ 32 characters), an explicit `CORS_ORIGINS` allow-list,
+strong database and admin credentials (no weak fallbacks), and running the backend container
+as a non-root user.

--- a/website/docs/security/report-a-vulnerability.md
+++ b/website/docs/security/report-a-vulnerability.md
@@ -1,0 +1,100 @@
+---
+id: report-a-vulnerability
+title: Report a vulnerability
+sidebar_label: Report a vulnerability
+sidebar_position: 2
+description: How to privately report a security vulnerability in ID PASS DataCollect.
+---
+
+# Report a vulnerability
+
+Thank you for helping keep ID PASS DataCollect and the people whose data it holds safe.
+This page describes how to report a vulnerability privately.
+
+:::danger Do not open a public issue
+Never report a suspected vulnerability through a public GitHub issue, pull request,
+discussion, or any other public channel. Public disclosure before a fix is available puts
+live deployments — and the beneficiaries whose data they hold — at risk.
+:::
+
+## When to use this
+
+Use the private disclosure channel for anything **exploitable** that is in scope below —
+when you are not sure whether a behavior is exploitable, report it privately and let us
+assess.
+
+Use the [public issue tracker](https://github.com/idpass/idpass-data-collect/issues) instead
+for **known, documented limitations** and non-security bugs (for example, a feature that is
+disabled by default, or hardening an operator is expected to configure). These are not
+vulnerabilities.
+
+## Before you start
+
+Have the following ready. It lets us reproduce and triage quickly:
+
+- The affected **version, release tag, or commit SHA**.
+- The **configuration shape** involved — for example the external-sync adapter type
+  (OpenSPP V1/V2, OpenFn), authentication mode (JWT, OTP, National ID, OIDC), and whether
+  self-service or scoped sync is enabled.
+- **Reproduction steps**, as minimal as you can make them.
+- The **observed impact** and what you would have expected instead.
+
+:::warning Never include real secrets or beneficiary data
+Do not attach or paste live credentials, bearer tokens, API keys, private keys, or real
+household/individual records. Reproduce with **synthetic data** and redact anything
+sensitive. If a secret was exposed, describe *where* it leaks — do not include its value.
+:::
+
+## How to report
+
+1. **Preferred — GitHub private vulnerability reporting.** Open a private report from the
+   repository's Security tab, or directly at
+   [github.com/idpass/idpass-data-collect/security/advisories/new](https://github.com/idpass/idpass-data-collect/security/advisories/new).
+   This keeps the report, the discussion, and the eventual advisory in one private place.
+2. **Fallback — email.** If you cannot use GitHub, email **security@acn.fr** with the
+   subject `[SECURITY] DataCollect - <brief description>`.
+3. Include the items from [Before you start](#before-you-start).
+
+We will acknowledge your report within **2 business days** and follow the coordinated
+disclosure process described in the [Security overview](./index.md#coordinated-disclosure).
+
+## What is in scope
+
+Reports that demonstrate one of the following in a supported version are in scope:
+
+- **Authentication or authorization bypass** — obtaining access or a role you should not
+  have.
+- **Cross-tenant access** — reading or writing another program's entities, events, or
+  configuration.
+- **Horizontal access on entities** — acting on group members or records outside your
+  granted scope.
+- **Event or audit integrity failure** — forging events, or bypassing the hash-chain
+  tamper-evidence of the event store.
+- **Sync integrity** — injecting server-managed identifiers, or causing an adapter to push or
+  pull data across the wrong tenant or external record.
+- **Secret or credential disclosure** — secrets, tokens, or connection details exposed in
+  public configuration artifacts, API responses, logs, or error messages.
+- **Beneficiary-data exposure** — any leak of household or individual PII to an unauthorized
+  party.
+- **Token verification flaws** — accepting improperly signed, expired, or wrong-audience
+  tokens (including OIDC on sync routes).
+- **Injection & traversal** — SQL injection, path traversal, or SSRF (for example via an
+  external-sync URL or an uploaded attachment).
+
+## What is not in scope
+
+These are handled as normal issues or product decisions, not vulnerabilities:
+
+- Behavior of features that are **disabled by default** (for example self-service, which
+  ships off, or scoped sync, which is opt-in), unless you can show it is reachable in the
+  default configuration.
+- **Documented limitations** and deployment hardening that is the operator's responsibility
+  (TLS termination, secret rotation, firewalling, rate-limit tuning).
+- Findings that require an **already-trusted administrator** acting maliciously against their
+  own tenant.
+- Vulnerabilities in **third-party dependencies** with no demonstrated exploit path through
+  DataCollect — please report those upstream (we still want to hear about it if you find a
+  path).
+- Reports from **automated scanners** without a demonstrated, reproducible impact.
+
+If something sits on the line, report it privately and we will make the call together.

--- a/website/docs/security/report-a-vulnerability.md
+++ b/website/docs/security/report-a-vulnerability.md
@@ -11,7 +11,7 @@ description: How to privately report a security vulnerability in ID PASS DataCol
 Thank you for helping keep ID PASS DataCollect and the people whose data it holds safe.
 This page describes how to report a vulnerability privately.
 
-:::danger Do not open a public issue
+:::danger[Do not open a public issue]
 Never report a suspected vulnerability through a public GitHub issue, pull request,
 discussion, or any other public channel. Public disclosure before a fix is available puts
 live deployments — and the beneficiaries whose data they hold — at risk.
@@ -39,7 +39,7 @@ Have the following ready. It lets us reproduce and triage quickly:
 - **Reproduction steps**, as minimal as you can make them.
 - The **observed impact** and what you would have expected instead.
 
-:::warning Never include real secrets or beneficiary data
+:::warning[Never include real secrets or beneficiary data]
 Do not attach or paste live credentials, bearer tokens, API keys, private keys, or real
 household/individual records. Reproduce with **synthetic data** and redact anything
 sensitive. If a secret was exposed, describe *where* it leaks — do not include its value.

--- a/website/docs/user-guide/review-workflow.md
+++ b/website/docs/user-guide/review-workflow.md
@@ -5,12 +5,12 @@ sidebar_position: 4
 draft: true
 ---
 
-<!--
+{/*
   Review workflow is hidden from the v2.0.0 documentation.
   The backend/core code remains in place but the admin UI wiring
   was removed before release. Re-enable when the feature is completed
   post-2.0.0 (see commits 0e98a81, dabb139, 7492259).
--->
+*/}
 
 
 # Review Workflow

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -121,6 +121,11 @@ const config: Config = {
           position: 'left',
         },
         {
+          to: 'security',
+          label: 'Security',
+          position: 'left',
+        },
+        {
           href: 'https://github.com/idpass/idpass-data-collect',
           position: 'right',
           className: 'header-github-link',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -493,6 +493,15 @@ const sidebars = {
       collapsed: false,
       items: userSidebarItems,
     },
+    {
+      type: "category",
+      label: "Security",
+      collapsed: false,
+      link: { type: "doc", id: "security/security-overview" },
+      items: [
+        { type: "doc", id: "security/report-a-vulnerability" },
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
Adds a **Security** section to the documentation site and refreshes the root `SECURITY.md` (which was stale — listed 1.1.x as current and predated GitHub private vulnerability reporting).

Modeled on the disclosure pages used by peer projects (ODK Collect, Registry Stack), adapted to DataCollect's threat surfaces.

## Added — `website/docs/security/`
- **Overview** (`/security`) — supported versions (2.x), what DataCollect protects (tenant isolation, authz, event/sync integrity, data minimization), the coordinated-disclosure process (private GHSA draft → release → advisory), and response targets.
- **Report a vulnerability** (`/security/report-a-vulnerability`) — when to use the private channel vs the public tracker, a "before you start" checklist, reporting steps (GitHub private reporting preferred, `security@acn.fr` fallback), and explicit in-scope / out-of-scope lists tailored to DataCollect (cross-tenant access, event/hash-chain integrity, sync identifier injection, secret/PII exposure, token verification, injection/SSRF).
- Wired into the sidebar (new "Security" category) and the top navbar.

## Changed — `SECURITY.md`
- Supported versions 1.1.x → **2.x**.
- Reporting now leads with **GitHub private vulnerability reporting** (email as fallback); acknowledgement target aligned to 2 business days.
- Points to the docs site as the canonical policy; refreshed review dates.

## Notes
- No exploit detail or internal tracker IDs (public-repo hygiene).
- Verified: `docs` site builds clean with `onBrokenLinks: throw` (all links + anchors resolve); both routes generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)