### PR TITLE
fix(backend): harden SSRF guard for OpenSPP external-URL fetches

### DIFF
--- a/packages/backend/src/__tests__/ssrfGuard.test.ts
+++ b/packages/backend/src/__tests__/ssrfGuard.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Association pour la cooperation numerique (ACN) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ACN licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import dns from "dns/promises";
+import { isBlockedExternalUrl } from "../routes/opensppFieldRoutes";
+
+jest.mock("dns/promises", () => ({ __esModule: true, default: { lookup: jest.fn() } }));
+const mockLookup = dns.lookup as unknown as jest.Mock;
+
+describe("isBlockedExternalUrl — SSRF guard", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  // IP literals are checked without DNS, so these are hermetic.
+  describe.each([
+    ["cloud metadata", "http://169.254.169.254/latest/meta-data/"],
+    ["gcp metadata host", "http://metadata.google.internal/"],
+    ["localhost name", "http://localhost:8080/"],
+    ["loopback .1", "http://127.0.0.1/"],
+    ["loopback (whole /8)", "http://127.0.0.5/"],
+    ["loopback via decimal", "http://2130706433/"],
+    ["loopback via hex", "http://0x7f000001/"],
+    ["loopback via short form", "http://127.1/"],
+    ["rfc1918 10/8", "http://10.1.2.3/"],
+    ["rfc1918 172.16/12", "http://172.20.0.1/"],
+    ["rfc1918 192.168/16", "http://192.168.1.1/"],
+    ["link-local 169.254/16", "http://169.254.1.1/"],
+    ["cgnat 100.64/10", "http://100.100.0.1/"],
+    ["this-network 0/8", "http://0.0.0.0/"],
+    ["ipv6 loopback", "http://[::1]/"],
+    ["ipv6 ULA fc00::/7", "http://[fd12:3456::1]/"],
+    ["ipv6 link-local fe80::/10", "http://[fe80::1]/"],
+    ["ipv4-mapped ipv6", "http://[::ffff:127.0.0.1]/"],
+    ["non-http scheme", "ftp://example.com/"],
+    ["file scheme", "file:///etc/passwd"],
+    ["garbage", "not a url"],
+  ])("blocks %s", (_label, url) => {
+    it("returns true", async () => {
+      await expect(isBlockedExternalUrl(url)).resolves.toBe(true);
+    });
+  });
+
+  describe("public IP literals are allowed", () => {
+    it.each([["http://8.8.8.8/"], ["http://1.1.1.1/"], ["https://93.184.216.34/"]])(
+      "allows %s",
+      async (url) => {
+        await expect(isBlockedExternalUrl(url)).resolves.toBe(false);
+      },
+    );
+  });
+
+  describe("hostname resolution (DNS-rebinding mitigation)", () => {
+    it("allows a hostname that resolves to a public address", async () => {
+      mockLookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+      await expect(isBlockedExternalUrl("https://openspp.example.org/")).resolves.toBe(false);
+      expect(mockLookup).toHaveBeenCalledWith("openspp.example.org", { all: true });
+    });
+
+    it("blocks a hostname that resolves to a private address", async () => {
+      mockLookup.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+      await expect(isBlockedExternalUrl("https://rebind.attacker.test/")).resolves.toBe(true);
+    });
+
+    it("blocks when ANY resolved address is internal (mixed A records)", async () => {
+      mockLookup.mockResolvedValue([
+        { address: "93.184.216.34", family: 4 },
+        { address: "127.0.0.1", family: 4 },
+      ]);
+      await expect(isBlockedExternalUrl("https://mixed.attacker.test/")).resolves.toBe(true);
+    });
+
+    it("blocks an unresolvable hostname", async () => {
+      mockLookup.mockRejectedValue(new Error("ENOTFOUND"));
+      await expect(isBlockedExternalUrl("https://does-not-resolve.invalid/")).resolves.toBe(true);
+    });
+  });
+});

--- a/packages/backend/src/routes/opensppFieldRoutes.ts
+++ b/packages/backend/src/routes/opensppFieldRoutes.ts
@@ -25,49 +25,110 @@ import { createLogger } from "../utils/logger";
 import multer from "multer";
 import path from "path";
 import fs from "fs/promises";
