### PR TITLE
fix(docker): align main with develop — postgres init + uploads-dir deploy fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,13 @@ WORKDIR /app
 # Own the app tree as the unprivileged built-in node user so the server can
 # write generated public artifacts at runtime while running as non-root.
 COPY --from=build --chown=node:node /app .
+# `WORKDIR /app` is created root-owned and `COPY --chown` only chowns the copied
+# *contents*, not the /app directory itself — so the non-root `node` user cannot
+# create new entries at the /app root. multer 2 eagerly `mkdir`s its upload
+# destination (`/app/uploads`) when routes are constructed at startup, which
+# would throw EACCES and crash-loop the server. Give `node` ownership of the
+# workdir and pre-create the uploads directory.
+RUN mkdir -p /app/uploads && chown node:node /app /app/uploads
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://localhost:3000/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"

--- a/docker/docker-compose.coolify.yaml
+++ b/docker/docker-compose.coolify.yaml
@@ -10,16 +10,22 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-datacollect}
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./init-reset-dbs.sh:/docker-entrypoint-initdb.d/init-reset-dbs.sh:ro
+      # NOTE: no /docker-entrypoint-initdb.d bind mount here. Postgres creates
+      # the `${POSTGRES_DB}` database from the env var on first init, which is
+      # all the runtime needs. A single-file bind mount (used by the other
+      # compose files to also create `datacollect_test`) is unreliable on
+      # Coolify — it materialises the host source as a *directory*, so the
+      # entrypoint fails with "init-reset-dbs.sh: Is a directory" and Postgres
+      # never becomes healthy on a fresh volume.
     networks:
       - internal
     command: ["postgres"]
     healthcheck:
       # Target the always-present `postgres` system database rather than
-      # `${POSTGRES_DB}` — the user-facing DB may not exist yet while the
-      # /docker-entrypoint-initdb.d scripts are still running on first init,
-      # which would cause `pg_isready -d datacollect` to report unhealthy and
-      # break the sync-server `depends_on { condition: service_healthy }` gate.
+      # `${POSTGRES_DB}`, which does not exist until Postgres finishes creating
+      # it from POSTGRES_DB on first init — `pg_isready -d datacollect` would
+      # report unhealthy meanwhile and break the sync-server
+      # `depends_on { condition: service_healthy }` gate.
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-admin} -d postgres"]
       interval: 5s
       timeout: 3s


### PR DESCRIPTION
Cherry-picks the two Docker deploy fixes that landed on `develop` after the v2.1.0 release, so `main` (what production/main-based deploys build from) no longer crash-loops a fresh backend container.

- **#113** — drop the unreliable single-file `init-reset-dbs.sh` bind mount from the coolify compose (Coolify materialises it as a directory → Postgres init fails on a fresh volume).
- **#114** — grant the non-root `node` user ownership of the workdir and pre-create `/app/uploads`, so multer 2's eager `mkdir` at startup doesn't `EACCES` crash-loop the backend.

After merge, `main` is tree-identical to `develop` (verified: empty diff). Docker-only change — no package version bump or re-publish. (Staging, on `develop`, is already running with both fixes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)