### PR TITLE
fix(docker): drop unreliable postgres init-script mount from coolify compose

### DIFF
--- a/docker/docker-compose.coolify.yaml
+++ b/docker/docker-compose.coolify.yaml
@@ -10,16 +10,22 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-datacollect}
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./init-reset-dbs.sh:/docker-entrypoint-initdb.d/init-reset-dbs.sh:ro
+      # NOTE: no /docker-entrypoint-initdb.d bind mount here. Postgres creates
+      # the `${POSTGRES_DB}` database from the env var on first init, which is
+      # all the runtime needs. A single-file bind mount (used by the other
+      # compose files to also create `datacollect_test`) is unreliable on
+      # Coolify — it materialises the host source as a *directory*, so the
+      # entrypoint fails with "init-reset-dbs.sh: Is a directory" and Postgres
+      # never becomes healthy on a fresh volume.
     networks:
       - internal
     command: ["postgres"]
     healthcheck:
       # Target the always-present `postgres` system database rather than
-      # `${POSTGRES_DB}` — the user-facing DB may not exist yet while the
-      # /docker-entrypoint-initdb.d scripts are still running on first init,
-      # which would cause `pg_isready -d datacollect` to report unhealthy and
-      # break the sync-server `depends_on { condition: service_healthy }` gate.
+      # `${POSTGRES_DB}`, which does not exist until Postgres finishes creating
+      # it from POSTGRES_DB on first init — `pg_isready -d datacollect` would
+      # report unhealthy meanwhile and break the sync-server
+      # `depends_on { condition: service_healthy }` gate.
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-admin} -d postgres"]
       interval: 5s
       timeout: 3s


### PR DESCRIPTION
## Problem
Staging (`idpass-datacollect-staging`, deploys `develop`) went into a restart loop, then failed to redeploy on a fresh Postgres volume with:
```
/docker-entrypoint.d/... init-reset-dbs.sh: Is a directory
dependency failed to start: container postgres-... is unhealthy
```
`docker-compose.coolify.yaml` bind-mounts a single init script:
`./init-reset-dbs.sh:/docker-entrypoint-initdb.d/init-reset-dbs.sh`. On Coolify this **single-file bind mount materialises the host source as a directory**, so Postgres's entrypoint fails to run it on first init → container never healthy → `sync-server` (`depends_on: postgres: service_healthy`) can't start → deploy fails. This only surfaces on a *fresh* volume (an existing volume skips `/docker-entrypoint-initdb.d`), which is why it was latent until the volume was reset.

## Fix
Remove that bind mount from the **coolify** compose only. It's redundant there: Postgres already creates `${POSTGRES_DB}` (`datacollect`) from the env var on first init, and the script's other database (`datacollect_test`) is test-only — no backend runtime code reads `POSTGRES_TEST`, and staging ran for months without this script ever executing.

The other compose files (dev/test/prod-nginx/adapters) keep the mount — single-file mounts work fine on direct Docker and local test runs rely on `datacollect_test`.

## Verification
- `docker compose config` valid.
- After merge + redeploy, `sync-server` should return `200` on `/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)