+import net from "net";
+import dns from "dns/promises";
 import { OdooClient } from "@idpass/adapter-openspp";
 
 const log = createLogger("openspp-fields");
 
 /**
- * Checks whether a URL targets a private/internal IP range or cloud metadata endpoint.
- * Used to prevent SSRF attacks via the /fetch endpoint.
+ * Loopback / private / link-local / reserved ranges that an operator-supplied
+ * external URL must never resolve to. Used to prevent SSRF via the OpenSPP
+ * connection-test / field-fetch endpoints.
  */
-function isPrivateOrMetadataUrl(urlString: string): boolean {
+const ssrfBlockList = (() => {
+  const bl = new net.BlockList();
+  // IPv4: this-network, RFC1918, CGNAT, loopback, link-local (incl. cloud
+  // metadata 169.254.169.254), IETF protocol assignments, benchmarking,
+  // multicast, broadcast.
+  bl.addSubnet("0.0.0.0", 8, "ipv4");
+  bl.addSubnet("10.0.0.0", 8, "ipv4");
+  bl.addSubnet("100.64.0.0", 10, "ipv4");
+  bl.addSubnet("127.0.0.0", 8, "ipv4");
+  bl.addSubnet("169.254.0.0", 16, "ipv4");
+  bl.addSubnet("172.16.0.0", 12, "ipv4");
+  bl.addSubnet("192.0.0.0", 24, "ipv4");
+  bl.addSubnet("192.168.0.0", 16, "ipv4");
+  bl.addSubnet("198.18.0.0", 15, "ipv4");
+  bl.addSubnet("224.0.0.0", 4, "ipv4");
+  bl.addAddress("255.255.255.255", "ipv4");
+  // IPv6: unspecified, loopback, unique-local (fc00::/7), link-local
+  // (fe80::/10), multicast (ff00::/8). IPv4-mapped addresses are handled in
+  // isBlockedIp by extracting the embedded IPv4 (a mapped /96 rule here would
+  // make net.BlockList match every IPv4 address).
+  bl.addAddress("::", "ipv6");
+  bl.addAddress("::1", "ipv6");
+  bl.addSubnet("fc00::", 7, "ipv6");
+  bl.addSubnet("fe80::", 10, "ipv6");
+  bl.addSubnet("ff00::", 8, "ipv6");
+  return bl;
+})();
+
+/** Extract the embedded IPv4 from an IPv4-mapped IPv6 address, else null. */
+function mappedIpv4(v6: string): string | null {
+  const s = v6.toLowerCase();
+  const dotted = s.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dotted) return dotted[1];
+  const hex = s.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hex) {
+    const hi = parseInt(hex[1], 16);
+    const lo = parseInt(hex[2], 16);
+    return `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`;
+  }
+  return null;
+}
+
+function isBlockedIp(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) return ssrfBlockList.check(ip, "ipv4");
+  if (family === 6) {
+    const mapped = mappedIpv4(ip);
+    if (mapped && net.isIP(mapped) === 4) return ssrfBlockList.check(mapped, "ipv4");
+    return ssrfBlockList.check(ip, "ipv6");
+  }
+  return true; // not a parseable IP → block
+}
+
+/**
+ * SSRF guard for outbound requests to an operator-supplied external URL.
+ * Blocks non-HTTP(S) schemes, loopback/private/link-local/reserved IPv4 and
+ * IPv6 targets (incl. cloud metadata and IPv4-mapped IPv6), and resolves
+ * hostnames so a name pointing at an internal address is rejected (best-effort
+ * DNS-rebinding mitigation; callers also pass `redirect: "error"` to `fetch` so
+ * a 3xx to an internal host is not followed). Alternate IPv4 encodings
+ * (decimal/octal/hex) are normalised to dotted-quad by the URL parser before
+ * the range check. Returns true when the URL should be BLOCKED.
+ */
+export async function isBlockedExternalUrl(urlString: string): Promise<boolean> {
   let parsed: URL;
   try {
     parsed = new URL(urlString);
   } catch {
-    return true; // Invalid URLs are blocked
+    return true; // invalid URL → block
   }
 
-  const hostname = parsed.hostname.toLowerCase();
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return true; // only http(s) is allowed
+  }
 
-  // Block cloud metadata endpoints
-  if (hostname === "169.254.169.254" || hostname === "metadata.google.internal") {
+  const host = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (host === "" || host === "localhost" || host.endsWith(".localhost") || host === "metadata.google.internal") {
     return true;
   }
 
-  // Block localhost
-  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]") {
-    return true;
+  // Literal IP (any encoding is already normalised by the URL parser).
+  if (net.isIP(host)) {
+    return isBlockedIp(host);
   }
 
