### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions on CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/mock-server.yml
+++ b/.github/workflows/mock-server.yml
@@ -12,6 +12,9 @@ on:
       - "examples/mock-server/**"
       - ".github/workflows/mock-server.yml"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the 6 CodeQL `actions/missing-workflow-permissions` alerts by declaring an explicit least-privilege `permissions:` block on the workflows that lacked one.

- `ci.yml`, `e2e.yml`, `mock-server.yml` → top-level `permissions: { contents: read }`.
- All jobs in these workflows are read-only (lint/test/scan/e2e/local docker build+run — no registry push, PR comments, or pages), so `contents: read` is sufficient. `publish-packages.yml` already scopes its own permissions.

Removes 6 medium alerts on the next scan. No behavior change.

> Note: the CodeQL "exclude vendored/example paths" cleanup (`security/skills/**`, `examples/mock-server/**`) is **not** included here — CodeQL runs in **default setup** on this repo, so path filters can't be committed as a config file. That needs either a repo-settings change or migrating to advanced setup; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)