### PR TITLE
fix(docker): let non-root backend create its uploads dir (multer 2 eager mkdir)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,13 @@ WORKDIR /app
 # Own the app tree as the unprivileged built-in node user so the server can
 # write generated public artifacts at runtime while running as non-root.
 COPY --from=build --chown=node:node /app .
+# `WORKDIR /app` is created root-owned and `COPY --chown` only chowns the copied
+# *contents*, not the /app directory itself — so the non-root `node` user cannot
+# create new entries at the /app root. multer 2 eagerly `mkdir`s its upload
+# destination (`/app/uploads`) when routes are constructed at startup, which
+# would throw EACCES and crash-loop the server. Give `node` ownership of the
+# workdir and pre-create the uploads directory.
+RUN mkdir -p /app/uploads && chown node:node /app /app/uploads
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://localhost:3000/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"


### PR DESCRIPTION
## Problem
Staging `sync-server` crash-looped (16× restarts) after the volume/init-script fix (#113) cleared the postgres issue. Real cause, from the container log:
```
EACCES: permission denied, mkdir '/app/uploads'
  at new DiskStorage (multer@2.2.0/storage/disk.js:20)
  at createOpenSppFieldRoutes (dist/routes/opensppFieldRoutes.js:260)
```
Two recent changes collide:
- **multer 2.x** eagerly `mkdirSync`s a `diskStorage` destination at route-construction (startup), where multer 1.x did not.
- the backend container runs as the **non-root `node` user**.

`WORKDIR /app` is created root-owned, and `COPY --chown=node:node` only chowns the copied *contents* — not the `/app` directory itself. So `node` can't create `/app/uploads` (the OpenSPP-field route's upload dir, `path.resolve(process.cwd(), "uploads")`) → uncaught exception → crash loop. DB init succeeds first, which is why it looked DB-related.

## Fix
In the `backend` stage of `docker/Dockerfile`, before `USER node`:
```dockerfile
RUN mkdir -p /app/uploads && chown node:node /app /app/uploads
```
Gives `node` ownership of the workdir and pre-creates the uploads dir (multer's recursive mkdir then no-ops).

## Scope / impact
Affects **any fresh deploy of the backend image** — including **production / v2.1.0** (same Dockerfile + multer 2 + non-root). Recommend cherry-picking to `main` (or a `2.1.1`) after this merges. Verified by redeploying staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)