-  // Block private IP ranges
-  const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4Match) {
-    const [, a, b] = ipv4Match.map(Number);
-    // 10.0.0.0/8
-    if (a === 10) return true;
-    // 172.16.0.0/12
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    // 192.168.0.0/16
-    if (a === 192 && b === 168) return true;
-    // 0.0.0.0
-    if (a === 0) return true;
+  // Hostname: resolve and block if ANY resolved address is internal.
+  try {
+    const records = await dns.lookup(host, { all: true });
+    if (records.length === 0) return true;
+    return records.some((r) => isBlockedIp(r.address));
+  } catch {
+    return true; // unresolvable → block
   }
-
-  return false;
 }
 
 export interface ParsedOpenSppField {
@@ -377,7 +438,7 @@ export function createOpenSppFieldRoutes(): Router {
         throw new AppError("URL, database, username, and password are required", 400);
       }
 
-      if (isPrivateOrMetadataUrl(url)) {
+      if (await isBlockedExternalUrl(url)) {
         throw new AppError("URLs targeting private or internal networks are not allowed", 400);
       }
 
@@ -426,7 +487,7 @@ export function createOpenSppFieldRoutes(): Router {
         throw new AppError("baseUrl, clientId, and clientSecret are required", 400);
       }
 
-      if (isPrivateOrMetadataUrl(baseUrl)) {
+      if (await isBlockedExternalUrl(baseUrl)) {
         throw new AppError("URLs targeting private or internal networks are not allowed", 400);
       }
 
@@ -434,6 +495,7 @@ export function createOpenSppFieldRoutes(): Router {
 
       try {
         const response = await fetch(tokenUrl, {
+          redirect: "error",
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -484,7 +546,7 @@ export function createOpenSppFieldRoutes(): Router {
         throw new AppError("baseUrl, clientId, and clientSecret are required", 400);
       }
 
-      if (isPrivateOrMetadataUrl(baseUrl)) {
+      if (await isBlockedExternalUrl(baseUrl)) {
         throw new AppError("URLs targeting private or internal networks are not allowed", 400);
       }
 
@@ -495,6 +557,7 @@ export function createOpenSppFieldRoutes(): Router {
       let accessToken: string;
       try {
         const tokenResponse = await fetch(tokenUrl, {
+          redirect: "error",
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -540,6 +603,7 @@ export function createOpenSppFieldRoutes(): Router {
           }
 
           const fieldsResponse = await fetch(`${base}/api/v2/spp/Studio/fields?${params}`, {
+            redirect: "error",
             headers: {
               Authorization: `Bearer ${accessToken}`,
               "Content-Type": "application/json",


### PR DESCRIPTION
Strengthens the SSRF guard on the authenticated OpenSPP connection-test / field-fetch endpoints (`opensppFieldRoutes.ts`). The previous guard only covered a subset of IPv4 dotted-quad ranges; this makes it comprehensive defense-in-depth.

## What changed
- Replaced the hand-rolled range check with a `net.BlockList` covering the full set of loopback / private / link-local / reserved ranges for **both IPv4 and IPv6** (incl. all of `127.0.0.0/8`, `169.254.0.0/16`, `100.64.0.0/10`, IPv6 ULA `fc00::/7` and link-local `fe80::/10`).
- **IPv4-mapped IPv6** (e.g. `::ffff:127.0.0.1`) now has its embedded IPv4 extracted and range-checked.
- The guard now **resolves hostnames** (`dns.lookup`) and rejects the URL if any resolved address is internal — best-effort DNS-rebinding mitigation.
- Restricted schemes to `http`/`https`.
- The outbound `fetch` calls now use `redirect: "error"` so a 3xx to an internal host cannot be followed.
- Alternate IPv4 encodings (decimal/octal/hex) are normalised by the URL parser before the range check.

Endpoints remain `authenticateJWT`-gated as before.

## Tests
- New `ssrfGuard.test.ts` — 28 cases: blocks loopback/private/link-local/CGNAT/metadata (v4 + v6 + mapped + decimal/hex encodings), non-http schemes, and hostnames resolving to internal addresses; allows public IPs and public-resolving hostnames.
- Backend type-check + lint clean.

Note: full DNS-rebinding elimination (pinning the vetted IP at connect time) is a further hardening step tracked separately; this PR closes the concrete denylist/redirect gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)